### PR TITLE
Remove return and update docstrings

### DIFF
--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -115,7 +115,9 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
     @classmethod
     def _build_child_objects(cls, data: dict, session: Session = None) -> dict:
         """
-        Build the data concepts objects that this object points to.
+        Build the data concepts objects that this serialized object points to.
+
+        This method modifies the serialized object in place.
 
         Parameters
         ----------
@@ -126,9 +128,9 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
 
         Returns
         -------
-        dict
-            The serialized object, but all of its dictionary values that are themselves serialized
-            objects have been deserialized into the objects themselves.
+        None
+            The serialized object is modified so that all of its dictionary values that are
+            themselves serialized objects have been deserialized .
 
         """
         def _is_dc(prop_type: Property) -> bool:
@@ -159,7 +161,6 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
                             .build(data[key].as_dict())
                         if isinstance(data[key], DataConcepts):
                             data[key].session = session
-        return data
 
     @classmethod
     def get_type(cls, data) -> Type[Serializable]:

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -84,9 +84,9 @@ class MaterialTemplate(DataConcepts, Resource['MaterialTemplate'], TaurusMateria
 
         Returns
         -------
-        dict
-            The serialized material template, but its properties are now a list of object pairs
-            of the form [PropertyTemplate, Bounds].
+        None
+            The serialized measurement template is modified so that its
+             properties are [PropertyTemplate, Bounds].
 
         """
         if 'properties' in data and len(data['properties']) != 0:

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -107,10 +107,10 @@ class MeasurementTemplate(DataConcepts, Resource['MeasurementTemplate'],
 
         Returns
         -------
-        dict
-            The serialized material template, but its conditions are now a list of object pairs
-            of the form [ConditionTemplate, Bounds], the parameters are
-            [ParameterTemplate, Bounds], and the properties are [PropertyTemplate, Bounds]
+        None
+            The serialized measurement template is modified so that its conditions are now a list
+            of object pairs of the form [ConditionTemplate, Bounds], the parameters are
+            [ParameterTemplate, Bounds], and the properties are [PropertyTemplate, Bounds].
 
         """
         if 'properties' in data and len(data['properties']) != 0:

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -98,9 +98,9 @@ class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTe
 
         Returns
         -------
-        dict
-            The serialized material template, but its conditions are now a list of object pairs
-            of the form [ConditionTemplate, Bounds], and the parameters are
+        None
+            The serialized material template is modified so that its conditions are now a list
+            of object pairs of the form [ConditionTemplate, Bounds], and the parameters are
             [ParameterTemplate, Bounds].
 
         """


### PR DESCRIPTION
The method `_build_child_objects` modifies its input dictionary in-place, and hence the return value is not needed. Update docstrings to reflect.