### PR TITLE
Feature/file upload

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ arrow==0.14.5
 strip-hints==0.1.7
 sphinx==2.2.0
 sphinxcontrib-apidoc==0.3.0
+boto3==1.9.226
+botocore==1.12.226

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,9 @@ setup(name='citrine',
           "arrow",
           "pytest>=4.3",
           "strip-hints>=0.1.5",
-          "taurus"
+          "taurus",
+          "boto3",
+          "botocore"
       ],
       cmdclass={
           'install': PostInstallCommand,

--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -32,12 +32,12 @@ class Property(typing.Generic[DeserializedType, SerializedType]):
     @property
     @abstractmethod
     def underlying_types(self) -> typing.Union[DeserializedType, typing.Tuple[DeserializedType]]:
-        """Return the python types handled by this property"""
+        """Return the python types handled by this property."""
 
     @property
     @abstractmethod
     def serialized_types(self) -> typing.Union[SerializedType, typing.Tuple[SerializedType]]:
-        """Return the types used to serialize this property"""
+        """Return the types used to serialize this property."""
 
     def serialize(self, value: DeserializedType) -> SerializedType:
         if not isinstance(value, self.underlying_types):
@@ -53,11 +53,11 @@ class Property(typing.Generic[DeserializedType, SerializedType]):
 
     @abstractmethod
     def _serialize(self, value: DeserializedType) -> SerializedType:
-        """Perform serialization"""
+        """Perform serialization."""
 
     @abstractmethod
     def _deserialize(self, value: SerializedType) -> DeserializedType:
-        """Perform deserialization"""
+        """Perform deserialization."""
 
     def deserialize_from_dict(self, data: dict) -> DeserializedType:
         value = data

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -107,13 +107,10 @@ class Session(requests.Session):
         """POST to a particular resource as JSON."""
         return self.checked_request('POST', path, *args, json=json, **kwargs).json()
 
-<<<<<<< HEAD
     def put_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
         """PUT data given by some JSON at a particular resource."""
         return self.checked_request('PUT', path, *args, json=json, **kwargs).json()
 
-=======
->>>>>>> 1308e8b434f94a848ac27005170402c325801d38
     def delete_resource(self, path: str) -> dict:
         """DELETE a particular resource as JSON."""
         return self.checked_request('DELETE', path).json()

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -20,6 +20,7 @@ from citrine.resources.material_run import MaterialRunCollection
 from citrine.resources.material_spec import MaterialSpecCollection
 from citrine.resources.ingredient_run import IngredientRunCollection
 from citrine.resources.ingredient_spec import IngredientSpecCollection
+from citrine.resources.file_link import FileCollection
 
 
 class Dataset(Resource['Dataset']):
@@ -162,6 +163,11 @@ class Dataset(Resource['Dataset']):
     def ingredient_specs(self) -> IngredientSpecCollection:
         """Return a resource representing all ingredient specs in this dataset."""
         return IngredientSpecCollection(self.project_id, self.uid, self.session)
+
+    @property
+    def files(self) -> FileCollection:
+        """Return a resource representing all files in the dataset."""
+        return FileCollection(self.project_id, self.uid, self.session)
 
 
 class DatasetCollection(Collection[Dataset]):

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -17,11 +17,10 @@ class _Uploader(object):
 
     def __init__(self):
         self.bucket = ''
-        self.key = ''
+        self.object_key = ''
         self.upload_id = ''
         self.region_name = ''
         self.aws_access_key_id = ''
-        self.aws_secret_access_token = ''
         self.aws_secret_access_key = ''
         self.aws_session_token = ''
         self.object_key = ''
@@ -110,6 +109,7 @@ class FileCollection(Collection[FileLink]):
         extension = os.path.splitext(file_path)[1]
         mime_type = mimetypes.types_map[extension]
         file_size = os.stat(file_path).st_size
+        assert isinstance(file_size, int)
         upload_json = {
             'files': [
                 {

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -12,7 +12,7 @@ from citrine._rest.resource import Resource
 from citrine._session import Session
 
 
-class _Uploader(object):
+class _Uploader:
     """Holds the many parameters that are generated and used during file upload."""
 
     def __init__(self):
@@ -23,7 +23,6 @@ class _Uploader(object):
         self.aws_access_key_id = ''
         self.aws_secret_access_key = ''
         self.aws_session_token = ''
-        self.object_key = ''
         self.s3_version = ''
 
 

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -12,6 +12,21 @@ from citrine._rest.resource import Resource
 from citrine._session import Session
 
 
+class _Uploader(object):
+    """Holds the many parameters that are generated and used during file upload."""
+
+    def __init__(self):
+        self.bucket = ''
+        self.key = ''
+        self.upload_id = ''
+        self.region_name = ''
+        self.aws_access_key_id = ''
+        self.aws_secret_access_token = ''
+        self.aws_secret_access_key = ''
+        self.aws_session_token = ''
+        self.object_key = ''
+
+
 class FileLink(Resource['FileLink'], TaurusFileLink):
     """Resource that stores the name and url of an external file."""
 
@@ -41,7 +56,7 @@ class FileCollection(Collection[FileLink]):
         """Build an instance of FileLink."""
         return FileLink.build(data)
 
-    def upload(self, file_path, dest_name=None) -> FileLink:
+    def upload(self, file_path: str, dest_name: str = None) -> FileLink:
         """
         Uploads a file to the dataset.
 
@@ -67,6 +82,29 @@ class FileCollection(Collection[FileLink]):
             # Use the file name as a default dest_name
             dest_name = os.path.basename(file_path)
 
+        uploader = self._make_upload_request(file_path, dest_name)
+        uploader = self._upload_file(file_path, uploader)
+        return self._complete_upload(dest_name, uploader)
+
+    def _make_upload_request(self, file_path: str, dest_name: str):
+        """
+        Make a request to the backend to upload a file.
+
+        Parameters
+        ----------
+        file_path: str
+            The path to the file on the local computer.
+        dest_name: str
+            The name the file will have after being uploaded.
+
+        Returns
+        -------
+        _Uploader
+            Holds the parameters returned by the upload request, for later use.
+            These must include region_name, aws_access_key_id, aws_secret_access_key,
+            aws_session_token, bucket, object_key, & upload_id.
+
+        """
         path = self._get_path() + "/uploads"
         extension = os.path.splitext(file_path)[1]
         mimeType = mimetypes.types_map[extension]
@@ -82,35 +120,80 @@ class FileCollection(Collection[FileLink]):
         }
         # POST request creates space in S3 for the file and returns AWS-related information
         # (such as temporary credentials) that allow the file to be uploaded.
-        upload_response = self.session.post_resource(path=path, json=upload_json)
+        upload_request = self.session.post_resource(path=path, json=upload_json)
+        uploader = _Uploader()
 
-        # Extract all relevant information from the POST response
+        # Extract all relevant information from the upload request
         try:
-            region_name = upload_response['s3_region']
-            aws_access_key_id = upload_response['temporary_credentials']['access_key_id']
-            aws_secret_access_key = upload_response['temporary_credentials']['secret_access_key']
-            aws_session_token = upload_response['temporary_credentials']['session_token']
-            bucket = upload_response['s3_bucket']
-            object_key = upload_response['uploads'][0]['s3_key']
-            upload_id = upload_response['uploads'][0]['upload_id']
+            uploader.region_name = upload_request['s3_region']
+            uploader.aws_access_key_id = upload_request['temporary_credentials']['access_key_id']
+            uploader.aws_secret_access_key = \
+                upload_request['temporary_credentials']['secret_access_key']
+            uploader.aws_session_token = upload_request['temporary_credentials']['session_token']
+            uploader.bucket = upload_request['s3_bucket']
+            uploader.object_key = upload_request['uploads'][0]['s3_key']
+            uploader.upload_id = upload_request['uploads'][0]['upload_id']
         except KeyError:
             raise RuntimeError("Upload initiation response is missing some fields: "
-                               "{}".format(upload_response))
+                               "{}".format(upload_request))
+        return uploader
 
+    @staticmethod
+    def _upload_file(file_path: str, uploader: _Uploader):
+        """
+        Upload a file to S3.
+
+        Parameters
+        ----------
+        file_path: str
+            The path to the file on the local computer.
+        uploader: _Uploader
+            Holds the parameters returned by the upload request.
+
+        Returns
+        -------
+        _Uploader
+            The input uploader object with its s3_version field now populated.
+
+        """
         s3_client = boto3_client('s3',
-                                 region_name=region_name,
-                                 aws_access_key_id=aws_access_key_id,
-                                 aws_secret_access_key=aws_secret_access_key,
-                                 aws_session_token=aws_session_token)
+                                 region_name=uploader.region_name,
+                                 aws_access_key_id=uploader.aws_access_key_id,
+                                 aws_secret_access_key=uploader.aws_secret_access_key,
+                                 aws_session_token=uploader.aws_session_token)
         with open(file_path, 'rb') as f:
             try:
-                upload_s3_response = s3_client.put_object(Bucket=bucket, Key=object_key, Body=f)
+                upload_response = s3_client.put_object(
+                    Bucket=uploader.bucket,
+                    Key=uploader.object_key,
+                    Body=f,
+                    Metadata={"X-Citrine-Upload-Id": uploader.upload_id})
             except ClientError as e:
                 raise RuntimeError("Upload of file {} failed with the following "
                                    "exception: {}".format(file_path, e))
-            s3_version = upload_s3_response['VersionId']
-            path = self._get_path() + "/uploads/{}/complete".format(upload_id)
-            complete_response = self.session.put_resource(path=path, json={'s3_version': s3_version})
+        uploader.s3_version = upload_response['VersionId']
+        return uploader
+
+    def _complete_upload(self, dest_name: str, uploader: _Uploader):
+        """
+        Indicate that the upload has finished and determine the file URL.
+
+        Parameters
+        ----------
+        dest_name: str
+            The name the file will have after being uploaded.
+        uploader: _Uploader
+            Holds the parameters returned by the upload request and the upload response.
+
+        Returns
+        -------
+        FileLink
+            The filename and url of the uploaded object.
+
+        """
+        path = self._get_path() + "/uploads/{}/complete".format(uploader.upload_id)
+        complete_response = self.session.put_resource(path=path,
+                                                      json={'s3_version': uploader.s3_version})
 
         try:
             file_id = complete_response['file_info']['file_id']

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -25,6 +25,7 @@ class _Uploader(object):
         self.aws_secret_access_key = ''
         self.aws_session_token = ''
         self.object_key = ''
+        self.s3_version = ''
 
 
 class FileLink(Resource['FileLink'], TaurusFileLink):
@@ -107,14 +108,14 @@ class FileCollection(Collection[FileLink]):
         """
         path = self._get_path() + "/uploads"
         extension = os.path.splitext(file_path)[1]
-        mimeType = mimetypes.types_map[extension]
+        mime_type = mimetypes.types_map[extension]
+        file_size = os.stat(file_path).st_size
         upload_json = {
             'files': [
                 {
                     'file_name': dest_name,
-                    'metadata': dict(),
-                    'mime_type': mimeType,
-                    'size': os.stat(file_path).st_size
+                    'mime_type': mime_type,
+                    'size': file_size
                 }
             ]
         }

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -32,9 +32,11 @@ class FileLink(Resource['FileLink'], TaurusFileLink):
 
     filename = String('filename')
     url = String('url')
+    typ = String('type')
 
     def __init__(self, filename, url):
         TaurusFileLink.__init__(self, filename, url)
+        self.typ = TaurusFileLink.typ
 
     def __str__(self):
         return '<File link {!r}>'.format(self.filename)
@@ -202,8 +204,6 @@ class FileCollection(Collection[FileLink]):
         except KeyError:
             raise RuntimeError("Upload completion response is missing some "
                                "fields: {}".format(complete_response))
-        file_link_dict = {
-            'filename': dest_name,
-            'url': self._get_path(file_id) + '/versions/{}'.format(version)
-        }
-        return FileLink.build(file_link_dict)
+
+        url = self._get_path(file_id) + '/versions/{}'.format(version)
+        return FileLink(filename=dest_name, url=url)

--- a/src/citrine/resources/material_run.py
+++ b/src/citrine/resources/material_run.py
@@ -11,9 +11,7 @@ from citrine._serialization.properties import String, LinkOrElse, Mapping, Objec
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from taurus.client.json_encoder import TaurusEncoder
-from taurus.entity.dict_serializable import DictSerializable
 from taurus.entity.file_link import FileLink
-from taurus.entity.link_by_uid import LinkByUID
 from taurus.entity.object.process_run import ProcessRun as TaurusProcessRun
 from taurus.entity.object.material_run import MaterialRun as TaurusMaterialRun
 from taurus.entity.object.material_spec import MaterialSpec as TaurusMaterialSpec

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -10,9 +10,7 @@ from citrine._serialization.properties import Optional as PropertyOptional
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
 from citrine.attributes.condition import Condition
 from citrine.attributes.parameter import Parameter
-from taurus.entity.dict_serializable import DictSerializable
 from taurus.entity.file_link import FileLink
-from taurus.entity.link_by_uid import LinkByUID
 from taurus.entity.object.process_run import ProcessRun as TaurusProcessRun
 from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -10,8 +10,6 @@ from citrine._serialization.properties import Optional as PropertyOptional
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
 from citrine.attributes.condition import Condition
 from citrine.attributes.parameter import Parameter
-from taurus.entity.dict_serializable import DictSerializable
-from taurus.entity.link_by_uid import LinkByUID
 from taurus.entity.file_link import FileLink
 from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 from taurus.entity.template.process_template import ProcessTemplate as TaurusProcessTemplate

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -23,13 +23,13 @@ def collection(session) -> FileCollection:
 
 @pytest.fixture
 def uploader() -> _Uploader:
+    """An _Uploader object with all of its fields filled in."""
     uploader = _Uploader()
     uploader.bucket = 'citrine-datasvc'
-    uploader.key = '334455'
+    uploader.object_key = '334455'
     uploader.upload_id = 'dea3a-555'
     uploader.region_name = 'us-west'
     uploader.aws_access_key_id = 'sahgkjsgahnei'
-    uploader.aws_secret_access_token = 'hjhguneheehhhhsdjfjnjjnelkooius'
     uploader.aws_secret_access_key = 'kdydahkd78452978'
     uploader.aws_session_token = 'sdfhuaf74yf783g4ofg7g3o'
     uploader.object_key = '234787521--abcde'
@@ -48,9 +48,50 @@ class MockClient(object):
         return self.put_object_output
 
 
+@patch('citrine.resources.file_link.os.stat')
+def test_upload_request(mock_stat, collection, session, uploader):
+    """Test that an upload request response contains all required fields."""
+    # Mock the method that gets the size of the file.
+    mock_stat_object = Mock()
+    mock_stat_object.st_size = 17
+    mock_stat.return_value = mock_stat_object
+
+    # This is the dictionary structure we expect from the upload request
+    upload_request_response = {
+        's3_region': uploader.region_name,
+        's3_bucket': uploader.bucket,
+        'temporary_credentials': {
+            'access_key_id': uploader.aws_access_key_id,
+            'secret_access_key': uploader.aws_secret_access_key,
+            'session_token': uploader.aws_session_token,
+        },
+        'uploads': [
+            {
+                's3_key': uploader.object_key,
+                'upload_id': uploader.upload_id
+            }
+        ]
+    }
+    session.set_response(upload_request_response)
+    new_uploader = collection._make_upload_request('foo.txt', 'foo.txt')
+    assert new_uploader.bucket == uploader.bucket
+    assert new_uploader.object_key == uploader.object_key
+    assert new_uploader.upload_id == uploader.upload_id
+    assert new_uploader.region_name == uploader.region_name
+    assert new_uploader.aws_access_key_id == uploader.aws_access_key_id
+    assert new_uploader.aws_secret_access_key == uploader.aws_secret_access_key
+    assert new_uploader.aws_session_token == uploader.aws_session_token
+    assert new_uploader.object_key == uploader.object_key
+
+    # Using a request response that is missing a field throws a RuntimeError
+    del upload_request_response['s3_bucket']
+    with pytest.raises(RuntimeError):
+        collection._make_upload_request('foo.txt', 'foo.txt')
+
+
 @patch('citrine.resources.file_link.open')
 def test_upload_file(_, collection, uploader):
-    """Test uploading a file."""
+    """Test that uploading a file returns the version ID."""
     # A successful file upload sets uploader.s3_version
     new_version = '3'
     with patch('citrine.resources.file_link.boto3_client',
@@ -68,7 +109,7 @@ def test_upload_file(_, collection, uploader):
 
 
 def test_complete_upload(collection, session, uploader):
-    """Test the signaling that an upload has completed and the creation of a FileLink object."""
+    """Test signaling that an upload has completed and the creation of a FileLink object."""
     dest_name = 'foo.txt'
     file_id = '12345'
     version = '13'

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -1,0 +1,63 @@
+import pytest
+from uuid import uuid4
+
+from citrine.resources.file_link import FileCollection, FileLink, _Uploader
+from tests.utils.session import FakeSession
+
+
+@pytest.fixture
+def session() -> FakeSession:
+    return FakeSession()
+
+
+@pytest.fixture
+def collection(session) -> FileCollection:
+    return FileCollection(
+        project_id=uuid4(),
+        dataset_id=uuid4(),
+        session=session
+    )
+
+
+@pytest.fixture
+def uploader() -> _Uploader:
+    uploader = _Uploader
+    uploader.bucket = 'citrine-datasvc'
+    uploader.key = '334455'
+    uploader.upload_id = 'dea3a-555'
+    uploader.region_name = 'us-west'
+    uploader.aws_access_key_id = 'sahgkjsgahnei'
+    uploader.aws_secret_access_token = 'hjhguneheehhhhsdjfjnjjnelkooius'
+    uploader.aws_secret_access_key = 'kdydahkd78452978'
+    uploader.aws_session_token = 'sdfhuaf74yf783g4ofg7g3o'
+    uploader.object_key = '234787521--abcde'
+    uploader.s3_version = '2'
+    return uploader
+
+
+def test_complete_upload(collection, session, uploader):
+    """Test the signaling that an upload has completed and the creation of a FileLink object."""
+    dest_name = 'foo.txt'
+    file_id = '12345'
+    version = '13'
+    bad_complete_response = {
+        'file_info': {
+            'file_id': file_id
+        },
+        'version': version  # 'version' is supposed to go inside 'file_info'
+    }
+    with pytest.raises(RuntimeError):
+        session.set_response(bad_complete_response)
+        collection._complete_upload(dest_name, uploader)
+
+    complete_response = {
+        'file_info': {
+            'file_id': file_id,
+            'version': version
+        }
+    }
+    session.set_response(complete_response)
+    file_link = collection._complete_upload(dest_name, uploader)
+    url = 'projects/{}/datasets/{}/files/{}/versions/{}'\
+        .format(collection.project_id, collection.dataset_id, file_id, version)
+    assert file_link.dump() == FileLink(dest_name, url=url).dump()

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -5,6 +5,7 @@ from botocore.exceptions import ClientError
 
 from citrine.resources.file_link import FileCollection, FileLink, _Uploader
 from tests.utils.session import FakeSession
+from tests.utils.factories import FileLinkDataFactory
 
 
 @pytest.fixture
@@ -19,6 +20,21 @@ def collection(session) -> FileCollection:
         dataset_id=uuid4(),
         session=session
     )
+
+
+@pytest.fixture
+def valid_data() -> dict:
+    return FileLinkDataFactory(url='www.citrine.io', filename='materials.txt')
+
+
+def test_build_equivalence(collection, valid_data):
+    """Test that build() works the same whether called from FileLink or FileCollection."""
+    assert collection.build(valid_data).dump() == FileLink.build(valid_data).dump()
+
+
+def test_string_representation(valid_data):
+    """Test the string representation."""
+    assert str(FileLink.build(valid_data)) == '<File link \'materials.txt\'>'
 
 
 @pytest.fixture

--- a/tests/serialization/test_file_link.py
+++ b/tests/serialization/test_file_link.py
@@ -1,23 +1,18 @@
 """Tests of FileLink serialization and deserialization."""
-import pytest
-
 from citrine.resources.file_link import FileLink
 from tests.utils.factories import FileLinkDataFactory
 
 
-@pytest.fixture
-def valid_data() -> dict:
-    return FileLinkDataFactory(url='www.citrine.io', filename='materials.txt')
-
-
-def test_simple_deserialization(valid_data):
+def test_simple_deserialization():
     """Ensure that a deserialized File Link looks sane."""
+    valid_data = FileLinkDataFactory(url='www.citrine.io', filename='materials.txt')
     file_link = FileLink.build(valid_data)
     assert file_link.url == 'www.citrine.io'
     assert file_link.filename == 'materials.txt'
 
 
-def test_serialization(valid_data):
+def test_serialization():
     """Ensure that a serialized File Link looks sane."""
+    valid_data = FileLinkDataFactory(url='www.citrine.io', filename='materials.txt')
     file_link = FileLink.build(valid_data)
     assert file_link.dump() == valid_data

--- a/tests/serialization/test_file_link.py
+++ b/tests/serialization/test_file_link.py
@@ -1,0 +1,23 @@
+"""Tests of FileLink serialization and deserialization."""
+import pytest
+
+from citrine.resources.file_link import FileLink
+from tests.utils.factories import FileLinkDataFactory
+
+
+@pytest.fixture
+def valid_data() -> dict:
+    return FileLinkDataFactory(url='www.citrine.io', filename='materials.txt')
+
+
+def test_simple_deserialization(valid_data):
+    """Ensure that a deserialized File Link looks sane."""
+    file_link = FileLink.build(valid_data)
+    assert file_link.url == 'www.citrine.io'
+    assert file_link.filename == 'materials.txt'
+
+
+def test_serialization(valid_data):
+    """Ensure that a serialized File Link looks sane."""
+    file_link = FileLink.build(valid_data)
+    assert file_link.dump() == valid_data

--- a/tests/serialization/test_material_run.py
+++ b/tests/serialization/test_material_run.py
@@ -1,7 +1,4 @@
 """Tests of the Material Run schema."""
-import pytest
-from uuid import uuid4
-
 from citrine.resources.material_run import MaterialRun
 from citrine.resources.material_spec import MaterialSpec
 from citrine.resources.measurement_spec import MeasurementSpec

--- a/tests/serialization/test_process_spec.py
+++ b/tests/serialization/test_process_spec.py
@@ -51,7 +51,7 @@ def valid_data():
             'description': 'a long description',
             'tags': []
         },
-        file_links=[{'type': 'file_link', 'filename': 'Cake spec', 'url': 'specs/cake.txt'}],
+        file_links=[{'type': 'file_link', 'filename': 'cake_recipe.txt', 'url': 'www.baking.com'}],
         type='process_spec'
     )
 

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -43,6 +43,12 @@ class LinkByUIDInputFactory(factory.DictFactory):
     scope = 'id'
 
 
+class FileLinkDataFactory(factory.DictFactory):
+    url = factory.Faker('www.citrine.io')
+    filename = factory.Faker('materials.txt')
+    type = 'file_link'
+
+
 class MaterialRunDataFactory(factory.DictFactory):
     uids = factory.SubFactory(IDDataFactory)
     name = factory.Faker('color_name')

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -7,6 +7,7 @@
 import factory
 from taurus.entity.link_by_uid import LinkByUID
 
+from citrine.resources.file_link import _Uploader
 from citrine.resources.dataset import Dataset
 from citrine.resources.material_run import MaterialRun
 
@@ -90,3 +91,19 @@ class DatasetFactory(factory.Factory):
     name = factory.Faker('company')
     summary = factory.Faker('catch_phrase')
     description = factory.Faker('bs')
+
+
+class _UploaderFactory(factory.Factory):
+    class Meta:
+        model = _Uploader
+
+    @factory.post_generation
+    def assign_values(obj, create, extracted):
+        obj.bucket = 'citrine-datasvc'
+        obj.object_key = '334455'
+        obj.upload_id = 'dea3a-555'
+        obj.region_name = 'us-west'
+        obj.aws_access_key_id = 'dkfjiejkcm'
+        obj.aws_secret_access_key = 'ifeemkdsfjeijie8759235u2wjr388'
+        obj.aws_session_token = 'fafjeijfi87834j87woa'
+        obj.s3_version = '2'

--- a/tests/utils/session.py
+++ b/tests/utils/session.py
@@ -3,9 +3,7 @@ from urllib.parse import urlencode
 
 
 class FakeCall:
-    """
-    Encapsulates a call to a FakeSession
-    """
+    """Encapsulates a call to a FakeSession."""
 
     def __init__(self, method, path, json=None, params: dict = None):
         self.method = method
@@ -31,9 +29,7 @@ class FakeCall:
 
 
 class FakeSession:
-    """
-    Fake version of Session used to test API interaction
-    """
+    """Fake version of Session used to test API interaction."""
     def __init__(self):
         self.calls = []
         self.response = {}
@@ -65,3 +61,13 @@ class FakeSession:
         self.calls.append(FakeCall('DELETE', path))
         return self.response
 
+
+class FakeS3Client:
+    """A fake version of the S3 client that has a put_object method."""
+
+    def __init__(self, put_object_output):
+        self.put_object_output = put_object_output
+
+    def put_object(self, *args, **kwargs):
+        """Return the expected output of the real client's put_object method."""
+        return self.put_object_output

--- a/tests/utils/session.py
+++ b/tests/utils/session.py
@@ -57,6 +57,10 @@ class FakeSession:
         self.calls.append(FakeCall('POST', path, json))
         return self.response
 
+    def put_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
+        self.calls.append(FakeCall('PUT', path, json))
+        return self.response
+
     def delete_resource(self, path: str) -> dict:
         self.calls.append(FakeCall('DELETE', path))
         return self.response


### PR DESCRIPTION
Adds the ability to upload a file to S3 through the python client.

Upload is broken up into three pieces: a request to the database that returns temporary credentials, the upload itself using the S3 client, and a message to the database saying that the upload is complete.

Tests make heavy use of mock objects to represent the S3 client and the Citrine Session.