### PR TITLE
Feature/unique label to name

### DIFF
--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -40,7 +40,7 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
         The number fraction of the ingredient in the process.
     absolute_quantity: ContinuousValue, optional
         The absolute quantity of the ingredient in the process.
-    unique_label: str, optional
+    name: str, optional
         Label on the ingredient that is unique within the process that contains it.
     labels: List[str], optional
         Additional labels on the ingredient that must be unique.
@@ -62,7 +62,7 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
     number_fraction = PropertyOptional(Object(ContinuousValue), 'number_fraction')
     absolute_quantity = PropertyOptional(
         Object(ContinuousValue), 'absolute_quantity')
-    unique_label = PropertyOptional(String(), 'unique_label')
+    name = PropertyOptional(String(), 'name')
     labels = PropertyOptional(PropertyList(String()), 'labels')
     spec = PropertyOptional(LinkOrElse(), 'spec')
     file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
@@ -77,7 +77,7 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
                  volume_fraction: Optional[ContinuousValue] = None,
                  number_fraction: Optional[ContinuousValue] = None,
                  absolute_quantity: Optional[ContinuousValue] = None,
-                 unique_label: Optional[str] = None,
+                 name: Optional[str] = None,
                  labels: Optional[List[str]] = None,
                  spec: Optional[TaurusIngredientSpec] = None,
                  file_links: Optional[List[FileLink]] = None):
@@ -87,10 +87,10 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
                                      volume_fraction=volume_fraction,
                                      number_fraction=number_fraction,
                                      absolute_quantity=absolute_quantity, labels=labels,
-                                     unique_label=unique_label, spec=spec, file_links=file_links)
+                                     name=name, spec=spec, file_links=file_links)
 
     def __str__(self):
-        return '<Ingredient run {!r}>'.format(self.unique_label)
+        return '<Ingredient run {!r}>'.format(self.name)
 
 
 class IngredientRunCollection(DataConceptsCollection[IngredientRun]):

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -39,7 +39,7 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
         The number fraction of the ingredient in the process.
     absolute_quantity: ContinuousValue, optional
         The absolute quantity of the ingredient in the process.
-    unique_label: str, optional
+    name: str, optional
         Label on the ingredient that is unique within the process that contains it.
     labels: List[str], optional
         Additional labels on the ingredient that must be unique.
@@ -59,7 +59,7 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
     number_fraction = PropertyOptional(Object(ContinuousValue), 'number_fraction')
     absolute_quantity = PropertyOptional(
         Object(ContinuousValue), 'absolute_quantity')
-    unique_label = PropertyOptional(String(), 'unique_label')
+    name = PropertyOptional(String(), 'name')
     labels = PropertyOptional(PropertyList(String()), 'labels')
     file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
     typ = String('type')
@@ -73,7 +73,7 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
                  volume_fraction: Optional[ContinuousValue] = None,
                  number_fraction: Optional[ContinuousValue] = None,
                  absolute_quantity: Optional[ContinuousValue] = None,
-                 unique_label: Optional[str] = None,
+                 name: Optional[str] = None,
                  labels: Optional[List[str]] = None,
                  file_links: Optional[List[FileLink]] = None):
         DataConcepts.__init__(self, TaurusIngredientSpec.typ)
@@ -82,10 +82,10 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
                                       volume_fraction=volume_fraction,
                                       number_fraction=number_fraction,
                                       absolute_quantity=absolute_quantity, labels=labels,
-                                      unique_label=unique_label, file_links=file_links)
+                                      name=name, file_links=file_links)
 
     def __str__(self):
-        return '<Ingredient spec {!r}>'.format(self.unique_label)
+        return '<Ingredient spec {!r}>'.format(self.name)
 
 
 class IngredientSpecCollection(DataConceptsCollection[IngredientSpec]):

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -58,7 +58,7 @@ class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTe
     parameters = PropertyOptional(PropertyList(
         MixedList([LinkOrElse, Object(BaseBounds)])), 'parameters')
     allowed_labels = PropertyOptional(PropertyList(String()), 'allowed_labels')
-    allowed_unique_labels = PropertyOptional(PropertyList(String()), 'allowed_unique_labels')
+    allowed_names = PropertyOptional(PropertyList(String()), 'allowed_names')
     typ = String('type')
 
     def __init__(self,
@@ -75,14 +75,14 @@ class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTe
                                                                     BaseBounds]]
                                                      ]]] = None,
                  allowed_labels: Optional[List[str]] = None,
-                 allowed_unique_labels: Optional[List[str]] = None,
+                 allowed_names: Optional[List[str]] = None,
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None):
         DataConcepts.__init__(self, TaurusProcessTemplate.typ)
         TaurusProcessTemplate.__init__(self, name=name, uids=set_default_uid(uids),
                                        conditions=conditions, parameters=parameters, tags=tags,
                                        description=description, allowed_labels=allowed_labels,
-                                       allowed_unique_labels=allowed_unique_labels)
+                                       allowed_names=allowed_names)
 
     @classmethod
     def _build_child_objects(cls, data: dict, session: Session = None):

--- a/tests/rest/test_ingredient_rest.py
+++ b/tests/rest/test_ingredient_rest.py
@@ -9,7 +9,7 @@ def valid_data():
     """Return valid data used for these tests."""
     return {"type": "ingredient_run", "material":
         {"type": "link_by_uid", "id": "5c913611-c304-4254-bad2-4797c952a3b3", "scope": "ID"},
-            "spec": None, "unique_label": "Good Ingredient Run", "labels": [],
+            "spec": None, "name": "Good Ingredient Run", "labels": [],
             "mass_fraction": None, "volume_fraction": None, "number_fraction": None,
             "absolute_quantity": None,
             "uids": {

--- a/tests/serialization/test_ingredient_run.py
+++ b/tests/serialization/test_ingredient_run.py
@@ -22,7 +22,7 @@ def valid_data():
         volume_fraction=None,
         number_fraction=None,
         absolute_quantity=None,
-        unique_label='flour',
+        name='flour',
         labels=['fine', 'bleached'],
         spec=None,
         file_links=[],
@@ -41,7 +41,7 @@ def test_simple_deserialization(valid_data):
     assert ingredient_run.volume_fraction is None
     assert ingredient_run.number_fraction is None
     assert ingredient_run.absolute_quantity is None
-    assert ingredient_run.unique_label == 'flour'
+    assert ingredient_run.name == 'flour'
     assert ingredient_run.labels == ['fine', 'bleached']
     assert ingredient_run.spec is None
     assert ingredient_run.file_links == []
@@ -63,7 +63,7 @@ def test_material_attachment():
     """
     flour = MaterialRun("flour", sample_type='unknown')
     flour_ingredient = IngredientRun(material=flour, absolute_quantity=NominalReal(500, 'g'),
-                                     unique_label='500 g flour')
+                                     name='500 g flour')
 
     flour_ingredient_copy = IngredientRun.build(flour_ingredient.dump())
     assert flour_ingredient_copy == flour_ingredient

--- a/tests/serialization/test_object_template.py
+++ b/tests/serialization/test_object_template.py
@@ -32,7 +32,7 @@ def test_object_template_serde():
 
     proc_template = ProcessTemplate("Make an object", parameters=[index_template],
                                     conditions=[pressure_template], allowed_labels=["Label"],
-                                    allowed_unique_labels=["first sample", "second sample"])
+                                    allowed_names=["first sample", "second sample"])
     assert ProcessTemplate.build(proc_template.dump()) == proc_template
 
     # Check that serde still works if the template is a LinkByUID

--- a/tests/serialization/test_process_spec.py
+++ b/tests/serialization/test_process_spec.py
@@ -47,7 +47,7 @@ def valid_data():
                 ]
             ],
             'allowed_labels': ['a', 'b'],
-            'allowed_unique_labels': ['a unique label'],
+            'allowed_names': ['a name'],
             'description': 'a long description',
             'tags': []
         },
@@ -76,7 +76,7 @@ def test_simple_deserialization(valid_data):
                            ],
                            description='a long description',
                            allowed_labels=['a', 'b'],
-                           allowed_unique_labels=['a unique label'])
+                           allowed_names=['a name'])
     assert process_spec.name == 'Process 1'
     assert process_spec.notes == 'make sure to use oven mitts'
     assert process_spec.file_links == [FileLink('Cake spec', 'specs/cake.txt')]


### PR DESCRIPTION
Change `unique_label` to `name` and `allowed_unique_labels` to `allowed_names`.

Tested by locally changing `pipfile` so that the taurus dependency points to the branch `feature/unique-label-to-name`, which implements the corresponding changes in taurus. The tests then all pass when running in a pipenv shell.