### PR TITLE
Feature/pla 1336 ingredients to processes

### DIFF
--- a/docs/source/getting_started/code_examples.rst
+++ b/docs/source/getting_started/code_examples.rst
@@ -73,11 +73,13 @@ Create a linked process, material, and measurement
 --------------------------------------------------
 
 Imagine you purchase some toluene, measure its index of refraction, and then use it as an ingredient in a chemical reaction.
-The code below converts those actions into data model objects: the process of purchasing, the material of toluene, the optical measurement, and the use of the toluene as an ingredient in a subsequent process.
+The code below converts those actions into data model objects: the process of purchasing, the material of toluene,
+the optical measurement, and the use of the toluene as an ingredient in a subsequent process.
 Specs relate the intent and runs relate what actually happened, which may or may not be the same.
 This assumes that you have already created or retrieved the following:
 a process template ``purchase_template``, a material template ``toluene_template``, a measurement template ``refractive_index_template``,
-a condition template ``temperature_template``, a parameter template ``wavelength_template``, and a property template ``refractive_index_template``.
+a process template ``reaction_template``, a condition template ``temperature_template``,
+a parameter template ``wavelength_template``, and a property template ``refractive_index_template``.
 
 .. code-block:: python
 
@@ -98,7 +100,9 @@ a condition template ``temperature_template``, a parameter template ``wavelength
     refractive_index_spec = solvents.measurement_specs.register(MeasurementSpec("Index of refraction", template=refractive_index_template,
         conditions=[Condition("Room temperature", template=temperature_template, value=NominalReal(22, 'degC'))],
         parameters=[Parameter("Optical wavelength", template=wavelength_template, value=NominalReal(633, 'nm'))]))
-    toluene_ingredient_spec = solvents.ingredient_specs.register(IngredientSpec("Toluene solvent", absolute_quantity=NominalReal(34, 'mL')))
+    reaction_spec = solvents.process_specs.register(ProcessSpec("A chemical reaction", template=reaction_template))
+    toluene_ingredient_spec = solvents.ingredient_specs.register(
+        IngredientSpec("Toluene solvent", material=toluene_spec, process=reaction_spec, absolute_quantity=NominalReal(34, 'mL')))
 
     buy_toluene_run = solvents.process_runs.register(ProcessRun("Buy 1 liter of toluene", tags=["lot2019-140B"], spec=buy_toluene_spec))
     toluene = solvents.material_runs.register(MaterialRun("Toluene", process=buy_toluene_run, spec=toluene_spec))
@@ -107,5 +111,7 @@ a condition template ``temperature_template``, a parameter template ``wavelength
         conditions=[Condition("Room temperature", template=temperature_template, value=NominalReal(24, 'degC'))],
         parameters=[Parameter("Optical wavelength", template=wavelength_template, value=NominalReal(633, 'nm'))],
         properties=[Property("Refractive index", template=refractive_index_template, value=NominalReal(1.49, 'dimensionless'))]))
-    toluene_ingredient = solvents.ingredient_runs.register(IngredientRun("Toluene solvent", absolute_quantity=NominalReal(40, 'mL'), notes="I poured too much!"))
+    reation_run = solvents.process_runs.register(ProcessRun("A chemical reaction", spec=reaction_spec))
+    toluene_ingredient = solvents.ingredient_runs.register(
+        IngredientRun("Toluene solvent", spec=toluene_ingredient_spec, material=toluene, process=reation_run, absolute_quantity=NominalReal(40, 'mL'), notes="I poured too much!"))
 

--- a/docs/source/getting_started/data_model.rst
+++ b/docs/source/getting_started/data_model.rst
@@ -19,13 +19,16 @@ The Basic Objects: Processes, Materials, Measurements
 * An ingredient is a material and its amount that is used as an input to a process.
 
 The links between objects must be established in a specific direction.
-A process specifies its input ingredients, but does not specify the material it produces.
+An ingredient specifies both the material it is derived from and the process it is used in.
+A process does not specify either its input ingredients or the material it produces.
 A material specifies the process that creates it, but does not specify what measurements are done on it or how it is used as an ingredient.
-Measurements and ingredients specify the material that they relate to.
+Measurements specify the material that they are performed on.
 
 .. hint::
 
-    First create the process, *then* create the material, then create any measurements on or ingredients derived from that material.
+    First create the process, *then* create the output material, then create any measurements done on that material.
+    If the material is used as an ingredient in a subsequent process, first create the new process, then create the ingredient
+    that describes the materials role in the process.
 
 We make a first class distinction between intent (specs) and reality (runs).
 The same spec can be used to create many runs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/CitrineInformatics/taurus.git@feature/pla-1336-ingredients-to-processes
+git+https://github.com/CitrineInformatics/taurus.git@develop
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.14.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/CitrineInformatics/taurus.git@develop
+git+https://github.com/CitrineInformatics/taurus.git@feature/pla-1336-ingredients-to-processes
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.14.5

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -15,6 +15,7 @@ from citrine._utils.functions import (
     validate_type, scrub_none,
     replace_objects_with_links, get_object_id)
 from taurus.client.json_encoder import loads, dumps, LinkByUID
+from taurus.entity.dict_serializable import DictSerializable
 from taurus.entity.bounds.base_bounds import BaseBounds
 from taurus.entity.template.attribute_template import AttributeTemplate
 
@@ -192,7 +193,7 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
                                 elem.session = session
                     else:
                         elem = DataConcepts._get_field(data_with_soft_links, key)
-                        data[key] = DataConcepts.get_type(elem.as_dict()).build(elem)
+                        data[key] = DataConcepts.get_type(elem).build(elem)
                         if isinstance(data[key], DataConcepts):
                             data[key].session = session
 
@@ -241,7 +242,7 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
         ----------
         data: dict
             A dictionary corresponding to a serialized data concepts object of unknown type.
-            The method will also work if `data` is a deserialized Taurus object.
+            This method will also work if data is a deserialized Taurus object.
 
         Returns
         -------
@@ -251,8 +252,9 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
         """
         if len(DataConcepts.class_dict) == 0:
             DataConcepts._make_class_dict()
-        key = DataConcepts._get_field(data, 'type')
-        return DataConcepts.class_dict[key]
+        if isinstance(data, DictSerializable):
+            data = data.as_dict()
+        return DataConcepts.class_dict[data['type']]
 
     @staticmethod
     def _make_class_dict():

--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -11,6 +11,7 @@ from taurus.entity.file_link import FileLink
 from taurus.entity.object.ingredient_run import IngredientRun as TaurusIngredientRun
 from taurus.entity.object.ingredient_spec import IngredientSpec as TaurusIngredientSpec
 from taurus.entity.object.material_run import MaterialRun as TaurusMaterialRun
+from taurus.entity.object.process_run import ProcessRun as TaurusProcessRun
 from taurus.entity.value.continuous_value import ContinuousValue
 
 
@@ -32,6 +33,8 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
         Long-form notes about the ingredient run.
     material: MaterialRun
         Material that this ingredient is.
+    process: ProcessRun
+        Process that this ingredient is used in.
     mass_fraction: :py:class:`ContinuousValue \
     <taurus.entity.value.continuous_value.ContinuousValue>`, optional
         The mass fraction of the ingredient in the process.
@@ -61,6 +64,7 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
     tags = PropertyOptional(PropertyList(String()), 'tags')
     notes = PropertyOptional(String(), 'notes')
     material = PropertyOptional(LinkOrElse(), 'material')
+    process = PropertyOptional(LinkOrElse(), 'process')
     mass_fraction = PropertyOptional(Object(ContinuousValue), 'mass_fraction')
     volume_fraction = PropertyOptional(Object(ContinuousValue), 'volume_fraction')
     number_fraction = PropertyOptional(Object(ContinuousValue), 'number_fraction')
@@ -77,6 +81,7 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  material: Optional[TaurusMaterialRun] = None,
+                 process: Optional[TaurusProcessRun] = None,
                  mass_fraction: Optional[ContinuousValue] = None,
                  volume_fraction: Optional[ContinuousValue] = None,
                  number_fraction: Optional[ContinuousValue] = None,
@@ -87,8 +92,8 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
                  file_links: Optional[List[FileLink]] = None):
         DataConcepts.__init__(self, TaurusIngredientRun.typ)
         TaurusIngredientRun.__init__(self, uids=set_default_uid(uids), tags=tags, notes=notes,
-                                     material=material, mass_fraction=mass_fraction,
-                                     volume_fraction=volume_fraction,
+                                     material=material, process=process,
+                                     mass_fraction=mass_fraction, volume_fraction=volume_fraction,
                                      number_fraction=number_fraction,
                                      absolute_quantity=absolute_quantity, labels=labels,
                                      unique_label=unique_label, spec=spec, file_links=file_links)

--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -77,6 +77,7 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
     typ = String('type')
 
     def __init__(self,
+                 name: str,
                  uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
@@ -86,7 +87,6 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
                  volume_fraction: Optional[ContinuousValue] = None,
                  number_fraction: Optional[ContinuousValue] = None,
                  absolute_quantity: Optional[ContinuousValue] = None,
-                 name: Optional[str] = None,
                  labels: Optional[List[str]] = None,
                  spec: Optional[TaurusIngredientSpec] = None,
                  file_links: Optional[List[FileLink]] = None):

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -4,12 +4,13 @@ from typing import List, Dict, Optional, Type
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
 from citrine.resources.data_concepts import DataConceptsCollection, DataConcepts
-from citrine.resources.material_spec import MaterialSpec
 from citrine._serialization.properties import Mapping, String, LinkOrElse, Object
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from taurus.entity.file_link import FileLink
 from taurus.entity.object.ingredient_spec import IngredientSpec as TaurusIngredientSpec
+from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
+from taurus.entity.object.material_spec import MaterialSpec as TaurusMaterialSpec
 from taurus.entity.value.continuous_value import ContinuousValue
 
 
@@ -31,6 +32,8 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
         Long-form notes about the ingredient spec.
     material: MaterialSpec
         Material that this ingredient is.
+    process: ProcessSpec
+        Process that this ingredient is used in.
     mass_fraction: :py:class:`ContinuousValue \
     <taurus.entity.value.continuous_value.ContinuousValue>`, optional
         The mass fraction of the ingredient in the process.
@@ -58,6 +61,7 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
     tags = PropertyOptional(PropertyList(String()), 'tags')
     notes = PropertyOptional(String(), 'notes')
     material = PropertyOptional(LinkOrElse(), 'material')
+    process = PropertyOptional(LinkOrElse(), 'process')
     mass_fraction = PropertyOptional(Object(ContinuousValue), 'mass_fraction')
     volume_fraction = PropertyOptional(Object(ContinuousValue), 'volume_fraction')
     number_fraction = PropertyOptional(Object(ContinuousValue), 'number_fraction')
@@ -72,7 +76,8 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
                  uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
-                 material: Optional[MaterialSpec] = None,
+                 material: Optional[TaurusMaterialSpec] = None,
+                 process: Optional[TaurusProcessSpec] = None,
                  mass_fraction: Optional[ContinuousValue] = None,
                  volume_fraction: Optional[ContinuousValue] = None,
                  number_fraction: Optional[ContinuousValue] = None,
@@ -82,8 +87,8 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
                  file_links: Optional[List[FileLink]] = None):
         DataConcepts.__init__(self, TaurusIngredientSpec.typ)
         TaurusIngredientSpec.__init__(self, uids=set_default_uid(uids), tags=tags, notes=notes,
-                                      material=material, mass_fraction=mass_fraction,
-                                      volume_fraction=volume_fraction,
+                                      material=material, process=process,
+                                      mass_fraction=mass_fraction, volume_fraction=volume_fraction,
                                       number_fraction=number_fraction,
                                       absolute_quantity=absolute_quantity, labels=labels,
                                       unique_label=unique_label, file_links=file_links)

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -73,6 +73,7 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
     typ = String('type')
 
     def __init__(self,
+                 name: str,
                  uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
@@ -82,7 +83,6 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
                  volume_fraction: Optional[ContinuousValue] = None,
                  number_fraction: Optional[ContinuousValue] = None,
                  absolute_quantity: Optional[ContinuousValue] = None,
-                 name: Optional[str] = None,
                  labels: Optional[List[str]] = None,
                  file_links: Optional[List[FileLink]] = None):
         DataConcepts.__init__(self, TaurusIngredientSpec.typ)

--- a/src/citrine/resources/material_run.py
+++ b/src/citrine/resources/material_run.py
@@ -85,7 +85,7 @@ class MaterialRun(DataConcepts, Resource['MaterialRun'], TaurusMaterialRun):
         return '<Material run {!r}>'.format(self.name)
 
     @classmethod
-    def _build_soft_linked_objects(cls, obj, obj_with_soft_links, session: Session = None):
+    def _build_discarded_objects(cls, obj, obj_with_soft_links, session: Session = None):
         """
         Build the MeasurementRun objects that this MaterialRun has soft links to.
 
@@ -115,28 +115,10 @@ class MaterialRun(DataConcepts, Resource['MaterialRun'], TaurusMaterialRun):
             The MaterialRun object is modified so that it has links to its MeasurementRuns.
 
         """
-        measurements = None
-        # Get the measurements list, if it exists.
-        if isinstance(obj_with_soft_links, dict):
-            if obj_with_soft_links.get('measurements'):
-                measurements = obj_with_soft_links['measurements']
-        if isinstance(obj_with_soft_links, DictSerializable):
-            if hasattr(obj_with_soft_links, 'measurements'):
-                measurements = getattr(obj_with_soft_links, 'measurements')
-        if measurements is None:
-            return
-
         from citrine.resources.measurement_run import MeasurementRun
-        for meas in measurements:
-            # Cycle through measurements and if they are not LinkByUID, build them and then
-            # set their `material` field to obj
-            assert isinstance(meas, DictSerializable)
-            if isinstance(meas, LinkByUID):
-                pass
-            setattr(meas, 'material', None)
-            meas_object = MeasurementRun.build(meas, session)
-            setattr(meas_object, 'material', obj)
-        return
+        DataConcepts._build_list_of_soft_links(
+            obj, obj_with_soft_links, field='measurements', reverse_field='material',
+            linked_type=MeasurementRun, session=session)
 
 
 class MaterialRunCollection(DataConceptsCollection[MaterialRun]):

--- a/src/citrine/resources/material_run.py
+++ b/src/citrine/resources/material_run.py
@@ -130,14 +130,10 @@ class MaterialRun(DataConcepts, Resource['MaterialRun'], TaurusMaterialRun):
         for meas in measurements:
             # Cycle through measurements and if they are not LinkByUID, build them and then
             # set their `material` field to obj
-            if isinstance(meas, DictSerializable):
-                if isinstance(meas, LinkByUID):
-                    pass
-                setattr(meas, 'material', None)
-            elif isinstance(meas, dict):
-                if meas.get('type') == LinkByUID.typ:
-                    pass
-                meas['material'] = None
+            assert isinstance(meas, DictSerializable)
+            if isinstance(meas, LinkByUID):
+                pass
+            setattr(meas, 'material', None)
             meas_object = MeasurementRun.build(meas, session)
             setattr(meas_object, 'material', obj)
         return

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -131,14 +131,10 @@ class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
         for ingredient in ingredients:
             # Cycle through ingredients and if they are not LinkByUID, build them and then
             # set their `process` field to obj
-            if isinstance(ingredient, DictSerializable):
-                if isinstance(ingredient, LinkByUID):
-                    pass
-                setattr(ingredient, 'process', None)
-            elif isinstance(ingredient, dict):
-                if ingredient.get('type') == LinkByUID.typ:
-                    pass
-                ingredient['process'] = None
+            assert isinstance(ingredient, DictSerializable)
+            if isinstance(ingredient, LinkByUID):
+                pass
+            setattr(ingredient, 'process', None)
             ingredient_object = IngredientRun.build(ingredient, session)
             setattr(ingredient_object, 'process', obj)
         return

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -3,13 +3,16 @@ from typing import List, Dict, Optional, Type
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
+from citrine._session import Session
 from citrine._serialization.properties import String, Mapping, Object, LinkOrElse
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
-from taurus.entity.file_link import FileLink
 from citrine.attributes.condition import Condition
 from citrine.attributes.parameter import Parameter
+from taurus.entity.dict_serializable import DictSerializable
+from taurus.entity.file_link import FileLink
+from taurus.entity.link_by_uid import LinkByUID
 from taurus.entity.object.process_run import ProcessRun as TaurusProcessRun
 from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 
@@ -81,6 +84,64 @@ class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
 
     def __str__(self):
         return '<Process run {!r}>'.format(self.name)
+
+    @classmethod
+    def _build_soft_linked_objects(cls, obj, obj_with_soft_links, session: Session = None):
+        """
+        Build the IngredientRun objects that this ProcessRun has soft links to.
+
+        The ingredient runs are found in `obj_with_soft_link`
+
+        This method modifies the object in place.
+
+        Parameters
+        ----------
+        obj: ProcessRun
+            A ProcessRun object that might be missing some links to IngredientRun objects.
+        obj_with_soft_links: dict or \
+        :py:class:`DictSerializable <taurus.entity.dict_serializable.DictSerializable>`
+            A representation of the ProcessRun in which the IngredientRuns are encoded.
+            We consider both the possibility that this is a dictionary with an 'ingredients' key
+            and that it is a
+            :py:class:`DictSerializable <taurus.entity.dict_serializable.DictSerializable>`
+            (presumably a
+            :py:class:`TaurusProcessRun <taurus.entity.process_run.ProcessRun>`)
+            with a .ingredients field.
+        session: Session, optional
+            Citrine session used to connect to the database.
+
+        Returns
+        -------
+        None
+            The ProcessRun object is modified so that it has links to its IngredientRuns.
+
+        """
+        ingredients = None
+        # Get the ingredients list, if it exists.
+        if isinstance(obj_with_soft_links, dict):
+            if obj_with_soft_links.get('ingredients'):
+                ingredients = obj_with_soft_links['ingredients']
+        if isinstance(obj_with_soft_links, DictSerializable):
+            if hasattr(obj_with_soft_links, 'ingredients'):
+                ingredients = getattr(obj_with_soft_links, 'ingredients')
+        if ingredients is None:
+            return
+
+        from citrine.resources.ingredient_run import IngredientRun
+        for ingredient in ingredients:
+            # Cycle through ingredients and if they are not LinkByUID, build them and then
+            # set their `process` field to obj
+            if isinstance(ingredient, DictSerializable):
+                if isinstance(ingredient, LinkByUID):
+                    pass
+                setattr(ingredient, 'process', None)
+            elif isinstance(ingredient, dict):
+                if ingredient.get('type') == LinkByUID.typ:
+                    pass
+                ingredient['process'] = None
+            ingredient_object = IngredientRun.build(ingredient, session)
+            setattr(ingredient_object, 'process', obj)
+        return
 
 
 class ProcessRunCollection(DataConceptsCollection[ProcessRun]):

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -6,7 +6,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import String, Mapping, Object, LinkOrElse
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
-from citrine.resources.ingredient_run import IngredientRun
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
 from taurus.entity.file_link import FileLink
 from citrine.attributes.condition import Condition

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -37,8 +37,6 @@ class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
         Conditions under which this process run occurs.
     parameters: List[Parameter], optional
         Parameters of this process run.
-    ingredients: List[IngredientRun], optional
-        Ingredient runs that act as inputs to this process run.
     spec: ProcessSpec
         Spec for this process run.
     file_links: List[FileLink], optional
@@ -50,6 +48,10 @@ class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
         The material run that this process run produces. The link is established by creating
         the material run and settings its `process` field to this process run.
 
+    ingredients: List[IngredientRun]
+        Ingredient runs that act as inputs to this process run. The link is established by
+        creating each ingredient run and setting its `process` field to this process run.
+
     """
 
     _response_key = TaurusProcessRun.typ  # 'process_run'
@@ -60,8 +62,6 @@ class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
     notes = PropertyOptional(String(), 'notes')
     conditions = PropertyOptional(PropertyList(Object(Condition)), 'conditions')
     parameters = PropertyOptional(PropertyList(Object(Parameter)), 'parameters')
-    ingredients = PropertyOptional(
-        PropertyList(LinkOrElse()), 'ingredients')
     spec = PropertyOptional(LinkOrElse(), 'spec')
     file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
     typ = String('type')
@@ -73,14 +73,12 @@ class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
                  notes: Optional[str] = None,
                  conditions: Optional[List[Condition]] = None,
                  parameters: Optional[List[Parameter]] = None,
-                 ingredients: Optional[List[IngredientRun]] = None,
                  spec: Optional[TaurusProcessSpec] = None,
                  file_links: Optional[List[FileLink]] = None):
         DataConcepts.__init__(self, TaurusProcessRun.typ)
         TaurusProcessRun.__init__(self, name=name, uids=set_default_uid(uids),
                                   tags=tags, conditions=conditions, parameters=parameters,
-                                  ingredients=ingredients, spec=spec,
-                                  file_links=file_links, notes=notes)
+                                  spec=spec, file_links=file_links, notes=notes)
 
     def __str__(self):
         return '<Process run {!r}>'.format(self.name)

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -3,13 +3,16 @@ from typing import Optional, Dict, List, Type
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
+from citrine._session import Session
 from citrine._serialization.properties import String, Mapping, Object, LinkOrElse
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
-from taurus.entity.file_link import FileLink
 from citrine.attributes.condition import Condition
 from citrine.attributes.parameter import Parameter
+from taurus.entity.dict_serializable import DictSerializable
+from taurus.entity.link_by_uid import LinkByUID
+from taurus.entity.file_link import FileLink
 from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 from taurus.entity.template.process_template import ProcessTemplate as TaurusProcessTemplate
 
@@ -81,6 +84,64 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
 
     def __str__(self):
         return '<Process spec {!r}>'.format(self.name)
+
+    @classmethod
+    def _build_soft_linked_objects(cls, obj, obj_with_soft_links, session: Session = None):
+        """
+        Build the IngredientSpec objects that this ProcessSpec has soft links to.
+
+        The ingredient specs are found in `obj_with_soft_link`
+
+        This method modifies the object in place.
+
+        Parameters
+        ----------
+        obj: ProcessSpec
+            A ProcessSpec object that might be missing some links to IngredientSpec objects.
+        obj_with_soft_links: dict or \
+        :py:class:`DictSerializable <taurus.entity.dict_serializable.DictSerializable>`
+            A representation of the ProcessSpec in which the IngredientSpecs are encoded.
+            We consider both the possibility that this is a dictionary with an 'ingredients' key
+            and that it is a
+            :py:class:`DictSerializable <taurus.entity.dict_serializable.DictSerializable>`
+            (presumably a
+            :py:class:`TaurusProcessSpec <taurus.entity.process_spec.ProcessSpec>`)
+            with a .ingredients field.
+        session: Session, optional
+            Citrine session used to connect to the database.
+
+        Returns
+        -------
+        None
+            The ProcessSpec object is modified so that it has links to its IngredientSpecs.
+
+        """
+        ingredients = None
+        # Get the ingredients list, if it exists.
+        if isinstance(obj_with_soft_links, dict):
+            if obj_with_soft_links.get('ingredients'):
+                ingredients = obj_with_soft_links['ingredients']
+        if isinstance(obj_with_soft_links, DictSerializable):
+            if hasattr(obj_with_soft_links, 'ingredients'):
+                ingredients = getattr(obj_with_soft_links, 'ingredients')
+        if ingredients is None:
+            return
+
+        from citrine.resources.ingredient_spec import IngredientSpec
+        for ingredient in ingredients:
+            # Cycle through ingredients and if they are not LinkByUID, build them and then
+            # set their `process` field to obj
+            if isinstance(ingredient, DictSerializable):
+                if isinstance(ingredient, LinkByUID):
+                    pass
+                setattr(ingredient, 'process', None)
+            elif isinstance(ingredient, dict):
+                if ingredient.get('type') == LinkByUID.typ:
+                    pass
+                ingredient['process'] = None
+            ingredient_object = IngredientSpec.build(ingredient, session)
+            setattr(ingredient_object, 'process', obj)
+        return
 
 
 class ProcessSpecCollection(DataConceptsCollection[ProcessSpec]):

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -37,8 +37,6 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
         Conditions under which this process spec occurs.
     parameters: List[Parameter], optional
         Parameters of this process spec.
-    ingredients: List[IngredientSpec], optional
-        Ingredient specs that act as inputs to this process spec.
     template: ProcessTemplate, optional
         A template bounding the valid values for this process's parameters and conditions.
     file_links: List[FileLink], optional
@@ -50,6 +48,10 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
         The material spec that this process spec produces. The link is established by creating
         the material spec and settings its `process` field to this process spec.
 
+    ingredients: List[IngredientSpec], optional
+        Ingredient specs that act as inputs to this process spec. The link is established by
+        creating each ingredient spec and setting its `process` field to this process spec.
+
     """
 
     _response_key = TaurusProcessSpec.typ  # 'process_spec"
@@ -60,8 +62,6 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
     notes = PropertyOptional(String(), 'notes')
     conditions = PropertyOptional(PropertyList(Object(Condition)), 'conditions')
     parameters = PropertyOptional(PropertyList(Object(Parameter)), 'parameters')
-    ingredients = PropertyOptional(
-        PropertyList(LinkOrElse()), 'ingredients')
     template = PropertyOptional(LinkOrElse(), 'template')
     file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
     typ = String('type')
@@ -73,14 +73,12 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
                  notes: Optional[str] = None,
                  conditions: Optional[List[Condition]] = None,
                  parameters: Optional[List[Parameter]] = None,
-                 ingredients: Optional[List[IngredientSpec]] = None,
                  template: Optional[TaurusProcessTemplate] = None,
                  file_links: Optional[List[FileLink]] = None):
         DataConcepts.__init__(self, TaurusProcessSpec.typ)
         TaurusProcessSpec.__init__(self, name=name, uids=set_default_uid(uids),
                                    tags=tags, conditions=conditions, parameters=parameters,
-                                   ingredients=ingredients, template=template,
-                                   file_links=file_links, notes=notes)
+                                   template=template, file_links=file_links, notes=notes)
 
     def __str__(self):
         return '<Process spec {!r}>'.format(self.name)

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -7,7 +7,6 @@ from citrine._serialization.properties import String, Mapping, Object, LinkOrEls
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
-from citrine.resources.ingredient_spec import IngredientSpec
 from taurus.entity.file_link import FileLink
 from citrine.attributes.condition import Condition
 from citrine.attributes.parameter import Parameter

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -131,14 +131,10 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
         for ingredient in ingredients:
             # Cycle through ingredients and if they are not LinkByUID, build them and then
             # set their `process` field to obj
-            if isinstance(ingredient, DictSerializable):
-                if isinstance(ingredient, LinkByUID):
-                    pass
-                setattr(ingredient, 'process', None)
-            elif isinstance(ingredient, dict):
-                if ingredient.get('type') == LinkByUID.typ:
-                    pass
-                ingredient['process'] = None
+            assert isinstance(ingredient, DictSerializable)
+            if isinstance(ingredient, LinkByUID):
+                pass
+            setattr(ingredient, 'process', None)
             ingredient_object = IngredientSpec.build(ingredient, session)
             setattr(ingredient_object, 'process', obj)
         return

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -86,7 +86,7 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
         return '<Process spec {!r}>'.format(self.name)
 
     @classmethod
-    def _build_soft_linked_objects(cls, obj, obj_with_soft_links, session: Session = None):
+    def _build_discarded_objects(cls, obj, obj_with_soft_links, session: Session = None):
         """
         Build the IngredientSpec objects that this ProcessSpec has soft links to.
 
@@ -116,28 +116,10 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
             The ProcessSpec object is modified so that it has links to its IngredientSpecs.
 
         """
-        ingredients = None
-        # Get the ingredients list, if it exists.
-        if isinstance(obj_with_soft_links, dict):
-            if obj_with_soft_links.get('ingredients'):
-                ingredients = obj_with_soft_links['ingredients']
-        if isinstance(obj_with_soft_links, DictSerializable):
-            if hasattr(obj_with_soft_links, 'ingredients'):
-                ingredients = getattr(obj_with_soft_links, 'ingredients')
-        if ingredients is None:
-            return
-
         from citrine.resources.ingredient_spec import IngredientSpec
-        for ingredient in ingredients:
-            # Cycle through ingredients and if they are not LinkByUID, build them and then
-            # set their `process` field to obj
-            assert isinstance(ingredient, DictSerializable)
-            if isinstance(ingredient, LinkByUID):
-                pass
-            setattr(ingredient, 'process', None)
-            ingredient_object = IngredientSpec.build(ingredient, session)
-            setattr(ingredient_object, 'process', obj)
-        return
+        DataConcepts._build_list_of_soft_links(
+            obj, obj_with_soft_links, field='ingredients', reverse_field='process',
+            linked_type=IngredientSpec, session=session)
 
 
 class ProcessSpecCollection(DataConceptsCollection[ProcessSpec]):

--- a/tests/resources/test_object_setters.py
+++ b/tests/resources/test_object_setters.py
@@ -34,8 +34,8 @@ def test_soft_process_ingredient_attachment():
     vinegar = MaterialSpec("vinegar")
     baking_soda = MaterialSpec("baking soda")
     eruption = ProcessSpec("Volcano eruption")
-    vinegar_sample = IngredientSpec(material=vinegar, process=eruption)
-    baking_soda_sample = IngredientSpec(material=baking_soda)
+    vinegar_sample = IngredientSpec("a bit of vinegar", material=vinegar, process=eruption)
+    baking_soda_sample = IngredientSpec("a bit of NaOh", material=baking_soda)
     baking_soda_sample.process = eruption
     assert set(eruption.ingredients) == {vinegar_sample, baking_soda_sample}, \
         "Creating an ingredient for a process did not auto-populate that process's ingredient list"

--- a/tests/resources/test_object_setters.py
+++ b/tests/resources/test_object_setters.py
@@ -5,9 +5,12 @@ import pytest
 from taurus.entity.value.discrete_categorical import DiscreteCategorical
 from citrine.attributes.property import Property
 from citrine.resources.process_run import ProcessRun
+from citrine.resources.process_spec import ProcessSpec
 from citrine.resources.material_run import MaterialRun
+from citrine.resources.material_spec import MaterialSpec
 from citrine.resources.measurement_run import MeasurementRun
 from citrine.resources.ingredient_run import IngredientRun
+from citrine.resources.ingredient_spec import IngredientSpec
 
 
 def test_soft_process_material_attachment():
@@ -18,12 +21,24 @@ def test_soft_process_material_attachment():
 
 
 def test_soft_measurement_material_attachment():
-    """Test that soft attachments are formed from measurements to materials."""
+    """Test that soft attachments are formed from materials to measurements."""
     cake = MaterialRun("A cake")
     smell_test = MeasurementRun("use your nose", material=cake, properties=[
         Property(name="Smell",  value=DiscreteCategorical("yummy"))])
     taste_test = MeasurementRun("taste", material=cake)
     assert cake.measurements == [smell_test, taste_test]
+
+
+def test_soft_process_ingredient_attachment():
+    """Test that soft attachments are formed from process to ingredients"""
+    vinegar = MaterialSpec("vinegar")
+    baking_soda = MaterialSpec("baking soda")
+    eruption = ProcessSpec("Volcano eruption")
+    vinegar_sample = IngredientSpec(material=vinegar, process=eruption)
+    baking_soda_sample = IngredientSpec(material=baking_soda)
+    baking_soda_sample.process = eruption
+    assert set(eruption.ingredients) == {vinegar_sample, baking_soda_sample}, \
+        "Creating an ingredient for a process did not auto-populate that process's ingredient list"
 
 
 def test_object_pointer_serde():

--- a/tests/serialization/test_ingredient_run.py
+++ b/tests/serialization/test_ingredient_run.py
@@ -18,6 +18,7 @@ def valid_data():
         material={'type': 'material_run', 'name': 'flour', 'uids': {'id': str(uuid4())},
                   'tags': [], 'file_links': [], 'notes': None,
                   'process': None, 'sample_type': 'unknown', 'spec': None},
+        process=None,
         mass_fraction={'type': 'normal_real', 'mean': 0.5, 'std': 0.1, 'units': 'dimensionless'},
         volume_fraction=None,
         number_fraction=None,
@@ -37,6 +38,7 @@ def test_simple_deserialization(valid_data):
     assert ingredient_run.tags == []
     assert ingredient_run.notes is None
     assert ingredient_run.material.dump() == valid_data['material']
+    assert ingredient_run.process is None
     assert ingredient_run.mass_fraction == NormalReal(0.5, 0.1, '')
     assert ingredient_run.volume_fraction is None
     assert ingredient_run.number_fraction is None

--- a/tests/serialization/test_material_run.py
+++ b/tests/serialization/test_material_run.py
@@ -3,14 +3,17 @@ import pytest
 from uuid import uuid4
 
 from citrine.resources.material_run import MaterialRun
+from citrine.resources.material_spec import MaterialSpec
 from citrine.resources.measurement_spec import MeasurementSpec
 from citrine.resources.process_run import ProcessRun
 from citrine.resources.ingredient_run import IngredientRun
+from citrine.resources.ingredient_spec import IngredientSpec
 from citrine.resources.measurement_run import MeasurementRun
 from taurus.client.json_encoder import LinkByUID
 from taurus.client.json_encoder import loads, dumps
 from taurus.entity.object import MeasurementRun as TaurusMeasurementRun
 from taurus.entity.object import MaterialRun as TaurusMaterialRun
+from taurus.entity.object import MaterialSpec as TaurusMaterialSpec
 from taurus.entity.object import MeasurementSpec as TaurusMeasurementSpec
 from taurus.entity.object import ProcessSpec as TaurusProcessSpec
 from taurus.entity.object import ProcessRun as TaurusProcessRun
@@ -97,40 +100,50 @@ def test_nested_serialization():
 
 def test_measurement_material_connection_rehydration():
     """Test that fully-linked Taurus object can be built as fully-linked Citrine-python object."""
-    starting_mat = TaurusMaterialRun("starting material")
+    starting_mat_spec = TaurusMaterialSpec("starting material")
+    starting_mat = TaurusMaterialRun("starting material", spec=starting_mat_spec)
     meas_spec = TaurusMeasurementSpec("measurement spec")
     meas1 = TaurusMeasurementRun("measurement on starting material",
                                  spec=meas_spec, material=starting_mat)
 
-    process = TaurusProcessRun("Transformative process")
-    ingredient = TaurusIngredientRun(material=starting_mat, process=process)
+    process_spec = TaurusProcessSpec("Transformative process")
+    process = TaurusProcessRun("Transformative process", spec=process_spec)
+    ingredient_spec = TaurusIngredientSpec(material=starting_mat_spec, process=process_spec)
+    ingredient = TaurusIngredientRun(material=starting_mat, process=process, spec=ingredient_spec)
 
-    ending_mat = TaurusMaterialRun("ending material", process=process)
+    ending_mat_spec = TaurusMaterialSpec("ending material", process=process_spec)
+    ending_mat = TaurusMaterialRun("ending material", process=process, spec=ending_mat_spec)
     meas2 = TaurusMeasurementRun("measurement on ending material",
                                  spec=meas_spec, material=ending_mat)
 
     copy = MaterialRun.build(ending_mat)
-    assert isinstance(copy, MaterialRun), "copy of starting_mat should be a MaterialRun"
-    assert len(copy.measurements) == 1, "copy of starting_mat should have one measurement"
+    assert isinstance(copy, MaterialRun), "copy of ending_mat should be a MaterialRun"
+    assert len(copy.measurements) == 1, "copy of ending_mat should have one measurement"
     assert isinstance(copy.measurements[0], MeasurementRun), \
-        "copy of starting_mat should have a measurement that is a MeasurementRun"
+        "copy of ending_mat should have a measurement that is a MeasurementRun"
     assert isinstance(copy.measurements[0].spec, MeasurementSpec), \
-        "copy of starting_mat should have a measurement that has a spec that is a MeasurementSpec"
-    assert isinstance(copy.process, ProcessRun), "copy of starting_mat should have a process"
+        "copy of ending_mat should have a measurement that has a spec that is a MeasurementSpec"
+    assert isinstance(copy.process, ProcessRun), "copy of ending_mat should have a process"
     assert len(copy.process.ingredients) == 1, \
-        "copy of starting_mat should have a process with one ingredient"
+        "copy of ending_mat should have a process with one ingredient"
+    assert isinstance(copy.spec, MaterialSpec), "copy of ending_mat should have a spec"
+    assert len(copy.spec.process.ingredients) == 1, \
+        "copy of ending_mat should have a spec with a process that has one ingredient"
+    assert isinstance(copy.process.spec.ingredients[0], IngredientSpec), \
+        "copy of ending_mat should have a spec with a process that has an ingredient " \
+        "that is an IngredientRun"
 
     copy_ingredient = copy.process.ingredients[0]
     assert isinstance(copy_ingredient, IngredientRun), \
-        "copy of starting_mat should have a process with an ingredient that is an IngredientRun"
+        "copy of ending_mat should have a process with an ingredient that is an IngredientRun"
     assert isinstance(copy_ingredient.material, MaterialRun), \
-        "copy of starting_mat should have a process with an ingredient that links to a MaterialRun"
+        "copy of ending_mat should have a process with an ingredient that links to a MaterialRun"
     assert len(copy_ingredient.material.measurements) == 1, \
-        "copy of starting_mat should have a process with an ingredient derived from a material " \
+        "copy of ending_mat should have a process with an ingredient derived from a material " \
         "that has one measurement performed on it"
     assert isinstance(copy_ingredient.material.measurements[0], MeasurementRun), \
-        "copy of starting_mat should have a process with an ingredient derived from a material " \
+        "copy of ending_mat should have a process with an ingredient derived from a material " \
         "that has one measurement that gets deserialized as a MeasurementRun"
     assert isinstance(copy_ingredient.material.measurements[0].spec, MeasurementSpec), \
-        "copy of starting_mat should have a process with an ingredient derived from a material " \
+        "copy of ending_mat should have a process with an ingredient derived from a material " \
         "that has one measurement that has a spec"

--- a/tests/serialization/test_material_run.py
+++ b/tests/serialization/test_material_run.py
@@ -113,8 +113,10 @@ def test_measurement_material_connection_rehydration():
 
     process_spec = TaurusProcessSpec("Transformative process")
     process = TaurusProcessRun("Transformative process", spec=process_spec)
-    ingredient_spec = TaurusIngredientSpec(material=starting_mat_spec, process=process_spec)
-    ingredient = TaurusIngredientRun(material=starting_mat, process=process, spec=ingredient_spec)
+    ingredient_spec = TaurusIngredientSpec(name="ingredient", material=starting_mat_spec,
+                                           process=process_spec)
+    ingredient = TaurusIngredientRun(name="ingredient", material=starting_mat, process=process,
+                                     spec=ingredient_spec)
 
     ending_mat_spec = TaurusMaterialSpec("ending material", process=process_spec)
     ending_mat = TaurusMaterialRun("ending material", process=process, spec=ending_mat_spec)

--- a/tests/serialization/test_process_run.py
+++ b/tests/serialization/test_process_run.py
@@ -22,7 +22,6 @@ def valid_data():
                      'value': {'nominal': 203.0, 'units': 'dimensionless', 'type': 'nominal_real'}
                      }],
         parameters=[],
-        ingredients=[],
         spec={'type': 'process_spec', 'name': 'Spec for proc 1',
               'uids': {'id': str(uuid4())}, 'file_links': [], 'notes': None,
               'conditions': [{'type': 'condition', 'name': 'oven temp', 'origin': 'specified',
@@ -31,7 +30,7 @@ def valid_data():
                                         'lower_bound': 175, 'upper_bound': 225
                                         }
                               }],
-              'template': None, 'tags': [], 'parameters': [], 'ingredients': []
+              'template': None, 'tags': [], 'parameters': []
               },
         file_links=[],
         type='process_run'
@@ -47,7 +46,6 @@ def test_simple_deserialization(valid_data):
                                                          value=NominalReal(203.0, ''),
                                                          origin='measured')
     assert process_run.parameters == []
-    assert process_run.ingredients == []
     assert process_run.file_links == []
     assert process_run.template is None
     assert process_run.output_material is None

--- a/tests/serialization/test_process_spec.py
+++ b/tests/serialization/test_process_spec.py
@@ -25,7 +25,6 @@ def valid_data():
                                'units': 'dimensionless', 'type': 'uniform_real'}
                      }],
         conditions=[],
-        ingredients=[],
         template={
             'name': 'the template',
             'uids': {'id': str(uuid4())},
@@ -65,7 +64,6 @@ def test_simple_deserialization(valid_data):
                                                           value=UniformReal(195, 205, ''),
                                                           origin='specified')
     assert process_spec.conditions == []
-    assert process_spec.ingredients == []
     assert process_spec.template == \
            ProcessTemplate('the template', uids={'id': valid_data['template']['uids']['id']},
                            parameters=[


### PR DESCRIPTION
Flips the order of the ingredient<-->process connection so that it is set in the ingredient.

Extends the pattern established in #21 to create soft-links between a process run/spec and the ingredient runs/specs that go into them.
~Essentially the same method is now written in three places, so it can be deduped in this or a subsequent PR.~

Do not merge until the corresponding change is merged in Taurus (https://github.com/CitrineInformatics/taurus/pull/10).