### PR TITLE
Add pagination support to all the collections

### DIFF
--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -50,11 +50,19 @@ class Collection(Generic[ResourceType]):
         data = data[self._individual_key] if self._individual_key else data
         return self.build(data)
 
-    def list(self) -> Iterable[ResourceType]:
+    def list(self,
+             page: Optional[int] = None,
+             per_page: Optional[int] = None) -> Iterable[ResourceType]:
         """List all visible elements in the collection."""
-        # TODO: Handle paging
         path = self._get_path()
-        data = self.session.get_resource(path)
+
+        params = {}
+        if page is not None:
+            params["page"] = page
+        if per_page is not None:
+            params["per_page"] = per_page
+
+        data = self.session.get_resource(path, params=params)
         # A 'None' collection key implies response has a top-level array
         # of 'ResourceType'
         # TODO: Unify backend return values

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -550,16 +550,17 @@ class DataConceptsCollection(Collection[ResourceType]):
             template_id = get_object_id(key)
             attribute_bounds_dict[template_id] = value.as_dict()
         body = {'attribute_bounds': attribute_bounds_dict}
+        params = {}
         if self.dataset_id is not None:
-            body['dataset_id'] = str(self.dataset_id)
+            params['dataset_id'] = str(self.dataset_id)
         if page is not None:
-            body['page'] = page
+            params['page'] = page
         if per_page is not None:
-            body['per_page'] = per_page
+            params['per_page'] = per_page
 
         response = self.session.post_resource(
             self._get_path(ignore_dataset=True) + "/filter-by-attribute-bounds",
-            json=body)
+            json=body, params=params)
         return [self.build(content) for content in response["contents"]]
 
     def filter_by_name(self, name: str, exact: bool = False,

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -548,18 +548,16 @@ class DataConceptsCollection(Collection[ResourceType]):
             template_id = get_object_id(key)
             attribute_bounds_dict[template_id] = value.as_dict()
         body = {'attribute_bounds': attribute_bounds_dict}
-        params = {}
         if self.dataset_id is not None:
-            params['dataset_id'] = str(self.dataset_id)
+            body['dataset_id'] = str(self.dataset_id)
         if page is not None:
-            params['page'] = page
+            body['page'] = page
         if per_page is not None:
-            params['per_page'] = per_page
+            body['per_page'] = per_page
 
         response = self.session.post_resource(
             self._get_path(ignore_dataset=True) + "/filter-by-attribute-bounds",
-            json=body,
-            params=params)
+            json=body)
         return [self.build(content) for content in response["contents"]]
 
     def filter_by_name(self, name: str, exact: bool = False,

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -141,13 +141,15 @@ def test_filter_by_attribute_bounds(collection, session):
     expected_call = FakeCall(
         method='POST',
         path='projects/{}/material-runs/filter-by-attribute-bounds'.format(collection.project_id),
-        json={
-            'attribute_bounds': {
-                link.id: {'lower_bound': 1, 'upper_bound': 5, 'type': 'integer_bounds'}
-            },
+        params={
             "page": 1,
             "per_page": 10,
             "dataset_id": str(collection.dataset_id)
+        },
+        json={
+            'attribute_bounds': {
+                link.id: {'lower_bound': 1, 'upper_bound': 5, 'type': 'integer_bounds'}
+            }
         }
     )
     assert expected_call == session.last_call

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -81,7 +81,7 @@ def test_list_material_runs(collection, session):
     })
 
     # When
-    runs = collection.list()
+    runs = collection.list(page=1, per_page=10)
 
     # Then
     assert 1 == session.num_calls
@@ -90,7 +90,9 @@ def test_list_material_runs(collection, session):
         path='projects/{}/material-runs'.format(collection.project_id),
         params={
             'dataset_id': str(collection.dataset_id),
-            'tags': []
+            'tags': [],
+            'page': 1,
+            'per_page': 10
         }
     )
     assert expected_call == session.last_call
@@ -104,7 +106,7 @@ def test_filter_by_name(collection, session):
     session.set_response({'contents': [sample_run]})
 
     # When
-    runs = collection.filter_by_name('test run')
+    runs = collection.filter_by_name('test run', page=1, per_page=10)
 
     # Then
     assert 1 == session.num_calls
@@ -114,7 +116,9 @@ def test_filter_by_name(collection, session):
         params={
             'dataset_id': str(collection.dataset_id),
             'name': 'test run',
-            'exact': False
+            'exact': False,
+            "page": 1,
+            "per_page": 10
         }
     )
     assert expected_call == session.last_call
@@ -130,14 +134,21 @@ def test_filter_by_attribute_bounds(collection, session):
     bounds = {link: IntegerBounds(1, 5)}
 
     # When
-    runs = collection.filter_by_attribute_bounds(bounds)
+    runs = collection.filter_by_attribute_bounds(bounds, page=1, per_page=10)
 
     # Then
     assert 1 == session.num_calls
     expected_call = FakeCall(
         method='POST',
         path='projects/{}/material-runs/filter-by-attribute-bounds'.format(collection.project_id),
-        json={'attribute_bounds': {link.id: {'lower_bound': 1, 'upper_bound': 5, 'type': 'integer_bounds'}}}
+        json={
+            'attribute_bounds': {
+                link.id: {'lower_bound': 1, 'upper_bound': 5, 'type': 'integer_bounds'}
+            },
+            "page": 1,
+            "per_page": 10,
+            "dataset_id": str(collection.dataset_id)
+        }
     )
     assert expected_call == session.last_call
     assert 1 == len(runs)

--- a/tests/utils/session.py
+++ b/tests/utils/session.py
@@ -50,7 +50,7 @@ class FakeSession:
         return self.response
 
     def post_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
-        self.calls.append(FakeCall('POST', path, json))
+        self.calls.append(FakeCall('POST', path, json, params=kwargs.get('params')))
         return self.response
 
     def put_resource(self, path: str, json: dict, *args, **kwargs) -> dict:


### PR DESCRIPTION
The pattern here is `page` (1-indexing) and `per_page`.  If you iterate through pages, there is no guarantee that you hit everything, because elements of the list could have been added or deleted in the middle of that iteration.

I tested this if `page` and `per_page` are both given, but @dannycodes is going to fix an issue when only one of them is given.