### PR TITLE
Feature/mock test coverage

### DIFF
--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -34,7 +34,6 @@ class Collection(Generic[ResourceType]):
     @abstractmethod
     def build(self, data: dict):
         """Build an individual element of the collection."""
-        pass
 
     def get(self, uid: Union[UUID, str]) -> ResourceType:
         """Get a particular element of the collection."""

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -288,7 +288,6 @@ class DataConceptsCollection(Collection[ResourceType]):
     @abstractmethod
     def get_type(cls) -> Type[Serializable]:
         """Return the resource type in the collection."""
-        pass
 
     def build(self, data: dict) -> ResourceType:
         """

--- a/tests/resources/test_data_concepts.py
+++ b/tests/resources/test_data_concepts.py
@@ -1,0 +1,32 @@
+import pytest
+import unittest
+import mock
+import requests
+from uuid import uuid4
+
+from citrine._session import Session
+from citrine.resources.measurement_spec import MeasurementSpec, MeasurementSpecCollection
+
+
+class SessionTests(unittest.TestCase):
+    def test_register(self):
+        session = mock.Mock()
+        spec_uid = str(uuid4())
+        session.post_resource.return_value = {
+            'uids': {'id': spec_uid},
+            'name': 'spec name',
+            'tags': [],
+            'notes': None,
+            'conditions': [],
+            'parameters': [],
+            'template': None,
+            'file_links': [],
+            'type': 'measurement_spec'
+        }
+        measurement_spec = MeasurementSpec("spec name", uids={'id': spec_uid})
+        measurement_spec_collection = MeasurementSpecCollection(uuid4(), None, session)
+        with pytest.raises(RuntimeError):
+            # Cannot register if no dataset is provided
+            measurement_spec_collection.register(measurement_spec)
+        registered_measurement_spec = MeasurementSpec("spec name", uids={'id': spec_uid})
+        assert registered_measurement_spec == measurement_spec

--- a/tests/resources/test_data_concepts.py
+++ b/tests/resources/test_data_concepts.py
@@ -1,15 +1,25 @@
 import pytest
 import unittest
 import mock
-import requests
 from uuid import uuid4
 
-from citrine._session import Session
 from citrine.resources.measurement_spec import MeasurementSpec, MeasurementSpecCollection
 from citrine.resources.condition_template import ConditionTemplate
 from taurus.entity.link_by_uid import LinkByUID
 from taurus.entity.bounds.real_bounds import RealBounds
 
+spec_uid = str(uuid4())
+measurement_spec_dict = {
+    'uids': {'id': spec_uid},
+    'name': 'spec name',
+    'tags': [],
+    'notes': None,
+    'conditions': [],
+    'parameters': [],
+    'template': None,
+    'file_links': [],
+    'type': 'measurement_spec'
+}
 
 class SessionTests(unittest.TestCase):
     def test_register(self):
@@ -21,18 +31,8 @@ class SessionTests(unittest.TestCase):
         """
         session = mock.Mock()
         spec_uid = str(uuid4())
-        session.post_resource.return_value = {
-            'uids': {'id': spec_uid},
-            'name': 'spec name',
-            'tags': [],
-            'notes': None,
-            'conditions': [],
-            'parameters': [],
-            'template': None,
-            'file_links': [],
-            'type': 'measurement_spec'
-        }
-        measurement_spec = MeasurementSpec("spec name", uids={'id': spec_uid})
+        session.post_resource.return_value = measurement_spec_dict
+        measurement_spec = MeasurementSpec("spec name", uids={'id': measurement_spec_dict['uids']['id']})
         measurement_spec_collection = MeasurementSpecCollection(uuid4(), None, session)
         with pytest.raises(RuntimeError):
             # Cannot register if no dataset is provided
@@ -50,23 +50,11 @@ class SessionTests(unittest.TestCase):
         dictionaries can be built into the expected objects.
         """
         session = mock.Mock()
-        spec_uid = str(uuid4())
-        measurement_spec_dict = {
-            'uids': {'id': spec_uid},
-            'name': 'spec name',
-            'tags': [],
-            'notes': None,
-            'conditions': [],
-            'parameters': [],
-            'template': None,
-            'file_links': [],
-            'type': 'measurement_spec'
-        }
         # mock session so that it returns a list containing the above dict after calling
         # either get_resource or post_resource.
         session.get_resource.return_value = {'contents': [measurement_spec_dict]}
         session.post_resource.return_value = {'contents': [measurement_spec_dict]}
-        measurement_spec = MeasurementSpec("spec name", uids={'id': spec_uid})
+        measurement_spec = MeasurementSpec("spec name", uids={'id': measurement_spec_dict['uids']['id']})
         measurement_spec_collection = MeasurementSpecCollection(uuid4(), uuid4(), session)
 
         # List

--- a/tests/resources/test_data_concepts.py
+++ b/tests/resources/test_data_concepts.py
@@ -6,10 +6,19 @@ from uuid import uuid4
 
 from citrine._session import Session
 from citrine.resources.measurement_spec import MeasurementSpec, MeasurementSpecCollection
+from citrine.resources.condition_template import ConditionTemplate
+from taurus.entity.link_by_uid import LinkByUID
+from taurus.entity.bounds.real_bounds import RealBounds
 
 
 class SessionTests(unittest.TestCase):
     def test_register(self):
+        """
+        Mock registering an object.
+
+        Assuming the registration returns the object in dictionary form, assert that it gets
+        built into a copy of the original object.
+        """
         session = mock.Mock()
         spec_uid = str(uuid4())
         session.post_resource.return_value = {
@@ -28,5 +37,62 @@ class SessionTests(unittest.TestCase):
         with pytest.raises(RuntimeError):
             # Cannot register if no dataset is provided
             measurement_spec_collection.register(measurement_spec)
-        registered_measurement_spec = MeasurementSpec("spec name", uids={'id': spec_uid})
+
+        measurement_spec_collection = MeasurementSpecCollection(uuid4(), uuid4(), session)
+        registered_measurement_spec = measurement_spec_collection.register(measurement_spec)
         assert registered_measurement_spec == measurement_spec
+
+    def test_filter(self):
+        """
+        Mock the various list/filter methods.
+
+        Assuming they all return object dictionaries in the expected form, assert that those
+        dictionaries can be built into the expected objects.
+        """
+        session = mock.Mock()
+        spec_uid = str(uuid4())
+        measurement_spec_dict = {
+            'uids': {'id': spec_uid},
+            'name': 'spec name',
+            'tags': [],
+            'notes': None,
+            'conditions': [],
+            'parameters': [],
+            'template': None,
+            'file_links': [],
+            'type': 'measurement_spec'
+        }
+        # mock session so that it returns a list containing the above dict after calling
+        # either get_resource or post_resource.
+        session.get_resource.return_value = {'contents': [measurement_spec_dict]}
+        session.post_resource.return_value = {'contents': [measurement_spec_dict]}
+        measurement_spec = MeasurementSpec("spec name", uids={'id': spec_uid})
+        measurement_spec_collection = MeasurementSpecCollection(uuid4(), uuid4(), session)
+
+        # List
+        list_response = measurement_spec_collection.list()
+        assert next(iter(list_response)) == measurement_spec
+
+        # Filter by tags
+        filter_by_tags_response = measurement_spec_collection.filter_by_tags(['tag 1', 'tag 2'])
+        assert next(iter(filter_by_tags_response)) == measurement_spec
+
+        # Filter by name
+        filter_by_name_response = measurement_spec_collection.filter_by_name('some name', True)
+        assert next(iter(filter_by_name_response)) == measurement_spec
+
+        # Filter by attribute, using either an attribute template or a LinkByUID
+        cond_template = ConditionTemplate("a template", bounds=RealBounds(0, 1000, ''))
+        cond_template_link = LinkByUID(scope='id', id=uuid4())
+        bounds = RealBounds(0, 100, '')
+        filter_by_attribute_bounds_response = \
+            measurement_spec_collection.filter_by_attribute_bounds({cond_template: bounds})
+        assert next(iter(filter_by_attribute_bounds_response)) == measurement_spec
+        filter_by_attribute_bounds_response = \
+            measurement_spec_collection.filter_by_attribute_bounds({cond_template_link: bounds})
+        assert next(iter(filter_by_attribute_bounds_response)) == measurement_spec
+
+        # Trying to filter by name without a dataset id throws an error
+        measurement_spec_collection = MeasurementSpecCollection(uuid4(), None, session)
+        with pytest.raises(RuntimeError):
+            measurement_spec_collection.filter_by_name("some name", True)

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -53,3 +53,24 @@ class SessionTests(unittest.TestCase):
         session.get_resource.return_value = {'projects': [project_dict]}
         projects_iterator = project_collection.list()
         assert next(projects_iterator).dump() == project_dict
+
+    def test_project_has_collections(self):
+        """Check that a project has all expected collections."""
+        session = mock.Mock()
+        project = Project.build(project_dict)
+        project.session = session
+        assert project.datasets.project_id == project.uid
+        assert project.property_templates.project_id == project.uid
+        assert project.condition_templates.project_id == project.uid
+        assert project.parameter_templates.project_id == project.uid
+        assert project.material_templates.project_id == project.uid
+        assert project.process_templates.project_id == project.uid
+        assert project.measurement_templates.project_id == project.uid
+        assert project.process_runs.project_id == project.uid
+        assert project.process_specs.project_id == project.uid
+        assert project.material_runs.project_id == project.uid
+        assert project.material_specs.project_id == project.uid
+        assert project.measurement_runs.project_id == project.uid
+        assert project.measurement_specs.project_id == project.uid
+        assert project.ingredient_runs.project_id == project.uid
+        assert project.ingredient_specs.project_id == project.uid

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -1,0 +1,55 @@
+import pytest
+import unittest
+import mock
+import requests
+from uuid import uuid4
+
+from citrine._session import Session
+from citrine.resources.project import Project, ProjectCollection
+
+project_dict = {
+    'id': str(uuid4()),
+    'created_at': 1559933807392,
+    'name': 'my project',
+    'description': 'a good project',
+    'status': 'in-progress'
+}
+
+class SessionTests(unittest.TestCase):
+    def test_build_project(self):
+        """
+        Build a project from a dictionary using both the Resource and Collection methods.
+
+        The results should be identical.
+        """
+        session = mock.Mock()
+        project = Project.build(project_dict)
+        project.session = session
+
+        project_collection = ProjectCollection(session)
+        built_project = project_collection.build(project_dict)
+        assert built_project.dump() == project.dump()
+
+    def test_register(self):
+        """
+        Register a project a project collection.
+
+        Check that the resulting dictionary is a copy of the original project.
+        """
+        session = mock.Mock()
+        project_collection = ProjectCollection(session)
+        session.post_resource.return_value = {'project': project_dict}
+        built_project = project_collection.register('my project', 'a good project')
+        assert built_project.dump() == project_dict
+
+    def test_list(self):
+        """
+        List the projects in a collection
+
+        Check that the resulting dictionary is a copy of the original project.
+        """
+        session = mock.Mock()
+        project_collection = ProjectCollection(session)
+        session.get_resource.return_value = {'projects': [project_dict]}
+        projects_iterator = project_collection.list()
+        assert next(projects_iterator).dump() == project_dict

--- a/tests/serialization/test_material_run.py
+++ b/tests/serialization/test_material_run.py
@@ -93,8 +93,6 @@ def test_nested_serialization():
     batter.process.ingredients.append(make_ingredient(material=MaterialRun('Flour')))
     batter.process.ingredients.append(make_ingredient(material=MaterialRun('Milk')))
 
-    print(cake.dump())
-
 
 def test_measurement_material_connection_rehydration():
     """Test that fully-linked Taurus object can be built as fully-linked Citrine-python object."""


### PR DESCRIPTION
Bring up the test coverage, mostly by using Mock to mock a Session object. This brings us up to 89% and establishes a pattern that can be used to get coverage on most of the remaining statements.