### PR TITLE
Update ingredient{spec, run} docstrings for name -> required

### DIFF
--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -44,7 +44,7 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
     absolute_quantity: :py:class:`ContinuousValue \
     <taurus.entity.value.continuous_value.ContinuousValue>`, optional
         The absolute quantity of the ingredient in the process.
-    name: str, optional
+    name: str
         Label on the ingredient that is unique within the process that contains it.
     labels: List[str], optional
         Additional labels on the ingredient that must be unique.

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -43,7 +43,7 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
     absolute_quantity: :py:class:`ContinuousValue \
     <taurus.entity.value.continuous_value.ContinuousValue>`, optional
         The absolute quantity of the ingredient in the process.
-    name: str, optional
+    name: str
         Label on the ingredient that is unique within the process that contains it.
     labels: List[str], optional
         Additional labels on the ingredient that must be unique.


### PR DESCRIPTION
We had updated the schema in https://github.com/CitrineInformatics/citrine-python/pull/26 but didn't update the docstring.  Note that the `name: Optional[str]` in the constructor signature is for the keyword argument pattern (all required members are marked as optional there, with default values of None).