### PR TITLE
Added an enumerated design space

### DIFF
--- a/tests/informatics/test_design_spaces.py
+++ b/tests/informatics/test_design_spaces.py
@@ -1,13 +1,13 @@
 """Tests for citrine.informatics.design_spaces."""
 import pytest
 
-from citrine.informatics.design_spaces import ProductDesignSpace
 from citrine.informatics.descriptors import RealDescriptor, CategoricalDescriptor
+from citrine.informatics.design_spaces import ProductDesignSpace, EnumeratedDesignSpace
 from citrine.informatics.dimensions import ContinuousDimension, EnumeratedDimension
 
 
 @pytest.fixture
-def design_space() -> ProductDesignSpace:
+def product_design_space() -> ProductDesignSpace:
     """Build a ProductDesignSpace for testing."""
     alpha = RealDescriptor('alpha', 0, 100)
     beta = RealDescriptor('beta', 0, 100)
@@ -20,11 +20,30 @@ def design_space() -> ProductDesignSpace:
     return ProductDesignSpace('my design space', 'does some things', dimensions)
 
 
-def test_initialization(design_space):
+@pytest.fixture
+def enumerated_design_space() -> EnumeratedDesignSpace:
+    """Build an EnumeratedDesignSpace for testing."""
+    x = RealDescriptor('x', lower_bound=0.0, upper_bound=1.0)
+    color = CategoricalDescriptor('color', ['r', 'g', 'b'])
+    data = [dict(x=0, color='r'), dict(x=1.0, color='b')]
+    return EnumeratedDesignSpace('enumerated', 'desc', descriptors=[x, color], data=data)
+
+
+def test_product_initialization(product_design_space):
     """Make sure the correct fields go to the correct places."""
-    assert design_space.name == 'my design space'
-    assert design_space.description == 'does some things'
-    assert len(design_space.dimensions) == 3
-    assert design_space.dimensions[0].descriptor.key == 'alpha'
-    assert design_space.dimensions[1].descriptor.key == 'beta'
-    assert design_space.dimensions[2].descriptor.key == 'gamma'
+    assert product_design_space.name == 'my design space'
+    assert product_design_space.description == 'does some things'
+    assert len(product_design_space.dimensions) == 3
+    assert product_design_space.dimensions[0].descriptor.key == 'alpha'
+    assert product_design_space.dimensions[1].descriptor.key == 'beta'
+    assert product_design_space.dimensions[2].descriptor.key == 'gamma'
+
+
+def test_enumerated_initialization(enumerated_design_space):
+    """Make sure the correct fields go to the correct places."""
+    assert enumerated_design_space.name == 'enumerated'
+    assert enumerated_design_space.description == 'desc'
+    assert len(enumerated_design_space.descriptors) == 2
+    assert enumerated_design_space.descriptors[0].key == 'x'
+    assert enumerated_design_space.descriptors[1].key == 'color'
+    assert enumerated_design_space.data == [{'x': 0.0, 'color': 'r'}, {'x': 1.0, 'color': 'b'}]

--- a/tests/serialization/test_design_spaces.py
+++ b/tests/serialization/test_design_spaces.py
@@ -3,13 +3,14 @@ import uuid
 
 import pytest
 
-from citrine.informatics.design_spaces import DesignSpace, ProductDesignSpace
+from citrine.informatics.descriptors import CategoricalDescriptor, RealDescriptor
+from citrine.informatics.design_spaces import DesignSpace, ProductDesignSpace, EnumeratedDesignSpace
 from citrine.informatics.dimensions import ContinuousDimension, EnumeratedDimension
 
 
 @pytest.fixture
-def valid_data():
-    """Produce valid design space data."""
+def valid_product_data():
+    """Produce valid product design space data."""
     return dict(
         module_type='DESIGN_SPACE',
         status='VALIDATING',
@@ -51,13 +52,48 @@ def valid_data():
 
 
 @pytest.fixture
+def valid_enumerated_data():
+    """Produce valid enumerated design space data."""
+    return dict(
+        module_type='DESIGN_SPACE',
+        status='VALIDATING',
+        status_info=None,
+        display_name='my enumerated design space',
+        schema_id='f3907a58-aa46-462c-8837-a5aa9605e79e',
+        id=str(uuid.uuid4()),
+        config=dict(
+            type='EnumeratedDesignSpace',
+            name='my enumerated design space ',
+            description='enumerates some things',
+            descriptors=[
+                dict(
+                    type='Real',
+                    descriptor_key='x',
+                    units='',
+                    lower_bound=1.0,
+                    upper_bound=2.0,
+                ),
+                dict(
+                    type='Categorical',
+                    descriptor_key='color',
+                    descriptor_values=['red', 'green', 'blue'],
+                )
+            ],
+            data=[
+                dict(x=1, color='red'),
+                dict(x=2.0, color='green')
+            ]
+        )
+    )
+
+
 def valid_serialization_output(valid_data):
     return {x: y for x, y in valid_data.items() if x not in ['status', 'status_info']}
 
 
-def test_simple_deserialization(valid_data):
+def test_simple_product_deserialization(valid_product_data):
     """Ensure that a deserialized ProductDesignSpace looks sane."""
-    design_space: ProductDesignSpace = ProductDesignSpace.build(valid_data)
+    design_space: ProductDesignSpace = ProductDesignSpace.build(valid_product_data)
     assert design_space.name == 'my design space'
     assert design_space.description == 'does some things'
     assert type(design_space.dimensions[0]) == ContinuousDimension
@@ -66,9 +102,9 @@ def test_simple_deserialization(valid_data):
     assert design_space.dimensions[1].values == ['red']
 
 
-def test_polymorphic_deserialization(valid_data):
+def test_polymorphic_product_deserialization(valid_product_data):
     """Ensure that a polymorphically deserialized ProductDesignSpace looks sane."""
-    design_space: ProductDesignSpace = DesignSpace.build(valid_data)
+    design_space: ProductDesignSpace = DesignSpace.build(valid_product_data)
     assert design_space.name == 'my design space'
     assert design_space.description == 'does some things'
     assert type(design_space.dimensions[0]) == ContinuousDimension
@@ -77,9 +113,67 @@ def test_polymorphic_deserialization(valid_data):
     assert design_space.dimensions[1].values == ['red']
 
 
-def test_serialization(valid_data, valid_serialization_output):
+def test_product_serialization(valid_product_data):
     """Ensure that a serialized ProductDesignSpace looks sane."""
-    design_space = ProductDesignSpace.build(valid_data)
+    design_space = ProductDesignSpace.build(valid_product_data)
     serialized = design_space.dump()
-    serialized['id'] = valid_data['id']
-    assert serialized == valid_serialization_output
+    serialized['id'] = valid_product_data['id']
+    assert serialized == valid_serialization_output(valid_product_data)
+
+
+def test_simple_enumerated_deserialization(valid_enumerated_data):
+    """Ensure that a deserialized EnumeratedDesignSpace looks sane."""
+    design_space: EnumeratedDesignSpace = EnumeratedDesignSpace.build(valid_enumerated_data)
+    assert design_space.name == 'my enumerated design space'
+    assert design_space.description == 'enumerates some things'
+
+    assert len(design_space.descriptors) == 2
+
+    real, categorical = design_space.descriptors
+
+    assert type(real) == RealDescriptor
+    assert real.key == 'x'
+    assert real.units == ''
+    assert real.lower_bound == 1.0
+    assert real.upper_bound == 2.0
+
+    assert type(categorical) == CategoricalDescriptor
+    assert categorical.key == 'color'
+    assert categorical.categories == ['red', 'green', 'blue']
+
+    assert len(design_space.data) == 2
+    assert design_space.data[0] == {'x': 1.0, 'color': 'red'}
+    assert design_space.data[1] == {'x': 2.0, 'color': 'green'}
+
+
+def test_polymorphic_enumerated_deserialization(valid_enumerated_data):
+    """Ensure that a polymorphically deserialized EnumeratedDesignSpace looks sane."""
+    design_space: EnumeratedDesignSpace = DesignSpace.build(valid_enumerated_data)
+    assert design_space.name == 'my enumerated design space'
+    assert design_space.description == 'enumerates some things'
+
+    assert len(design_space.descriptors) == 2
+
+    real, categorical = design_space.descriptors
+
+    assert type(real) == RealDescriptor
+    assert real.key == 'x'
+    assert real.units == ''
+    assert real.lower_bound == 1.0
+    assert real.upper_bound == 2.0
+
+    assert type(categorical) == CategoricalDescriptor
+    assert categorical.key == 'color'
+    assert categorical.categories == ['red', 'green', 'blue']
+
+    assert len(design_space.data) == 2
+    assert design_space.data[0] == {'x': 1.0, 'color': 'red'}
+    assert design_space.data[1] == {'x': 2.0, 'color': 'green'}
+
+
+def test_enumerated_serialization(valid_enumerated_data):
+    """Ensure that a serialized EnumeratedDesignSpace looks sane."""
+    design_space = EnumeratedDesignSpace.build(valid_enumerated_data)
+    serialized = design_space.dump()
+    serialized['id'] = valid_enumerated_data['id']
+    assert serialized == valid_serialization_output(valid_enumerated_data)

--- a/tests/serialization/test_design_spaces.py
+++ b/tests/serialization/test_design_spaces.py
@@ -63,7 +63,7 @@ def valid_enumerated_data():
         id=str(uuid.uuid4()),
         config=dict(
             type='EnumeratedDesignSpace',
-            name='my enumerated design space ',
+            name='my enumerated design space',
             description='enumerates some things',
             descriptors=[
                 dict(


### PR DESCRIPTION
This PR adds an enumerated design space defined by a list of python dictionaries. Users define a list of descriptors and a list of dictionaries that map from descriptor key to value. Values are allowed to be any type, i.e. `data: Mapping[str, Any]`. The backend casts the value to a string when building the design space.