### PR TITLE
Increase orion test coverage

### DIFF
--- a/src/citrine/informatics/workflows.py
+++ b/src/citrine/informatics/workflows.py
@@ -8,6 +8,8 @@ from citrine._rest.resource import Resource
 from citrine._session import Session
 from citrine.resources.workflow_executions import WorkflowExecutionCollection
 
+__all__ = ['Workflow', 'DesignWorkflow']
+
 
 class Workflow(PolymorphicSerializable['Workflow']):
     """A Citrine Workflow."""
@@ -60,6 +62,6 @@ class DesignWorkflow(Resource['DesignWorkflow'], Workflow):
     @property
     def executions(self) -> WorkflowExecutionCollection:
         """Return a resource representing all visible executions of this workflow."""
-        if not hasattr(self, 'project_id'):
+        if getattr(self, 'project_id', None) is None:
             raise AttributeError('Cannot initialize execution without project reference!')
         return WorkflowExecutionCollection(self.project_id, self.uid, self.session)

--- a/tests/informatics/test_descriptors.py
+++ b/tests/informatics/test_descriptors.py
@@ -19,3 +19,8 @@ def test_deser_from_parent(descriptor):
     descriptor_data = descriptor.dump()
     descriptor_deserialized = Descriptor.build(descriptor_data)
     assert descriptor == descriptor_deserialized
+
+
+def test_invalid_eq(descriptor):
+    other = None
+    assert not descriptor == other

--- a/tests/informatics/test_workflows.py
+++ b/tests/informatics/test_workflows.py
@@ -1,0 +1,47 @@
+"""Tests for citrine.informatics.workflows."""
+from uuid import uuid4
+
+import pytest
+
+from citrine._session import Session
+from citrine.informatics.workflows import DesignWorkflow
+from citrine.resources.workflow_executions import WorkflowExecutionCollection
+
+DESIGN_SPACE_ID = uuid4()
+PROCESSOR_ID = uuid4()
+PREDICTOR_ID = uuid4()
+PROJECT_ID = uuid4()
+
+
+@pytest.fixture
+def design_workflow() -> DesignWorkflow:
+    return DesignWorkflow('foo', DESIGN_SPACE_ID, PROCESSOR_ID, PREDICTOR_ID, PROJECT_ID)
+
+
+def test_workflow_initialization(design_workflow):
+    """Make sure the correct fields go to the correct places."""
+    assert design_workflow.name == 'foo'
+    assert design_workflow.design_space_id == DESIGN_SPACE_ID
+    assert design_workflow.processor_id == PROCESSOR_ID
+    assert design_workflow.predictor_id == PREDICTOR_ID
+    assert isinstance(design_workflow.session, Session)
+
+
+def test_workflow_str(design_workflow):
+    assert str(design_workflow) == '<DesignWorkflow \'foo\'>'
+
+
+def test_workflow_executions_with_project(design_workflow):
+    assert isinstance(design_workflow.executions, WorkflowExecutionCollection)
+
+
+def test_workflow_executions_without_project():
+    workflow = DesignWorkflow(
+        name="workflow",
+        design_space_id=uuid4(),
+        processor_id=uuid4(),
+        predictor_id=uuid4()
+    )
+
+    with pytest.raises(AttributeError):
+        workflow.executions


### PR DESCRIPTION
This PR adds unit tests to increase test coverage in orion. It also fixes a minor bug when trying to access `DesignWorkflow.executions` when project ID is None.