### PR TITLE
List files in dataset

### DIFF
--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -52,7 +52,22 @@ class Collection(Generic[ResourceType]):
     def list(self,
              page: Optional[int] = None,
              per_page: Optional[int] = None) -> Iterable[ResourceType]:
-        """List all visible elements in the collection."""
+        """
+        List all visible elements in the collection.
+
+        Parameters
+        ---------
+        page: int, optional
+            The "page" of results to list. Default is the first page, which is 1.
+        per_page: int, optional
+            Max number of results to return. Default is 20.
+
+        Returns
+        -------
+        Iterable[ResourceType]
+            Resources in this collection.
+
+        """
         path = self._get_path()
 
         params = {}

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -2,6 +2,7 @@
 from uuid import UUID
 import os
 import mimetypes
+from typing import Iterable
 from boto3 import client as boto3_client
 from botocore.exceptions import ClientError
 
@@ -45,6 +46,7 @@ class FileCollection(Collection[FileLink]):
     """Represents the collection of all file links associated with a dataset."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/files'
+    _dataset_agnostic_path_template = 'projects/{project_id}/files'
     _individual_key = 'file'
     _collection_key = 'files'
 
@@ -56,6 +58,11 @@ class FileCollection(Collection[FileLink]):
     def build(self, data: dict) -> FileLink:
         """Build an instance of FileLink."""
         return FileLink.build(data)
+
+    def list(self) -> Iterable[FileLink]:
+        url = self._get_path(ignore_dataset=False)
+        params = {'dataset_id': str(self.dataset_id)}
+        response = self.session.get_resource(path=url)
 
     def upload(self, file_path: str, dest_name: str = None) -> FileLink:
         """

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -28,7 +28,17 @@ class _Uploader:
 
 
 class FileLink(Resource['FileLink'], TaurusFileLink):
-    """Resource that stores the name and url of an external file."""
+    """
+    Resource that stores the name and url of an external file.
+
+    Parameters
+    ----------
+    filename: str
+        The name of the file.
+    url: str
+        URL that can be used to access the file.
+
+    """
 
     filename = String('filename')
     url = String('url')
@@ -60,9 +70,9 @@ class FileCollection(Collection[FileLink]):
         return FileLink.build(data)
 
     def list(self) -> Iterable[FileLink]:
-        url = self._get_path(ignore_dataset=False)
+        path = self._get_path(ignore_dataset=True)
         params = {'dataset_id': str(self.dataset_id)}
-        response = self.session.get_resource(path=url)
+        return self.session.get_resource(path=path, params=params)
 
     def upload(self, file_path: str, dest_name: str = None) -> FileLink:
         """

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -68,7 +68,8 @@ class FileCollection(Collection[FileLink]):
         """Build an instance of FileLink."""
         return FileLink.build(data)
 
-    def list(self, page: Optional[int] = None,
+    def list(self, 
+             page: Optional[int] = None,
              per_page: Optional[int] = None) -> Iterable[FileLink]:
         """
         List all visible files in the collection.
@@ -76,9 +77,9 @@ class FileCollection(Collection[FileLink]):
         Parameters
         ---------
         page: int, optional
-            The "page" of results to list. Default is the first page, which is 1.
+            The "page" number of results to list. Default is the first page, which is 1.
         per_page: int, optional
-            Max number of results to return. Default is 20.
+            Max number of results to return for each call. Default is 20.
 
         Returns
         -------

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -136,9 +136,12 @@ def test_complete_upload(collection, session, uploader):
 
 
 def test_list_file_links(collection, session, valid_data):
+    """Test that all files in a dataset can be turned into FileLink and listed."""
     file_id = str(uuid4())
     version = str(uuid4())
     filename = 'materials.txt'
+    # The actual response contains more fields, but these are the only ones we use.
+    # Crucial thing is that URL ends with "/files/file_id/versions/version"
     returned_data = {
         'filename': filename,
         'versioned_url': "http://citrine.com/api/files/{}/versions/{}".format(file_id, version)
@@ -167,6 +170,7 @@ def test_list_file_links(collection, session, valid_data):
     expected_file = FileLinkDataFactory(url=expected_url, filename=filename)
     assert files[0].dump() == FileLink.build(expected_file).dump()
 
+    # A response that does not have a URL of the expected form throws ValueError
     bad_returned_data = {
         'filename': filename,
         'versioned_url': "http://citrine.com/api/file_version/{}".format(version)

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -4,7 +4,7 @@ from mock import patch, Mock
 from botocore.exceptions import ClientError
 
 from citrine.resources.file_link import FileCollection, FileLink, _Uploader
-from tests.utils.session import FakeSession, FakeS3Client
+from tests.utils.session import FakeSession, FakeS3Client, FakeCall
 from tests.utils.factories import FileLinkDataFactory, _UploaderFactory
 
 
@@ -69,6 +69,7 @@ def test_upload_request(mock_stat, collection, session, uploader):
     }
     session.set_response(upload_request_response)
     new_uploader = collection._make_upload_request('foo.txt', 'foo.txt')
+    assert session.num_calls == 1
     assert new_uploader.bucket == uploader.bucket
     assert new_uploader.object_key == uploader.object_key
     assert new_uploader.upload_id == uploader.upload_id
@@ -108,6 +109,21 @@ def test_complete_upload(collection, session, uploader):
     dest_name = 'foo.txt'
     file_id = '12345'
     version = '13'
+
+    # This is the dictionary structure we expect from the upload completion request
+    complete_response = {
+        'file_info': {
+            'file_id': file_id,
+            'version': version
+        }
+    }
+    session.set_response(complete_response)
+    file_link = collection._complete_upload(dest_name, uploader)
+    assert session.num_calls == 1
+    url = 'projects/{}/datasets/{}/files/{}/versions/{}'\
+        .format(collection.project_id, collection.dataset_id, file_id, version)
+    assert file_link.dump() == FileLink(dest_name, url=url).dump()
+
     bad_complete_response = {
         'file_info': {
             'file_id': file_id
@@ -118,14 +134,32 @@ def test_complete_upload(collection, session, uploader):
         session.set_response(bad_complete_response)
         collection._complete_upload(dest_name, uploader)
 
-    complete_response = {
-        'file_info': {
-            'file_id': file_id,
-            'version': version
-        }
+
+def test_list_file_links(collection, session, valid_data):
+    valid_data = FileLinkDataFactory(url='www.citrine.io', filename='materials.txt')
+    # Modify this to be the actual dictionary returned by the backend
+    returned_data = {
+        'url': 'www.citrine.io',
+        'filename': 'materials.txt',
+        'type': 'file_link'
     }
-    session.set_response(complete_response)
-    file_link = collection._complete_upload(dest_name, uploader)
-    url = 'projects/{}/datasets/{}/files/{}/versions/{}'\
-        .format(collection.project_id, collection.dataset_id, file_id, version)
-    assert file_link.dump() == FileLink(dest_name, url=url).dump()
+    session.set_response({
+        'contents': [returned_data]
+    })
+
+    files_iterator = collection.list(page=1, per_page=15)
+    files = [file for file in files_iterator]
+
+    assert session.num_calls == 1
+    expected_call = FakeCall(
+        method='GET',
+        path='projects/{}/files'.format(collection.project_id),
+        params={
+            'dataset_id': str(collection.dataset_id),
+            'page': 1,
+            'per_page': 15
+        }
+    )
+    assert expected_call == session.last_call
+    assert len(files) == 1
+    assert files[0].dump() == FileLink.build(valid_data).dump()


### PR DESCRIPTION
Write `list()` method for `FileLinkCollection` class. Primary complication arises because the JSON returned from the URL does not map cleanly to a FileLink dictionary. 
Tests are written using a fake session.