### PR TITLE
Raise NotImplementedError when searching by >1 tag

### DIFF
--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -496,6 +496,8 @@ class DataConceptsCollection(Collection[ResourceType]):
             See (insert link) for a discussion of how to match on tags.
 
         """
+        if len(tags) > 1:
+            raise NotImplementedError('Searching by multiple tags is not currently supported.')
         params = {'tags': tags}
         if self.dataset_id is not None:
             params['dataset_id'] = str(self.dataset_id)

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -483,7 +483,7 @@ class DataConceptsCollection(Collection[ResourceType]):
         Parameters
         ----------
         tags: List[str]
-            A list of strings, each one a tag that an object can match. Currently,
+            A list of strings, each one a tag that an object can match. Currently
             limited to a length of 1 or 0 (empty list does not filter).
         page: Optional[int]
             The page of results to list, 1-indexed (i.e. the first page is page=1)

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -483,7 +483,8 @@ class DataConceptsCollection(Collection[ResourceType]):
         Parameters
         ----------
         tags: List[str]
-            a list of strings, each one a tag that an object can match.
+            A list of strings, each one a tag that an object can match. Currently,
+            limited to a length of 1 or 0 (empty list does not filter).
         page: Optional[int]
             The page of results to list, 1-indexed (i.e. the first page is page=1)
         per_page: Optional[int]

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -68,7 +68,7 @@ class FileCollection(Collection[FileLink]):
         """Build an instance of FileLink."""
         return FileLink.build(data)
 
-    def list(self, 
+    def list(self,
              page: Optional[int] = None,
              per_page: Optional[int] = None) -> Iterable[FileLink]:
         """


### PR DESCRIPTION
This operation is currently unsupported by the backend and results in some tags being ignored.