### PR TITLE
Allow filter_by_tags when user supplies a single string, as opposed to a list with one string

### DIFF
--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -497,6 +497,8 @@ class DataConceptsCollection(Collection[ResourceType]):
             See (insert link) for a discussion of how to match on tags.
 
         """
+        # if type(tags) == str:
+        #     tags = [tags]
         if len(tags) > 1:
             raise NotImplementedError('Searching by multiple tags is not currently supported.')
         params = {'tags': tags}

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -497,8 +497,8 @@ class DataConceptsCollection(Collection[ResourceType]):
             See (insert link) for a discussion of how to match on tags.
 
         """
-        # if type(tags) == str:
-        #     tags = [tags]
+        if type(tags) == str:
+            tags = [tags]
         if len(tags) > 1:
             raise NotImplementedError('Searching by multiple tags is not currently supported.')
         params = {'tags': tags}

--- a/tests/serialization/test_material_run.py
+++ b/tests/serialization/test_material_run.py
@@ -26,7 +26,7 @@ def test_simple_deserialization():
     material_run: MaterialRun = MaterialRun.build(valid_data)
     assert material_run.uids == {'id': valid_data['uids']['id']}
     assert material_run.name == 'Cake 1'
-    assert material_run.tags == []
+    assert material_run.tags == ["color"]
     assert material_run.notes is None
     assert material_run.process == LinkByUID('id', valid_data['process']['id'])
     assert material_run.sample_type == 'experimental'

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -53,7 +53,7 @@ class FileLinkDataFactory(factory.DictFactory):
 class MaterialRunDataFactory(factory.DictFactory):
     uids = factory.SubFactory(IDDataFactory)
     name = factory.Faker('color_name')
-    tags = []
+    tags = ["color"]
     notes = None
     process = factory.SubFactory(LinkByUIDInputFactory)
     sample_type = 'experimental'


### PR DESCRIPTION
`tags = ["a tag"]` should work
`tags = "a tag"` should work
`tags = ["a tag", "another tag"]` should throw a `NotImplementedError`