### PR TITLE
Add checked_* calls to the session

### DIFF
--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -101,16 +101,28 @@ class Session(requests.Session):
 
     def get_resource(self, path: str, *args, **kwargs) -> dict:
         """GET a particular resource as JSON."""
-        return self.checked_request('GET', path, *args, **kwargs).json()
+        return self.checked_get(path, *args, **kwargs).json
 
     def post_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
         """POST to a particular resource as JSON."""
-        return self.checked_request('POST', path, *args, json=json, **kwargs).json()
+        return self.checked_post(path, json, *args, **kwargs).json()
 
     def put_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
         """PUT data given by some JSON at a particular resource."""
-        return self.checked_request('PUT', path, *args, json=json, **kwargs).json()
+        return self.checked_put(path, *args, json=json, **kwargs).json()
 
     def delete_resource(self, path: str) -> dict:
         """DELETE a particular resource as JSON."""
-        return self.checked_request('DELETE', path).json()
+        return self.checked_delete(path).json()
+
+    def checked_post(self, path: str, json: dict, *args, **kwargs) -> None:
+        return self.checked_request('POST', path, *args, json=json, **kwargs)
+
+    def checked_put(self, path: str, json: dict, *args, **kwargs) -> None:
+        return self.checked_request('PUT', path, *args, json=json, **kwargs)
+
+    def checked_delete(self, path: str) -> dict:
+        return self.checked_request('DELETE', path)
+
+    def checked_get(self, path: str, *args, **kwargs) -> dict:
+        return self.checked_request('GET', path, *args, **kwargs)

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -116,13 +116,17 @@ class Session(requests.Session):
         return self.checked_delete(path).json()
 
     def checked_post(self, path: str, json: dict, *args, **kwargs) -> None:
+        """Execute a POST request to a URL and utilize error filtering on the response."""
         return self.checked_request('POST', path, *args, json=json, **kwargs)
 
     def checked_put(self, path: str, json: dict, *args, **kwargs) -> None:
+        """Execute a PUT request to a URL and utilize error filtering on the response."""
         return self.checked_request('PUT', path, *args, json=json, **kwargs)
 
     def checked_delete(self, path: str) -> dict:
+        """Execute a DELETE request to a URL and utilize error filtering on the response."""
         return self.checked_request('DELETE', path)
 
     def checked_get(self, path: str, *args, **kwargs) -> dict:
+        """Execute a GET request to a URL and utilize error filtering on the response."""
         return self.checked_request('GET', path, *args, **kwargs)

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -105,7 +105,7 @@ class Session(requests.Session):
 
     def post_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
         """POST to a particular resource as JSON."""
-        return self.checked_post(path, json, *args, **kwargs).json()
+        return self.checked_post(path, *args, json=json, **kwargs).json()
 
     def put_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
         """PUT data given by some JSON at a particular resource."""

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -101,7 +101,7 @@ class Session(requests.Session):
 
     def get_resource(self, path: str, *args, **kwargs) -> dict:
         """GET a particular resource as JSON."""
-        return self.checked_get(path, *args, **kwargs).json
+        return self.checked_get(path, *args, **kwargs).json()
 
     def post_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
         """POST to a particular resource as JSON."""

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -173,7 +173,7 @@ class Project(Resource['Project']):
             True if the action was performed successfully
 
         """
-        self.session.post_resource(self._path() + "/make-public", {
+        self.session.checked_post(self._path() + "/make-public", {
             "resource": resource.as_entity_dict()
         })
         return True
@@ -194,7 +194,7 @@ class Project(Resource['Project']):
             True if the action was performed successfully
 
         """
-        self.session.post_resource(self._path() + "/make-private", {
+        self.session.checked_post(self._path() + "/make-private", {
             "resource": resource.as_entity_dict()
         })
         return True

--- a/tests/utils/session.py
+++ b/tests/utils/session.py
@@ -46,18 +46,30 @@ class FakeSession:
         return self.calls[-1]
 
     def get_resource(self, path: str, *args, **kwargs) -> dict:
+        return self.checked_get(path, *args, **kwargs)
+
+    def post_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
+        return self.checked_post(path, json, *args, **kwargs)
+
+    def put_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
+        return self.checked_put(path, json, *args, **kwargs)
+
+    def delete_resource(self, path: str) -> dict:
+        return self.checked_delete(path)
+
+    def checked_get(self, path: str, *args, **kwargs) -> dict:
         self.calls.append(FakeCall('GET', path, params=kwargs.get('params')))
         return self.response
 
-    def post_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
+    def checked_post(self, path: str, json: dict, *args, **kwargs) -> dict:
         self.calls.append(FakeCall('POST', path, json, params=kwargs.get('params')))
         return self.response
 
-    def put_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
+    def checked_put(self, path: str, json: dict, *args, **kwargs) -> dict:
         self.calls.append(FakeCall('PUT', path, json))
         return self.response
 
-    def delete_resource(self, path: str) -> dict:
+    def checked_delete(self, path: str) -> dict:
         self.calls.append(FakeCall('DELETE', path))
         return self.response
 


### PR DESCRIPTION
Fix deserialization bug in the public/private endpoints

Session did not provide convenience methods for making
  checked requests without deserializing results as JSON.
  Not every endpoint will necessary return a response body, so
  it will be useful to have a way to get response objects without
  claiming they contain JSON.

Please briefly explain the goal of the changes/this PR.

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.