### PR TITLE
Only use supported units

### DIFF
--- a/tests/serialization/test_material_spec.py
+++ b/tests/serialization/test_material_spec.py
@@ -38,13 +38,13 @@ def valid_data():
                          {
                              'type': 'condition',
                              'origin': 'specified',
-                             'name': 'light level',
+                             'name': 'temperature',
                              'template': None,
                              'notes': None,
                              'value': {
                                  'type': 'nominal_real',
-                                 'nominal': 100.0,
-                                 'units': 'lumen'
+                                 'nominal': 300.0,
+                                 'units': 'kelvin'
                              },
                              'file_links': []
                          }
@@ -67,8 +67,8 @@ def test_simple_deserialization(valid_data):
     assert material_spec.properties[0] == \
         PropertyAndConditions(Property("color", origin='specified',
                                        value=NominalCategorical("tan")),
-                              conditions=[Condition('light level', origin='specified',
-                                                    value=NominalReal(100, units='lm'))])
+                              conditions=[Condition('temperature', origin='specified',
+                                                    value=NominalReal(300, units='kelvin'))])
     assert material_spec.template is None
     assert material_spec.file_links == []
     assert material_spec.typ == 'material_spec'

--- a/tests/serialization/test_object_template.py
+++ b/tests/serialization/test_object_template.py
@@ -23,7 +23,7 @@ def test_object_template_serde():
     assert copy_template == block_template
 
     # Tests below exercise similar code, but for measurement and process templates
-    pressure_template = ConditionTemplate("pressure", RealBounds(0.999, 1.001, 'atm'))
+    pressure_template = ConditionTemplate("pressure", RealBounds(0.1, 0.11, 'MPa'))
     index_template = ParameterTemplate("index", IntegerBounds(2, 10))
     meas_template = MeasurementTemplate("A measurement of length", properties=[length_template],
                                         conditions=[pressure_template], description="Description",


### PR DESCRIPTION
# Citrine Python PR

## Description 
https://github.com/CitrineInformatics/taurus/pull/21 down-selected the support units.  Let's only use them.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
