### PR TITLE
pass down the path to the underlying exception class

### DIFF
--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -85,13 +85,13 @@ class Session(requests.Session):
                 self.logger.error('%s %s %s', response.status_code, method, path)
                 raise Unauthorized(path)
             elif response.status_code == 404:
-                self.logger.warning('%s %s %s', response.status_code, method, path)
+                self.logger.error('%s %s %s', response.status_code, method, path)
                 raise NotFound(path)
             elif response.status_code == 409:
-                self.logger.warning('%s %s %s', response.status_code, method, path)
+                self.logger.debug('%s %s %s', response.status_code, method, path)
                 raise WorkflowConflictException(response.text)
             elif response.status_code == 425:
-                self.logger.warning('%s %s %s', response.status_code, method, path)
+                self.logger.debug('%s %s %s', response.status_code, method, path)
                 msg = 'Cant execute at this time. Try again later. Error: {}'.format(response.text)
                 raise WorkflowNotReadyException(msg)
             else:

--- a/src/citrine/exceptions.py
+++ b/src/citrine/exceptions.py
@@ -29,7 +29,7 @@ class NotFound(NonRetryableException):
     """A particular url was not found. (http status 404)."""
 
     def __init__(self, path: str):
-        super().__init__()
+        super().__init__(path)
         self.url = path
 
 
@@ -37,7 +37,7 @@ class Unauthorized(NonRetryableException):
     """The user is unauthorized to make this api call. (http status 401)."""
 
     def __init__(self, path: str):
-        super().__init__()
+        super().__init__(path)
         self.url = path
 
 


### PR DESCRIPTION
# Citrine Python PR

## Description 
The exception message is not being passed down to the underlying base exception class resulting in this:
```
~/Documents/GitHub/citrine-python/src/citrine/_session.py in checked_request(self, method, path, *args, **kwargs)
     87             elif response.status_code == 404:
     88                 self.logger.warning('%s %s %s', response.status_code, method, path)
---> 89                 raise NotFound(path)
     90             elif response.status_code == 409:
     91                 self.logger.warning('%s %s %s', response.status_code, method, path)

NotFound: 
```

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
