### PR TITLE
Re-establish soft links after severing when building discarded objects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-taurus-citrine==0.1.0
+git+https://github.com/CitrineInformatics/taurus.git@develop
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.14.5

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(name='citrine',
           "arrow",
           "pytest>=4.3",
           "strip-hints>=0.1.5",
-          "taurus-citrine>=0.1.0,<0.2.0",
+          "taurus",
           "boto3",
           "botocore"
       ],

--- a/src/citrine/resources/measurement_run.py
+++ b/src/citrine/resources/measurement_run.py
@@ -51,6 +51,7 @@ class MeasurementRun(DataConcepts, Resource['MeasurementRun'], TaurusMeasurement
         Links to associated files, with resource paths into the files API.
     source: PerformedSource, optional
         Information about the person who performed the run and when.
+
     """
 
     _response_key = TaurusMeasurementRun.typ  # 'measurement_run'


### PR DESCRIPTION
# Citrine Python PR

Changes to Taurus (https://github.com/CitrineInformatics/taurus/pull/27) have led to incompletely-rehydrated material histories in Citrine-Python. When establishing soft-links (e.g., the list of ingredients into a process) the code starts with a `DataConcepts` process that has no ingredients, _as well as_ a taurus representation of the process which does have the ingredients<-->process links intact. It loops through those ingredients and does the following:
1. Sever the link from ingredient to process in order to prevent infinite loops in the next step
2. Build a copy of the ingredient as a DataConcepts object
3. Link the DataConcepts ingredient to the DataConcepts process

The problem is that severing the link from ingredient to process now _also_ severs the link from process to ingredient, as per Taurus PR 27. This means that if the `build` algorithm ever comes back to the Taurus representation of this process, it no longer knows what ingredients it has. The solution is to add a 4th step to the above workflow
4. Re-establish the link from ingredient to process

## Description 
Please briefly explain the goal of the changes/this PR.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
