### PR TITLE
Switch ValueError with TypeError in validation test

### DIFF
--- a/tests/resources/test_object_setters.py
+++ b/tests/resources/test_object_setters.py
@@ -53,7 +53,7 @@ def test_object_pointer_serde():
 def test_object_validation():
     """Test that an object pointing to another object is validated."""
     meas = MeasurementRun("A measurement")
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         MaterialRun("A cake", process=meas)
 
 

--- a/tests/serialization/test_material_run.py
+++ b/tests/serialization/test_material_run.py
@@ -86,7 +86,7 @@ def test_nested_serialization():
     batter.process.ingredients.append(make_ingredient(material=MaterialRun('Flour')))
     batter.process.ingredients.append(make_ingredient(material=MaterialRun('Milk')))
 
-    print(cake.dump())
+    cake.dump()
 
 
 def test_measurement_material_connection_rehydration():


### PR DESCRIPTION
# Citrine Python PR

## Description 
Many of the value errors in taurus were changed to type errors in:
https://github.com/CitrineInformatics/taurus/commit/e3f5cde2766e889daf80d8839465bc111f3e5953

This just changes the expected exception type to match.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
