### PR TITLE
Support "Project Member" Endpoints in Citrine-Python

### DIFF
--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -129,6 +129,7 @@ class Session(requests.Session):
 
     def checked_get(self, path: str, *args, **kwargs) -> dict:
         """Execute a GET request to a URL and utilize error filtering on the response.
+
         :rtype: object
         """
         return self.checked_request('GET', path, *args, **kwargs)

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -128,8 +128,5 @@ class Session(requests.Session):
         return self.checked_request('DELETE', path)
 
     def checked_get(self, path: str, *args, **kwargs) -> dict:
-        """Execute a GET request to a URL and utilize error filtering on the response.
-
-        :rtype: object
-        """
+        """Execute a GET request to a URL and utilize error filtering on the response."""
         return self.checked_request('GET', path, *args, **kwargs)

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -115,7 +115,7 @@ class Session(requests.Session):
         """DELETE a particular resource as JSON."""
         return self.checked_delete(path).json()
 
-    def checked_post(self, path: str, json: dict, *args, **kwargs) -> None:
+    def checked_post(self, path: str, json: dict, *args, **kwargs) -> dict:
         """Execute a POST request to a URL and utilize error filtering on the response."""
         return self.checked_request('POST', path, *args, json=json, **kwargs)
 
@@ -128,5 +128,7 @@ class Session(requests.Session):
         return self.checked_request('DELETE', path)
 
     def checked_get(self, path: str, *args, **kwargs) -> dict:
-        """Execute a GET request to a URL and utilize error filtering on the response."""
+        """Execute a GET request to a URL and utilize error filtering on the response.
+        :rtype: object
+        """
         return self.checked_request('GET', path, *args, **kwargs)

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -206,7 +206,7 @@ class Project(Resource['Project']):
 
         Returns
         -------
-        ListMemberResponse
+        List[User]
             Dict with key 'users' containing an array of User objects
             These are the members of the current project
 

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -1,5 +1,5 @@
 """Resources that represent both individual and collections of projects."""
-from typing import Optional, Dict
+from typing import Optional, Dict, NamedTuple, List
 
 from citrine._session import Session
 from citrine.resources.dataset import DatasetCollection
@@ -21,6 +21,12 @@ from citrine.resources.ingredient_spec import IngredientSpecCollection
 from citrine._rest.collection import Collection
 from citrine._rest.resource import Resource
 from citrine._serialization import properties
+from citrine.resources.user import User
+
+
+class ActionRoleResponse(NamedTuple):
+    role: str
+    actions: List[str]
 
 
 class Project(Resource['Project']):
@@ -197,6 +203,45 @@ class Project(Resource['Project']):
         self.session.checked_post(self._path() + "/make-private", {
             "resource": resource.as_entity_dict()
         })
+        return True
+
+    def list_members(self) -> List[User]:
+        """
+        List all of the users in the current project
+
+        Returns
+        -------
+        ListMemberResponse
+            Dict w/ key 'users' containing an array of User objects
+            These are the members of the current project
+        """
+        return self.session.checked_get(self._path() + "/users")["users"]
+
+    def set_member(self, user_uid, role: str, actions: List[str]) -> bool:
+        """
+        Add a User to a Project with the given 'role' and 'actions'
+
+        Returns
+        -------
+        Returns True if member successfully added
+        """
+        self.session.checked_post(
+            self._path() + "/users/{}".format(user_uid),
+            {'role': role, 'actions': actions},
+        )
+        return True
+
+    def remove_member(self, user_uid: str):
+        """
+        Remove a User from a Project
+
+        Returns
+        -------
+        Returns True of user successfully removed
+        """
+        self.session.checked_delete(
+            self._path() + "/users/{}".format(user_uid)
+        )
         return True
 
 

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -207,7 +207,7 @@ class Project(Resource['Project']):
         Returns
         -------
         ListMemberResponse
-            Dict w/ key 'users' containing an array of User objects
+            Dict with key 'users' containing an array of User objects
             These are the members of the current project
 
         """

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -24,11 +24,6 @@ from citrine._serialization import properties
 from citrine.resources.user import User
 
 
-class ActionRoleResponse(NamedTuple):
-    role: str
-    actions: List[str]
-
-
 class Project(Resource['Project']):
     """
     A Citrine Project.
@@ -231,7 +226,7 @@ class Project(Resource['Project']):
         )
         return True
 
-    def remove_member(self, user_uid: str):
+    def remove_member(self, user_uid: str) -> bool:
         """
         Remove a User from a Project
 

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -207,8 +207,7 @@ class Project(Resource['Project']):
         Returns
         -------
         List[User]
-            Dict with key 'users' containing an array of User objects
-            These are the members of the current project
+            The members of the current project
 
         """
         return self.session.checked_get(self._path() + "/users")["users"]
@@ -219,7 +218,8 @@ class Project(Resource['Project']):
 
         Returns
         -------
-        Returns True if member successfully added
+        bool
+            Returns True if member successfully added
 
         """
         self.session.checked_post(
@@ -234,7 +234,8 @@ class Project(Resource['Project']):
 
         Returns
         -------
-        Returns True if user successfully removed
+        bool
+            Returns True if user successfully removed
 
         """
         self.session.checked_delete(

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -234,7 +234,7 @@ class Project(Resource['Project']):
 
         Returns
         -------
-        Returns True of user successfully removed
+        Returns True if user successfully removed
 
         """
         self.session.checked_delete(

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -1,5 +1,5 @@
 """Resources that represent both individual and collections of projects."""
-from typing import Optional, Dict, NamedTuple, List
+from typing import Optional, Dict, List
 
 from citrine._session import Session
 from citrine.resources.dataset import DatasetCollection
@@ -202,23 +202,25 @@ class Project(Resource['Project']):
 
     def list_members(self) -> List[User]:
         """
-        List all of the users in the current project
+        List all of the users in the current project.
 
         Returns
         -------
         ListMemberResponse
             Dict w/ key 'users' containing an array of User objects
             These are the members of the current project
+
         """
         return self.session.checked_get(self._path() + "/users")["users"]
 
     def set_member(self, user_uid, role: str, actions: List[str]) -> bool:
         """
-        Add a User to a Project with the given 'role' and 'actions'
+        Add a User to a Project with the given 'role' and 'actions'.
 
         Returns
         -------
         Returns True if member successfully added
+
         """
         self.session.checked_post(
             self._path() + "/users/{}".format(user_uid),
@@ -228,11 +230,12 @@ class Project(Resource['Project']):
 
     def remove_member(self, user_uid: str) -> bool:
         """
-        Remove a User from a Project
+        Remove a User from a Project.
 
         Returns
         -------
         Returns True of user successfully removed
+
         """
         self.session.checked_delete(
             self._path() + "/users/{}".format(user_uid)

--- a/src/citrine/resources/user.py
+++ b/src/citrine/resources/user.py
@@ -48,9 +48,9 @@ class User(Resource['User']):
         return '<User {!r}>'.format(self.screen_name)
 
     def get(self):
-        """Retrieve a specific user from the database"""
+        """Retrieve a specific user from the database."""
         raise NotImplementedError("Get Not Implemented in Citrine Platform")
-    
+
 
 class UserCollection(Collection[User]):
     """Represents the collection of all users."""
@@ -64,7 +64,7 @@ class UserCollection(Collection[User]):
         self.session: Session = session
 
     def me(self):
-        """Get information about the current user"""
+        """Get information about the current user."""
         data = self.session.get_resource('{}/me'.format(self._path_template))
         return self.build(data)
 
@@ -92,6 +92,7 @@ class UserCollection(Collection[User]):
                  email: str,
                  position: str,
                  is_admin: bool) -> User:
+        """Register a New User."""
         return super().register(User(
             screen_name=screen_name,
             email=email,


### PR DESCRIPTION
Add support in citrine-python for the "project membership" endpoints. See the Postman Collection for details on the implemented methods:   Workspace: "Citrine-APIs"   Collection: "Product API Spec"   Folders: projects -> users

Seeks to bring citrine-python to parity with the product-api.

This will facilitate the migration of functional tests / sdk e2e tests into
a unified wrapper.

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.