### PR TITLE
Reverting UUID defaults and fixing tests

### DIFF
--- a/src/citrine/informatics/design_spaces.py
+++ b/src/citrine/informatics/design_spaces.py
@@ -46,7 +46,7 @@ class ProductDesignSpace(Resource['ProductDesignSpace'], DesignSpace):
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = properties.String('module_type', default='DESIGN_SPACE')
-    schema_id = properties.UUID('schema_id', default='6c16d694-d015-42a7-b462-8ef299473c9a')
+    schema_id = properties.UUID('schema_id', default=UUID('6c16d694-d015-42a7-b462-8ef299473c9a'))
 
     def __init__(self,
                  name: str,

--- a/src/citrine/informatics/dimensions.py
+++ b/src/citrine/informatics/dimensions.py
@@ -29,7 +29,7 @@ class ContinuousDimension(Serializable['ContinuousDimension'], Dimension):
     lower_bound = properties.Float('lower_bound')
     upper_bound = properties.Float('upper_bound')
     typ = properties.String('type', default='ContinuousDimension', deserializable=False)
-    template_id = properties.UUID('template_id', default=str(uuid4()))
+    template_id = properties.UUID('template_id', default=uuid4())
 
     def __init__(self,
                  descriptor: RealDescriptor,

--- a/src/citrine/informatics/processors.py
+++ b/src/citrine/informatics/processors.py
@@ -82,7 +82,7 @@ class EnumeratedProcessor(Serializable['EnumeratedProcessor'], Processor):
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = properties.String('module_type', default='PROCESSOR')
-    schema_id = properties.UUID('schema_id', default='307b88a2-fd50-4d27-ae91-b8d6282f68f7')
+    schema_id = properties.UUID('schema_id', default=UUID('307b88a2-fd50-4d27-ae91-b8d6282f68f7'))
 
     def __init__(self,
                  name: str,

--- a/tests/resources/test_design_space.py
+++ b/tests/resources/test_design_space.py
@@ -17,6 +17,7 @@ def test_design_space_build():
             'description': 'For testing',
             'dimensions': [{
                 'type': 'ContinuousDimension',
+                'template_id': str(uuid.uuid4()),
                 'descriptor': {
                     'type': 'RealDescriptor',
                     'descriptor_key': 'foo',
@@ -28,6 +29,7 @@ def test_design_space_build():
             }],
         },
         'status': '',
+        'schema_id': '6c16d694-d015-42a7-b462-8ef299473c9a',
     }
 
     # When

--- a/tests/resources/test_processor.py
+++ b/tests/resources/test_processor.py
@@ -16,6 +16,7 @@ def test_processor_build():
             'max_size': 100,
         },
         'status': '',
+        'schema_id': '307b88a2-fd50-4d27-ae91-b8d6282f68f7',
     }
 
     # When


### PR DESCRIPTION
# Citrine Python PR

## Description 
Puts the default UUID values back and fixes the unit tests.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
