### PR TITLE
Fixing module collection lists

### DIFF
--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -95,7 +95,7 @@ class Collection(Generic[ResourceType]):
             except(KeyError, ValueError):
                 # TODO:  Right now this is a hack.  Clean this up soon.
                 # Module collections are not filtering on module type
-                # properly, so we care filtering client-side.
+                # properly, so we are filtering client-side.
                 pass
 
     def delete(self, uid: Union[UUID, str]) -> Response:

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -20,8 +20,8 @@ class Collection(Generic[ResourceType]):
     _path_template: str = NotImplemented
     _dataset_agnostic_path_template: str = NotImplemented
     _individual_key: str = NotImplemented
-    _collection_key: str = NotImplemented
     _resource: ResourceType = NotImplemented
+    _collection_key: str = 'entries'
 
     def _get_path(self, uid: Optional[Union[UUID, str]] = None,
                   ignore_dataset: Optional[bool] = False) -> str:
@@ -90,7 +90,13 @@ class Collection(Generic[ResourceType]):
             collection = data[self._collection_key]
 
         for element in collection:
-            yield self.build(element)
+            try:
+                yield self.build(element)
+            except(KeyError, ValueError):
+                # TODO:  Right now this is a hack.  Clean this up soon.
+                # Module collections are not filtering on module type
+                # properly, so we care filtering client-side.
+                pass
 
     def delete(self, uid: Union[UUID, str]) -> Response:
         """Delete a particular element of the collection."""

--- a/src/citrine/resources/design_space.py
+++ b/src/citrine/resources/design_space.py
@@ -13,7 +13,6 @@ class DesignSpaceCollection(Collection[DesignSpace]):
     """Represents the collection of all design spaces as well as the resources belonging to it."""
 
     _path_template = '/projects/{project_id}/modules'
-    _collection_key = 'entries'
     _individual_key = None
     _resource = DesignSpace
 

--- a/src/citrine/resources/predictor.py
+++ b/src/citrine/resources/predictor.py
@@ -14,7 +14,6 @@ class PredictorCollection(Collection[Predictor]):
 
     _path_template = '/projects/{project_id}/modules'
     _individual_key = None
-    _collection_key = 'entries'
     _resource = Predictor
 
     def __init__(self, project_id: UUID, session: Session):

--- a/src/citrine/resources/processor.py
+++ b/src/citrine/resources/processor.py
@@ -13,7 +13,6 @@ class ProcessorCollection(Collection[Processor]):
     """Represents the collection of all projects as well as the resources belonging to it."""
 
     _path_template = '/projects/{project_id}/modules'
-    _collection_key = 'entry'
     _individual_key = None
 
     def __init__(self, project_id: UUID, session: Session):

--- a/src/citrine/resources/workflow.py
+++ b/src/citrine/resources/workflow.py
@@ -15,7 +15,6 @@ class WorkflowCollection(Collection[Workflow]):
 
     _path_template = '/projects/{project_id}/workflows'
     _individual_key = None
-    _collection_key = 'entries'
     _resource = Workflow
 
     def __init__(self, project_id: UUID, session: Session):

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -231,6 +231,22 @@ def test_list_projects(collection, session):
     assert 5 == len(projects)
 
 
+def test_list_projects_filters_non_projects(collection, session):
+    # Given
+    projects_data = ProjectDataFactory.create_batch(5)
+    projects_data.append({'foo': 'not a project'})
+    session.set_response({'projects': projects_data})
+
+    # When
+    projects = list(collection.list())
+
+    # Then
+    assert 1 == session.num_calls
+    expected_call = FakeCall(method='GET', path='/projects')
+    assert expected_call == session.last_call
+    assert 5 == len(projects)   # The non-project data is filtered out
+
+
 def test_list_projects_with_page_params(collection, session):
     # Given
     project_data = ProjectDataFactory()

--- a/tests/resources/test_response.py
+++ b/tests/resources/test_response.py
@@ -2,6 +2,7 @@ import re
 
 from citrine.resources.response import Response
 
+
 def test_empty_response_repr():
     """Tests that the repr output expresses the absence of body and status code correctly."""
     resp = Response()
@@ -9,6 +10,7 @@ def test_empty_response_repr():
     no_status_code_found = re.search("No HTTP status available", resp.__repr__())
     assert no_body_found
     assert no_status_code_found
+
 
 def test_empty_body_present_code():
     """Tests that the repr output expresses the absence of body and presence of
@@ -18,6 +20,7 @@ def test_empty_body_present_code():
     status_code_found = re.search("404", resp_with_code.__repr__())
     assert no_body_found
     assert status_code_found
+
 
 def test_empty_body_present_code():
     """Tests that the repr output expresses the presence of body and presence of


### PR DESCRIPTION
# Citrine Python PR

## Description 
This is to get the collections listing working.  One issue was that some collections were looking for the wrong key, and a much bigger issue is that our API is not filtering modules correctly, which was throwing errors whenever lists were being parsed.  This includes a temporary hack to fix functionality in the client while we wait for a proper fix in the product API.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
