### PR TITLE
Create delete endpoint for files

### DIFF
--- a/docs/source/getting_started/working_with_files.rst
+++ b/docs/source/getting_started/working_with_files.rst
@@ -22,8 +22,8 @@ when uploaded. The `filename` **must be unique** within the dataset. If you uplo
 with the same `filename` it will be considered a new version of the same file. The old version
 is not deleted, but at the moment you can only download the latest version of a given FileLink.
 
-Example
--------
+Uploading and Downloading
+-------------------------
 
 Assume you have a dataset named `dataset` and a file at the location `/Users/me/status_20190913.csv`
 on your computer. The code below uploads the file and gives it the filename `microscope_status_20190913.csv`.
@@ -35,3 +35,15 @@ It then downloads the file back to your computer at `/Users/me/Downloads/setting
         "/Users/me/status_20190913.csv", "microscope_status_20190913.csv")
     dataset.files.download(file_link,
         "/Users/me/Downloads/settings.csv")
+
+Deleting
+--------
+
+If you have WRITE permission on a dataset then you may delete any file in the dataset.
+Use this ability carefully, as there are no checks as to whether or no the file is referenced by
+existing data objects.
+Deleting a file can therefore produce broken links.
+
+.. code-block:: python
+
+    dataset.files.delete(file_link)

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -323,3 +323,21 @@ class FileCollection(Collection[FileLink]):
         pre_signed_url = content_link_response['pre_signed_read_link']
         download_response = requests.get(pre_signed_url)
         write_file_locally(download_response.content, local_path)
+
+    def delete(self, file_link: FileLink):
+        """
+        Delete the file associated with a given FileLink from the database.
+
+        Parameters
+        ----------
+        file_link: FileLink
+            Resource referencing the external file.
+
+        """
+        split_url = file_link.url.split('/')
+        assert split_url[-2] == 'versions' and split_url[-4] == 'files',\
+            "File URL is expected to end with '/files/{{file_id}}/version/{{version id}}', " \
+            "but FileLink instead has url {}".format(file_link.url)
+        file_id = split_url[-3]
+        self.session.delete_resource(self._get_path(file_id))
+        return True


### PR DESCRIPTION
# Citrine Python PR

Adds the ability to delete a file in a dataset, and adds this functionality to the documentation.

## Description 
Please briefly explain the goal of the changes/this PR.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
