### PR TITLE
PLA-1881 add failure ID to parsed api error

### DIFF
--- a/src/citrine/resources/api_error.py
+++ b/src/citrine/resources/api_error.py
@@ -28,7 +28,7 @@ class ApiError(DictSerializable):
         if not failure_id:
             # Discourage both anonymous errors ('') and confusing has_failure(None)
             # syntax which may imply there is no failure at all.
-            raise ValueError(f"failure_id cannot be empty: '{failure_id}'")
+            raise ValueError("failure_id cannot be empty: '{}'".format(failure_id))
         return any(v.failure_id == failure_id for v in self.validation_errors)
 
     @classmethod

--- a/src/citrine/resources/api_error.py
+++ b/src/citrine/resources/api_error.py
@@ -8,10 +8,11 @@ class ValidationError(DictSerializable):
     """A user-facing error message describing why their request was invalid."""
 
     def __init__(self, failure_message: Optional[str] = None, property: Optional[str] = None,
-                 input: Optional[str] = None):
+                 input: Optional[str] = None, failure_id: Optional[str] = None):
         self.failure_message = failure_message
         self.property = property
         self.input = input
+        self.failure_id = failure_id
 
 
 class ApiError(DictSerializable):
@@ -21,6 +22,14 @@ class ApiError(DictSerializable):
         self.code = code
         self.message = message
         self.validation_errors = validation_errors or []
+
+    def has_failure(self, failure_id: str) -> bool:
+        """Checks if this error contains a ValidationError with specified failure ID."""
+        if not failure_id:
+            # Discourage both anonymous errors ('') and confusing has_failure(None)
+            # syntax which may imply there is no failure at all.
+            raise ValueError(f"failure_id cannot be empty: '{failure_id}'")
+        return any(v.failure_id == failure_id for v in self.validation_errors)
 
     @classmethod
     def from_dict(cls, d):

--- a/tests/resources/test_api_error.py
+++ b/tests/resources/test_api_error.py
@@ -1,0 +1,47 @@
+import pytest
+
+from citrine.resources.api_error import ApiError, ValidationError
+
+
+def test_has_failure():
+    error = ApiError(400, 'you messed up', [
+        ValidationError(failure_message='failure 1', failure_id='fail.one'),
+        ValidationError(failure_message='failure 2', failure_id='fail.two'),
+        ValidationError(failure_message='vague failure'),
+    ])
+    assert error.has_failure('fail.one')
+    assert error.has_failure('fail.two')
+    assert not error.has_failure('not.present')
+
+    with pytest.raises(ValueError):
+        error.has_failure(None)
+    with pytest.raises(ValueError):
+        error.has_failure('')
+
+
+def test_deserialization():
+    msg = 'ya failed'
+    missing_id = {
+        'code': 400,
+        'message': 'an error',
+        'validation_errors': [
+            {
+                'failure_message': msg,
+            }
+        ]
+    }
+    error = ApiError.from_dict(missing_id)
+    assert error.validation_errors[0].failure_message == msg
+
+    with_id = {
+        'code': 400,
+        'message': 'an error',
+        'validation_errors': [
+            {
+                'failure_message': msg,
+                'failure_id': 'foo.id'
+            }
+        ]
+    }
+    error_with_id = ApiError.from_dict(with_id)
+    assert error_with_id.validation_errors[0].failure_id == 'foo.id'


### PR DESCRIPTION
# Citrine Python PR

## Description 
Action item from last backend meeting: Adding failure ID to error model so we can check for stable error IDs (especially in tests).
Goes with https://github.com/CitrineInformatics/platform-backend/pull/633

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
