### PR TITLE
Fix flake8 style checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ install:
 - pip install -U -r test_requirements.txt
 - pip install --no-deps -e .
 script:
-- pytest --flake8 --cov=src/ --cov-report term-missing --cov-report term:skip-covered
+- pytest --cov=src/ --cov-report term-missing --cov-report term:skip-covered
   --cov-fail-under=100 -s -r .
+- flake8 src
 - cd docs; make html; cd ..;
 - touch ./docs/_build/html/.nojekyll
 deploy:

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -99,6 +99,7 @@ class Collection(Generic[ResourceType]):
                 pass
 
     def update(self, model: CreationType) -> CreationType:
+        """Update a particular element of the collection."""
         url = self._get_path(model.uid)
         updated = self.session.put_resource(url, model.dump())
         data = updated[self._individual_key] if self._individual_key else updated

--- a/src/citrine/informatics/constraints.py
+++ b/src/citrine/informatics/constraints.py
@@ -10,8 +10,10 @@ __all__ = ['Constraint', 'ScalarRangeConstraint', 'CategoricalConstraint']
 
 
 class Constraint(PolymorphicSerializable['Constraint']):
-    """A Citrine Constraint - an abstract type that returns the proper
-    subtype based on the 'type' value of the passed in dict.
+    """A Citrine Constraint places restrictions on a design space.
+
+    Abstract type that returns the proper type given a serialized dict.
+
     """
 
     _response_key = None
@@ -40,6 +42,7 @@ class ScalarRangeConstraint(Serializable['ScalarRangeConstraint'], Constraint):
         if True, will include the min value in the range
     max_inclusive: bool
         if True, will include the max value in the range
+
     """
 
     descriptor_key = properties.String('descriptor_key')
@@ -68,7 +71,7 @@ class ScalarRangeConstraint(Serializable['ScalarRangeConstraint'], Constraint):
 
 
 class CategoricalConstraint(Serializable['CategoricalConstraint'], Constraint):
-    """Represents a constraint on a categorical material attribute to be one of a set of acceptable values.
+    """A constraint on a categorical material attribute to be one of a set of acceptable values.
 
     Parameters
     ----------
@@ -76,6 +79,7 @@ class CategoricalConstraint(Serializable['CategoricalConstraint'], Constraint):
         the key corresponding to the associated Categorical descriptor
     acceptable_categories: list[str]
         the names of the acceptable categories to constrain to
+
     """
 
     descriptor_key = properties.String('descriptor_key')

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -7,8 +7,10 @@ from citrine._serialization import properties
 
 
 class Descriptor(PolymorphicSerializable['Descriptor']):
-    """A Citrine Descriptor - an abstract type that returns the proper
-    subtype based on the 'type' value of the passed in dict.
+    """A Citrine Descriptor describes the range of values that a quantity can take on.
+
+    Abstract type that returns the proper type given a serialized dict.
+
     """
 
     @classmethod
@@ -22,7 +24,7 @@ class Descriptor(PolymorphicSerializable['Descriptor']):
 
 
 class RealDescriptor(Serializable['RealDescriptor'], Descriptor):
-    """Captures domain-specific context about the bounds of an integer-valued datum.
+    """A descriptor to hold real-valued numbers.
 
     Parameters
     ----------
@@ -32,6 +34,7 @@ class RealDescriptor(Serializable['RealDescriptor'], Descriptor):
         inclusive lower bound for valid real values
     upper_bound: float
         inclusive upper bound for valid real values
+
     """
 
     key = properties.String('descriptor_key')
@@ -68,7 +71,9 @@ class InorganicDescriptor(Serializable['InorganicDescriptor'], Descriptor):
     key: str
         the key corresponding to a descriptor
     threshold: float
-        the threshold for valid chemical formulae. Users can think of this as a level of tolerance for typos and/or loss in interpreting a string input as a parseable chemical formula.
+        the threshold for valid chemical formulae. Users can think of this as a level of tolerance
+        for typos and/or loss in interpreting a string input as a parseable chemical formula.
+
     """
 
     key = properties.String('descriptor_key')
@@ -90,7 +95,9 @@ class InorganicDescriptor(Serializable['InorganicDescriptor'], Descriptor):
 
 
 class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):
-    """A descriptor to hold categorical variables. An exhaustive list of categorical values may be supplied.
+    """A descriptor to hold categorical variables.
+
+    An exhaustive list of categorical values may be supplied.
 
     Parameters
     ----------
@@ -98,6 +105,7 @@ class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):
         the key corresponding to a descriptor
     categories: list[str]
         possible categories for this descriptor
+
     """
 
     key = properties.String('descriptor_key')

--- a/src/citrine/informatics/design_spaces.py
+++ b/src/citrine/informatics/design_spaces.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 from citrine._rest.resource import Resource
 from citrine._serialization import properties
-from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
 from citrine._serialization.serializable import Serializable
 from citrine._session import Session
 from citrine.informatics.descriptors import Descriptor
@@ -15,8 +14,11 @@ __all__ = ['DesignSpace', 'ProductDesignSpace', 'EnumeratedDesignSpace']
 
 
 class DesignSpace(Module):
-    """A Citrine Design Space - an abstract type that returns the proper
-    subtype based on the 'type' value of the passed in dict.
+    """A Citrine Design Space describes the set of materials that can be made.
+
+    Abstract type that returns the proper type given a serialized dict.
+
+
     """
 
     _response_key = None
@@ -31,7 +33,7 @@ class DesignSpace(Module):
 
 
 class ProductDesignSpace(Resource['ProductDesignSpace'], DesignSpace):
-    """Design space composed of an outer product of univariate dimensions, either continuous or enumerated.
+    """An outer product of univariate dimensions, either continuous or enumerated.
 
     Parameters
     ----------
@@ -41,6 +43,7 @@ class ProductDesignSpace(Resource['ProductDesignSpace'], DesignSpace):
         the description of the design space
     dimensions: list[Dimension]
         univariate dimensions that are factors of the design space; can be enumerated or continuous
+
     """
 
     _response_key = None
@@ -81,7 +84,10 @@ class ProductDesignSpace(Resource['ProductDesignSpace'], DesignSpace):
 
 
 class EnumeratedDesignSpace(Resource['EnumeratedDesignSpace'], DesignSpace):
-    """Design space composed of an explicit enumeration of candidate materials to score. Note that every candidate must have exactly the descriptors in the list populated (no more, no less) to be included. 
+    """An explicit enumeration of candidate materials to score.
+
+    Note that every candidate must have exactly the descriptors in the list populated
+    (no more, no less) in order to be included.
 
     Parameters
     ----------
@@ -92,8 +98,9 @@ class EnumeratedDesignSpace(Resource['EnumeratedDesignSpace'], DesignSpace):
     descriptors: list[Descriptor]
         the list of descriptors included in the candidates of the design space
     data: list[dict]
-        list of dicts of the shape `{<descriptor_key>: <descriptor_value>}` where each dict corresponds to a candidate
-        in the design space
+        list of dicts of the shape `{<descriptor_key>: <descriptor_value>}`
+        where each dict corresponds to a candidate in the design space
+
     """
 
     _response_key = None

--- a/src/citrine/informatics/dimensions.py
+++ b/src/citrine/informatics/dimensions.py
@@ -11,8 +11,10 @@ __all__ = ['Dimension', 'ContinuousDimension', 'EnumeratedDimension']
 
 
 class Dimension(PolymorphicSerializable['Dimension']):
-    """A Citrine Dimension - an abstract type that returns the proper
-    subtype based on the 'type' value of the passed in dict.
+    """A Citrine Dimension describes the range of values that some quantity can take.
+
+    Abstract type that returns the proper type given a serialized dict.
+
     """
 
     @classmethod
@@ -25,7 +27,7 @@ class Dimension(PolymorphicSerializable['Dimension']):
 
 
 class ContinuousDimension(Serializable['ContinuousDimension'], Dimension):
-    """Continuous dimension that is defined by a template ID, material descriptor, lower bound, and upper bound.
+    """A continuous, real-valued dimension.
 
     Parameters
     ----------
@@ -37,6 +39,7 @@ class ContinuousDimension(Serializable['ContinuousDimension'], Dimension):
         inclusive upper bound
     template_id: UUID
         UUID that corresponds to the template in DC
+
     """
 
     descriptor = properties.Object(RealDescriptor, 'descriptor')
@@ -57,8 +60,7 @@ class ContinuousDimension(Serializable['ContinuousDimension'], Dimension):
 
 
 class EnumeratedDimension(Serializable['EnumeratedDimension'], Dimension):
-    """Finite enumerated dimension that is defined by a template ID, material descriptor, and a list of values
-    for that descriptor.
+    """A finite, enumerated dimension.
 
     Parameters
     ----------
@@ -68,6 +70,7 @@ class EnumeratedDimension(Serializable['EnumeratedDimension'], Dimension):
         UUID that corresponds to the template in DC
     values: list[str]
         list of values that can be parsed by the descriptor
+
     """
 
     descriptor = properties.Object(Descriptor, 'descriptor')

--- a/src/citrine/informatics/modules.py
+++ b/src/citrine/informatics/modules.py
@@ -1,14 +1,15 @@
 """Tools for working with design spaces."""
-from typing import Any, List, Mapping, Type
-from uuid import UUID
+from typing import Type
 
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
-from citrine._serialization.serializable import Serializable
 
 
 class Module(PolymorphicSerializable['Module']):
-    """A Citrine Module - an abstract type that returns the proper
-    subtype based on the 'type' value of the passed in dict.
+    """A Citrine Module is a reusable computational tool used to construct a workflow.
+
+    Abstract type that returns the proper type given a serialized dict.
+
+
     """
 
     _response_key = None

--- a/src/citrine/informatics/objectives.py
+++ b/src/citrine/informatics/objectives.py
@@ -11,8 +11,11 @@ __all__ = ['Objective', 'ScalarMaxObjective', 'ScalarMinObjective']
 
 
 class Objective(PolymorphicSerializable['Objective']):
-    """A Citrine Objective - an abstract type that returns the proper
-    subtype based on the 'type' value of the passed in dict.
+    """A Citrine Objective describes a goal for a score associated with a particular descriptor.
+
+    Abstract type that returns the proper type given a serialized dict.
+
+
     """
 
     _response_key = None
@@ -37,6 +40,7 @@ class ScalarMaxObjective(Serializable['ScalarMaxObjective'], Objective):
         the lower bound on the space, e.g. 0 for a non-negative property
     upper_bound: float
         the upper bound on the space, e.g. 0 for a non-positive property
+
     """
 
     descriptor_key = properties.String('descriptor_key')
@@ -69,6 +73,7 @@ class ScalarMinObjective(Serializable['ScalarMinObjective'], Objective):
         the lower bound on the space, e.g. 0 for a non-negative property
     upper_bound: float
         the upper bound on the space, e.g. 0 for a non-positive property
+
     """
 
     descriptor_key = properties.String('descriptor_key')

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -16,8 +16,11 @@ __all__ = ['Predictor', 'SimpleMLPredictor']
 
 
 class Predictor(Module):
-    """Module that describes the ability to compute/predict properties of materials. An abstract type that returns
-    the proper subtype based on the 'type' value of the passed in dict.
+    """Module that describes the ability to compute/predict properties of materials.
+
+    Abstract type that returns the proper type given a serialized dict. subtype
+    based on the 'type' value of the passed in dict.
+
     """
 
     _response_key = None
@@ -44,7 +47,11 @@ class Predictor(Module):
 
 
 class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
-    """A predictor interface that builds a graphical model connecting the set of inputs through latent variables to the outputs. Supported complex inputs (such as chemical formulas) are auto-featurized and machine learning models are built for each latent variable and output.
+    """A predictor interface that builds a simple grpahical model.
+
+    The model connects the set of inputs through latent variables to the outputs.
+    Supported complex inputs (such as chemical formulas) are auto-featurized and machine learning
+    models are built for each latent variable and output.
 
     Parameters
     ----------
@@ -60,6 +67,7 @@ class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
         Descriptors that are predicted from inputs and used when predicting the outputs
     training_data: str
         UUID of the table that contains the training data
+
     """
 
     uid = properties.Optional(properties.UUID, 'id', serializable=False)

--- a/src/citrine/informatics/processors.py
+++ b/src/citrine/informatics/processors.py
@@ -12,8 +12,10 @@ __all__ = ['Processor', 'GridProcessor', 'EnumeratedProcessor']
 
 
 class Processor(Module):
-    """A Citrine Processor - an abstract type that returns the proper
-    subtype based on the 'type' value of the passed in dict.
+    """A Citrine Processor describes how a design space is searched.
+
+    Abstract type that returns the proper type given a serialized dict.
+
     """
 
     _response_key = None
@@ -28,9 +30,11 @@ class Processor(Module):
 
 
 class GridProcessor(Serializable['GridProcessor'], Processor):
-    """Generates a finite set of materials from the domain defined by the design space, then scans over the set of
-    materials. To create a finite set of materials from continuous dimensions, a uniform grid is created between the
-    bounds of the descriptor. The number of points is specified by `grid_sizes`.
+    """Generates samples from the outer product of finite dimensions, then scans over them.
+
+    To create a finite set of materials from continuous dimensions, a uniform grid is created
+    between the lower and upper bounds of the descriptor.
+    The number of points along each dimension is specified by `grid_sizes`.
 
     Parameters
     ----------
@@ -40,6 +44,7 @@ class GridProcessor(Serializable['GridProcessor'], Processor):
         description of the processor
     grid_sizes: dict[str, int]
         the number of points to select along each dimension of the grid, by dimension name
+
     """
 
     uid = properties.Optional(properties.UUID, 'id', serializable=False)
@@ -82,8 +87,9 @@ class GridProcessor(Serializable['GridProcessor'], Processor):
 
 
 class EnumeratedProcessor(Serializable['EnumeratedProcessor'], Processor):
-    """Process a design space by enumerating up to `max_size` materials from the domain and processing each
-    independently.
+    """Process a design space by enumerating up to a fixed number of samples from the domain.
+
+    Each sample is processed independently.
 
     Parameters
     ----------
@@ -93,6 +99,7 @@ class EnumeratedProcessor(Serializable['EnumeratedProcessor'], Processor):
         description of the processor
     max_size: int
         maximum number of samples that can be enumerated over
+
     """
 
     uid = properties.Optional(properties.UUID, 'id', serializable=False)

--- a/src/citrine/informatics/reports.py
+++ b/src/citrine/informatics/reports.py
@@ -8,8 +8,11 @@ from citrine._session import Session
 
 
 class Report(PolymorphicSerializable['Report']):
-    """A Citrine Report - an abstract type that returns the proper
-    subtype based on the 'type' value of the passed in dict.
+    """A Citrine Report contains information and performance metrics related to a module.
+
+    Abstract type that returns the proper type given a serialized dict.
+
+
     """
 
     _response_key = None
@@ -29,6 +32,7 @@ class PredictorReport(Serializable['PredictorReport'], Report):
         the status of the report (e.g. PENDING, ERROR, OK, etc)
     json: dict
         the json content of the report
+
     """
 
     uid = properties.Optional(properties.UUID, 'id', serializable=False)

--- a/src/citrine/informatics/scores.py
+++ b/src/citrine/informatics/scores.py
@@ -12,8 +12,11 @@ __all__ = ['Score', 'MLIScore', 'MEIScore']
 
 
 class Score(PolymorphicSerializable['Score']):
-    """A Citrine Score - an abstract type that returns the proper
-    subtype based on the 'type' value of the passed in dict.
+    """A Citrine Score is used to rank materials according to objectives and constraints.
+
+    Abstract type that returns the proper type given a serialized dict.
+
+
     """
 
     @classmethod
@@ -40,6 +43,7 @@ class MLIScore(Serializable['MLIScore'], Score):
         best-so-far values for the various objectives (there must be one for each objective)
     constraints: list[Constraint]
         constraints limiting the allowed values that material instances can have
+
     """
 
     name = properties.String('name')
@@ -82,6 +86,7 @@ class MEIScore(Serializable['MEIScore'], Score):
         best-so-far values for the various objectives (there must be one for each objective)
     constraints: list[Constraint]
         constraints limiting the allowed values that material instances can have
+
     """
 
     name = properties.String('name')

--- a/src/citrine/informatics/workflows.py
+++ b/src/citrine/informatics/workflows.py
@@ -12,8 +12,11 @@ __all__ = ['Workflow', 'DesignWorkflow']
 
 
 class Workflow(PolymorphicSerializable['Workflow']):
-    """A Citrine Workflow - an abstract type that returns the proper
-    subtype based on the 'type' value of the passed in dict.
+    """A Citrine Workflow is a collection of Modules that together accomplish some task.
+
+    Abstract type that returns the proper type given a serialized dict.
+
+
     """
 
     _response_key = None
@@ -39,6 +42,7 @@ class DesignWorkflow(Resource['DesignWorkflow'], Workflow):
         the UUID corresponding to the predictor to use
     project_id: UUID
         the UUID corresponding to the project to use
+
     """
 
     uid = properties.Optional(properties.UUID, 'id', serializable=False)

--- a/src/citrine/resources/api_error.py
+++ b/src/citrine/resources/api_error.py
@@ -33,8 +33,10 @@ class ApiError(DictSerializable):
 
     @classmethod
     def from_dict(cls, d):
+        """Reconstitute the API error object from a dictionary."""
         d = copy(d)
         d.pop('debug_stacktrace', None)
         # TODO: deserialize to correct type automatically
-        d['validation_errors'] = [ValidationError.from_dict(e) for e in d.get('validation_errors', [])]
+        d['validation_errors'] = [ValidationError.from_dict(e)
+                                  for e in d.get('validation_errors', [])]
         return cls(**d)

--- a/src/citrine/resources/design_space.py
+++ b/src/citrine/resources/design_space.py
@@ -16,6 +16,7 @@ class DesignSpaceCollection(Collection[DesignSpace]):
     ----------
     project_id: UUID
         the UUID of the project
+
     """
 
     _path_template = '/projects/{project_id}/modules'

--- a/src/citrine/resources/module.py
+++ b/src/citrine/resources/module.py
@@ -13,6 +13,7 @@ class ModuleCollection(Collection[Module]):
     ----------
     project_id: UUID
         the UUID of the project
+
     """
 
     _path_template = '/projects/{project_id}/modules'

--- a/src/citrine/resources/predictor.py
+++ b/src/citrine/resources/predictor.py
@@ -16,6 +16,7 @@ class PredictorCollection(Collection[Predictor]):
     ----------
     project_id: UUID
         the UUID of the project
+
     """
 
     _path_template = '/projects/{project_id}/modules'

--- a/src/citrine/resources/processor.py
+++ b/src/citrine/resources/processor.py
@@ -16,6 +16,7 @@ class ProcessorCollection(Collection[Processor]):
     ----------
     project_id: UUID
         the UUID of the project
+
     """
 
     _path_template = '/projects/{project_id}/modules'

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -254,7 +254,7 @@ class Project(Resource['Project']):
 
     def update_user_role(self, user_uid: Union[str, UUID], role: ROLES, actions: ACTIONS = []):
         """
-        Update a User's role and action permissions in the Project
+        Update a User's role and action permissions in the Project.
 
         Valid roles are MEMBER or LEAD.
 
@@ -264,22 +264,27 @@ class Project(Resource['Project']):
         -------
         bool
             Returns True if user role successfully updated
+
         """
-        self.session.checked_post(self._path() + "/users/{}".format(user_uid), {'role': role, 'actions': actions})
+        self.session.checked_post(self._path() + "/users/{}".format(user_uid),
+                                  {'role': role, 'actions': actions})
         return True
 
     def add_user(self, user_uid: Union[str, UUID]):
         """
-        Add a User to a Project
+        Add a User to a Project.
 
-        Adds User with MEMBER role to the Project. Use the update_user_rule method to change a User's role.
+        Adds User with MEMBER role to the Project.
+        Use the update_user_rule method to change a User's role.
 
         Returns
         -------
         bool
             Returns True if user successfully added
+
         """
-        self.session.checked_post(self._path() + "/users/{}".format(user_uid), {'role': MEMBER, 'actions': []})
+        self.session.checked_post(self._path() + "/users/{}".format(user_uid),
+                                  {'role': MEMBER, 'actions': []})
         return True
 
     def remove_user(self, user_uid: Union[str, UUID]) -> bool:

--- a/src/citrine/resources/project_member.py
+++ b/src/citrine/resources/project_member.py
@@ -7,12 +7,12 @@ class ProjectMember:
 
     def __init__(self,
                  user: User,
-                 project: 'Project',
+                 project: 'Project',  # noqa: F821
                  role: ROLES):
         self.user: User = user
         # To avoid circular dependency, use forward-reference for type definition
         # https://www.python.org/dev/peps/pep-0484/#forward-references
-        self.project: 'Project' = project
+        self.project: 'Project' = project  # noqa: F821
         self.role: ROLES = role
 
     def __str__(self):

--- a/src/citrine/resources/report.py
+++ b/src/citrine/resources/report.py
@@ -13,6 +13,7 @@ class ReportResource(Resource['ReportResource']):
     ----------
     project_id: UUID
         the UUID of the project
+
     """
 
     _path_template = '/projects/{project_id}/modules/{module_id}/report'

--- a/src/citrine/resources/workflow.py
+++ b/src/citrine/resources/workflow.py
@@ -17,6 +17,7 @@ class WorkflowCollection(Collection[Workflow]):
     ----------
     project_id: UUID
         the UUID of the project
+
     """
 
     _path_template = '/projects/{project_id}/workflows'


### PR DESCRIPTION
# Citrine Python PR

## Description 
The command `pytest --flake8` was no longer running the flake8 style checker during tests. This PR breaks the build into two steps, one that does tests and coverage, and the other that checks for style errors.

This PR also brings the code into flake8 compliance, mostly by modifying the structure of some docstrings.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
