### PR TITLE
Citrine v0.5.0 is released!

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-taurus-citrine==0.2.0
+taurus-citrine==0.3.0
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.14.5

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(name='citrine',
           "arrow",
           "pytest>=4.3",
           "strip-hints>=0.1.5",
-          "taurus-citrine>=0.2.0,<0.3.0",
+          "taurus-citrine>=0.3.0,<0.4.0",
           "boto3",
           "botocore"
       ],

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='citrine',
-      version='0.4.1',
+      version='0.5.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',


### PR DESCRIPTION
This forces an upgrade to [taurus v0.3.0](https://github.com/CitrineInformatics/taurus/releases/tag/v0.3.0), which supports a much larger set of units.

## What's New
* The [units list](https://github.com/CitrineInformatics/taurus/blob/master/taurus/units/citrine_en.txt) has been greatly extended.