### PR TITLE
Upgraded Arrow to silence warnings and added a Dockerfile for testing

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -1,0 +1,42 @@
+Development
+===========
+
+Development of Citrine-Python requires 100% unit test coverage, pep-8 compliance and working Sphinx documentation.
+
+Running tests in Docker
+-----------------------
+
+Running these tests in Docker will ensure that you are using a consistent development environment to Travis CI, our
+continuous integration server.  See the file .travis.yml in the repository root for more information.
+
+Build the Container
+*******************
+
+Run this command from the repository root.  This will tag the image with as "citrine-python":
+
+`docker build -f scripts/Dockerfile.pytest -t citrine-python .`
+
+Run the Tests
+*************
+
+Run the Docker container with default parameters to run all unit tests:
+
+`docker run --rm -it citrine-python`
+
+Specify a path to run all the tests in one test module, in this case 'test_table.py'.  Note: running a subset of unit
+tests will report a low unit test coverage metric:
+
+`docker run --rm -it citrine-python tests/serialization/test_table.py`
+
+Specify a specific test to run:
+
+`docker run --rm -it citrine-python tests/serialization/test_table.py::test_simple_deserialization`
+
+See the `PyTest documentation <https://docs.pytest.org/en/latest/usage.html>`_ for more information.
+
+Running an Interactive Shell
+****************************
+
+Run this command to get an interactive bash shell in the Docker container, overriding the default entrypoint:
+
+`docker run --rm -it --entrypoint bash citrine-python`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,7 @@ Table of Contents
 
    getting_started/index
    workflows/index
+   development
    FAQ/index
 
 Indices and tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 taurus-citrine==0.3.0
 requests==2.22.0
 pyjwt==1.7.1
-arrow==0.14.5
+arrow==0.15.4
 strip-hints==0.1.7
 sphinx==2.2.0
 sphinxcontrib-apidoc==0.3.0

--- a/scripts/Dockerfile.pytest
+++ b/scripts/Dockerfile.pytest
@@ -1,13 +1,17 @@
-# Developmental Docker container
+# Developmental Docker container, performing the same tasks as in .travis.yml
 FROM python:3.8
 
 WORKDIR /src
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install -U -r requirements.txt
 
 COPY test_requirements.txt .
-RUN pip install -r test_requirements.txt
+RUN pip install -U -r test_requirements.txt
 
 COPY . .
-RUN python setup.py develop
-CMD pytest
+RUN pip install --no-deps -e .
+CMD pytest --cov=src/ --cov-report term-missing \
+    --cov-report term:skip-covered \
+    --cov-fail-under=100 -s -r . \
+    && flake8 src \
+    && cd docs; make html; cd ..

--- a/scripts/Dockerfile.pytest
+++ b/scripts/Dockerfile.pytest
@@ -1,0 +1,13 @@
+# Developmental Docker container
+FROM python:3.8
+
+WORKDIR /src
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY test_requirements.txt .
+RUN pip install -r test_requirements.txt
+
+COPY . .
+RUN python setup.py develop
+CMD pytest

--- a/scripts/Dockerfile.pytest
+++ b/scripts/Dockerfile.pytest
@@ -10,8 +10,6 @@ RUN pip install -U -r test_requirements.txt
 
 COPY . .
 RUN pip install --no-deps -e .
-CMD pytest --cov=src/ --cov-report term-missing \
-    --cov-report term:skip-covered \
-    --cov-fail-under=100 -s -r . \
-    && flake8 src \
-    && cd docs; make html; cd ..
+ENTRYPOINT ["pytest", "--cov=src/", "--cov-report", "term-missing", "--cov-report", "term:skip-covered", \
+    "--cov-fail-under=100", "-s"]
+CMD ["-r", "."]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,6 +2,7 @@ flake8==3.7.8
 flake8-docstrings==1.3.1
 mock==3.0.5
 pytest==4.3.1
+pytz==2019.3
 pydocstyle==3.0.0
 pytest-cov==2.7.1
 pytest-flake8==1.0.4


### PR DESCRIPTION
# Citrine Python PR

## Description 
This is a bugfix for https://citrine.atlassian.net/browse/PLA-1900.  Using arrow.get() with a date string would raise a warning.  We're parsing ISO8601 strings so this warning does not impact us.  Upgrading to the latest version has silenced this warning.  See the Jira issue for more detail.

I added a dockerfile under the scripts directory called Dockerfile.pytest.  This is a clean way of testing code and dependencies in an isolated environment.

The bugfix was simple and no changes to the code were required so it won't impact test coverage/docstrings/pep-8 compliance or have any downstream consequences as our use of Arrow is limited to string/int/float parsing with arrow.get().

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
