### PR TITLE
Proposed fix for PLA-1952: Annotating ValueError exceptions

### DIFF
--- a/tests/_serialization/test_simple_properties.py
+++ b/tests/_serialization/test_simple_properties.py
@@ -6,6 +6,7 @@ from citrine._serialization.properties import (
     Integer,
     String,
     Float,
+    UUID,
     Datetime,
     LinkByUID,
     LinkOrElse,
@@ -50,8 +51,23 @@ def test_invalid_deserialization_type(prop_type, serialized):
         prop.deserialize(serialized)
 
 
+@pytest.mark.parametrize('prop_type,serialized', INVALID_DESERIALIZATION_TYPES)
+def test_invalid_deserialization_type_with_base_class(prop_type, serialized):
+    class BaseTest:
+        pass
+
+    prop = prop_type()
+    prop.serialization_path = 'ser_path'
+    with pytest.raises(ValueError) as excinfo:
+        prop.deserialize(serialized, base_class=BaseTest().__class__)
+
+    # Check that the exception includes the calling class name and argument
+    if not isinstance(prop, UUID):
+        assert 'BaseTest:ser_path' in str(excinfo.value)
+
+
 @pytest.mark.parametrize('prop_type,path,expected', VALID_STRINGS)
-def test_invalid_property_deserialization(prop_type, path, expected):
+def test_valid_property_deserialization(prop_type, path, expected):
     assert expected == str(prop_type(path))
 
 

--- a/tests/_serialization/test_simple_properties.py
+++ b/tests/_serialization/test_simple_properties.py
@@ -2,6 +2,7 @@ import pytest
 import arrow
 import uuid
 
+from citrine.resources.dataset import Dataset
 from citrine._serialization.properties import (
     Integer,
     String,
@@ -64,6 +65,21 @@ def test_invalid_deserialization_type_with_base_class(prop_type, serialized):
     # Check that the exception includes the calling class name and argument
     if not isinstance(prop, UUID):
         assert 'BaseTest:ser_path' in str(excinfo.value)
+
+
+@pytest.mark.parametrize('prop_type,serialized', INVALID_DESERIALIZATION_TYPES)
+def test_invalid_deserialization_type_with_dataset(prop_type, serialized):
+    # Supplying a Daatset instance as the base_class should include it's
+    # name in the exception value string (UUIDs are a special case)
+    dset = Dataset(name="dset", summary="test dataset", description="description")
+
+    prop = prop_type()
+    prop.serialization_path = 'ser_path'
+    with pytest.raises(ValueError) as excinfo:
+        prop.deserialize(serialized, base_class=dset.__class__)
+
+    if not isinstance(prop, UUID):
+        assert 'Dataset:ser_path' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('prop_type,path,expected', VALID_STRINGS)


### PR DESCRIPTION
Adding the name of the class and the invalid parameter name that
caused the exception.  Added a new optional keyword argument
called base_class to avoid breaking existing code.  Also added
a test that exercises this new path.

There was a test with a duplicate name which I corrected.

Resolves #121

# Citrine Python PR

## Description 
Please briefly explain the goal of the changes/this PR.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
