### PR TITLE
Pla 2095/audit info

### DIFF
--- a/src/citrine/resources/audit_info.py
+++ b/src/citrine/resources/audit_info.py
@@ -26,6 +26,11 @@ class AuditInfo:
         self.updated_by = updated_by
         self.updated_at = updated_at
 
+    def __repr__(self):
+        return 'Created by: {}\nCreated at: {}\nUpdated by: {}\nUpdated at: {}'.format(
+            self.created_by, self.created_at, self.updated_by, self.updated_at
+        )
+
     def __str__(self):
         create_str = 'Created by user {} at time {}'.format(
             self.created_by, self._pprint_datetime(self.created_at))

--- a/src/citrine/resources/audit_info.py
+++ b/src/citrine/resources/audit_info.py
@@ -1,0 +1,49 @@
+from typing import Optional
+import arrow
+
+
+class AuditInfo:
+    """
+    Model that holds audit metadata. AuditInfo objects should not be created by the user.
+
+    Parameters
+    ----------
+    created_by: str
+        ID of the user who created the object
+    created_at: int
+        Time, in ms since epoch, at which the object was created
+    updated_by: Optional[str]
+        ID of the user who most recently updated the object
+    updated_at: Optional[int]
+        Time, in ms since epoch, at which the object was most recently updated
+
+    """
+
+    def __init__(self, created_by: str, created_at: int,
+                 updated_by: Optional[str] = None, updated_at: Optional[int] = None):
+        self.created_by = created_by
+        self.created_at = created_at
+        self.updated_by = updated_by
+        self.updated_at = updated_at
+
+    def __repr__(self):
+        return 'Created by: {}\nCreated at: {}\nUpdated by: {}\nUpdated at: {}'.format(
+            self.created_by, self.created_at, self.updated_by, self.updated_at
+        )
+
+    def __str__(self):
+        create_str = 'Created by user {} at time {}'.format(
+            self.created_by, self._pprint_datetime(self.created_at))
+        if self.updated_by is not None or self.updated_at is not None:
+            update_str = '\nUpdated by user {} at time {}'.format(
+                self.updated_by, self._pprint_datetime(self.updated_at))
+        else:
+            update_str = ''
+        return create_str + update_str
+
+    def __eq__(self, other):
+        return self.__repr__() == other.__repr__()
+
+    @staticmethod
+    def _pprint_datetime(create_time: int):
+        return arrow.get(create_time / 1000).datetime

--- a/src/citrine/resources/audit_info.py
+++ b/src/citrine/resources/audit_info.py
@@ -1,8 +1,12 @@
 from typing import Optional
-import arrow
+from uuid import UUID
+from datetime import datetime
+
+from citrine._serialization.serializable import Serializable
+from citrine._serialization import properties
 
 
-class AuditInfo:
+class AuditInfo(Serializable):
     """
     Model that holds audit metadata. AuditInfo objects should not be created by the user.
 
@@ -19,31 +23,32 @@ class AuditInfo:
 
     """
 
-    def __init__(self, created_by: str, created_at: int,
-                 updated_by: Optional[str] = None, updated_at: Optional[int] = None):
+    created_by = properties.UUID('created_by')
+    created_at = properties.Datetime('created_at')
+    updated_by = properties.Optional(properties.UUID, 'updated_by')
+    updated_at = properties.Optional(properties.Datetime, 'updated_at')
+
+    def __init__(self, created_by: UUID, created_at: datetime,
+                 updated_by: Optional[UUID] = None, updated_at: Optional[datetime] = None):
         self.created_by = created_by
         self.created_at = created_at
         self.updated_by = updated_by
         self.updated_at = updated_at
 
     def __repr__(self):
-        return 'Created by: {}\nCreated at: {}\nUpdated by: {}\nUpdated at: {}'.format(
+        return 'Created by: {!r}\nCreated at: {!r}\nUpdated by: {!r}\nUpdated at: {!r}'.format(
             self.created_by, self.created_at, self.updated_by, self.updated_at
         )
 
     def __str__(self):
         create_str = 'Created by user {} at time {}'.format(
-            self.created_by, self._pprint_datetime(self.created_at))
+            self.created_by, self.created_at)
         if self.updated_by is not None or self.updated_at is not None:
             update_str = '\nUpdated by user {} at time {}'.format(
-                self.updated_by, self._pprint_datetime(self.updated_at))
+                self.updated_by, self.updated_at)
         else:
             update_str = ''
         return create_str + update_str
 
     def __eq__(self, other):
         return self.__repr__() == other.__repr__()
-
-    @staticmethod
-    def _pprint_datetime(create_time: int):
-        return arrow.get(create_time / 1000).datetime

--- a/src/citrine/resources/audit_info.py
+++ b/src/citrine/resources/audit_info.py
@@ -26,11 +26,6 @@ class AuditInfo:
         self.updated_by = updated_by
         self.updated_at = updated_at
 
-    def __repr__(self):
-        return 'Created by: {}\nCreated at: {}\nUpdated by: {}\nUpdated at: {}'.format(
-            self.created_by, self.created_at, self.updated_by, self.updated_at
-        )
-
     def __str__(self):
         create_str = 'Created by user {} at time {}'.format(
             self.created_by, self._pprint_datetime(self.created_at))

--- a/src/citrine/resources/condition_template.py
+++ b/src/citrine/resources/condition_template.py
@@ -36,6 +36,8 @@ class ConditionTemplate(DataConcepts, Resource['ConditionTemplate'], TaurusCondi
 
     _response_key = TaurusConditionTemplate.typ  # 'condition_template'
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')

--- a/src/citrine/resources/condition_template.py
+++ b/src/citrine/resources/condition_template.py
@@ -1,5 +1,5 @@
 """Resources that represent condition templates."""
-from typing import List, Dict, Optional, Type
+from typing import List, Dict, Optional, Type, Any
 
 from citrine._rest.resource import Resource
 from citrine._serialization.properties import String, Mapping, Object
@@ -50,8 +50,9 @@ class ConditionTemplate(DataConcepts, Resource['ConditionTemplate'], TaurusCondi
                  bounds: BaseBounds,
                  uids: Optional[Dict[str, str]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None):
-        DataConcepts.__init__(self, TaurusConditionTemplate.typ)
+                 tags: Optional[List[str]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusConditionTemplate.typ, audit_info=audit_info)
         TaurusConditionTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
                                          uids=set_default_uid(uids), description=description)
 

--- a/src/citrine/resources/condition_template.py
+++ b/src/citrine/resources/condition_template.py
@@ -1,5 +1,5 @@
 """Resources that represent condition templates."""
-from typing import List, Dict, Optional, Type, Any
+from typing import List, Dict, Optional, Type
 
 from citrine._rest.resource import Resource
 from citrine._serialization.properties import String, Mapping, Object
@@ -7,11 +7,12 @@ from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from taurus.entity.template.condition_template import ConditionTemplate as TaurusConditionTemplate
 from taurus.entity.bounds.base_bounds import BaseBounds
 
 
-class ConditionTemplate(DataConcepts, Resource['ConditionTemplate'], TaurusConditionTemplate):
+class ConditionTemplate(Storable, Resource['ConditionTemplate'], TaurusConditionTemplate):
     """
     A condition template.
 
@@ -36,8 +37,6 @@ class ConditionTemplate(DataConcepts, Resource['ConditionTemplate'], TaurusCondi
 
     _response_key = TaurusConditionTemplate.typ  # 'condition_template'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')
@@ -50,9 +49,8 @@ class ConditionTemplate(DataConcepts, Resource['ConditionTemplate'], TaurusCondi
                  bounds: BaseBounds,
                  uids: Optional[Dict[str, str]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusConditionTemplate.typ, audit_info=audit_info)
+                 tags: Optional[List[str]] = None):
+        DataConcepts.__init__(self, TaurusConditionTemplate.typ)
         TaurusConditionTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
                                          uids=set_default_uid(uids), description=description)
 

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -11,6 +11,7 @@ from citrine._serialization.serializable import Serializable
 from citrine._serialization.properties import Property, LinkOrElse, Object
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
+from citrine.resources.audit_info import AuditInfo
 from citrine._utils.functions import (
     validate_type, scrub_none,
     replace_objects_with_links, get_object_id)
@@ -59,7 +60,12 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
     def __init__(self, typ: str, audit_info: Optional[Dict[str, Any]] = None):
         self.typ = typ
         self.session = None
-        self.audit_info = audit_info
+        if audit_info is None:
+            audit_info = dict()
+        self.audit_info = AuditInfo(created_by=audit_info.get('created_by', None),
+                                    created_at=audit_info.get('created_at', None),
+                                    updated_by=audit_info.get('updated_by', None),
+                                    updated_at=audit_info.get('updated_at', None))
 
     @classmethod
     def build(cls, data: dict, session: Session = None):
@@ -107,10 +113,8 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
         data_copy_dict.pop(DataConcepts._type_key, None)
         cls._build_child_objects(data_copy_dict, data)
 
-        data_concepts_object = cls(**data_copy_dict)
+        data_concepts_object = cls(**data_copy_dict, **client_only_dict)
         data_concepts_object.session = session
-        for client_key in cls._client_keys:
-            setattr(data_concepts_object, client_key, client_only_dict.get(client_key))
 
         cls._build_discarded_objects(data_concepts_object, data, session)
         return data_concepts_object

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -145,7 +145,7 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
         Parameters
         ----------
         data: dict or object
-            From which to pop the value of hte field
+            From which to pop the value of the field
         field: str
             The name of the field
 

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -110,7 +110,7 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
         data_concepts_object = cls(**data_copy_dict)
         data_concepts_object.session = session
         for client_key in cls._client_keys:
-            data_concepts_object.__setattr__(client_key, client_only_dict.get(client_key))
+            setattr(data_concepts_object, client_key, client_only_dict.get(client_key))
 
         cls._build_discarded_objects(data_concepts_object, data, session)
         return data_concepts_object

--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -1,5 +1,5 @@
 """Resources that represent ingredient run data objects."""
-from typing import List, Dict, Optional, Type
+from typing import List, Dict, Optional, Type, Any
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
@@ -93,8 +93,9 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
                  absolute_quantity: Optional[ContinuousValue] = None,
                  labels: Optional[List[str]] = None,
                  spec: Optional[TaurusIngredientSpec] = None,
-                 file_links: Optional[List[FileLink]] = None):
-        DataConcepts.__init__(self, TaurusIngredientRun.typ)
+                 file_links: Optional[List[FileLink]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusIngredientRun.typ, audit_info=audit_info)
         TaurusIngredientRun.__init__(self, uids=set_default_uid(uids), tags=tags, notes=notes,
                                      material=material, process=process,
                                      mass_fraction=mass_fraction, volume_fraction=volume_fraction,

--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -62,6 +62,8 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
 
     _response_key = TaurusIngredientRun.typ  # 'ingredient_run'
 
+    _client_keys = ["audit_info"]
+
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
     notes = PropertyOptional(String(), 'notes')

--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -1,9 +1,10 @@
 """Resources that represent ingredient run data objects."""
-from typing import List, Dict, Optional, Type, Any
+from typing import List, Dict, Optional, Type
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
 from citrine.resources.data_concepts import DataConceptsCollection, DataConcepts
+from citrine.resources.storable import Storable
 from citrine._serialization.properties import Mapping, String, LinkOrElse, Object
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
@@ -15,7 +16,7 @@ from taurus.entity.object.process_run import ProcessRun as TaurusProcessRun
 from taurus.entity.value.continuous_value import ContinuousValue
 
 
-class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun):
+class IngredientRun(Storable, Resource['IngredientRun'], TaurusIngredientRun):
     """
     An ingredient run.
 
@@ -62,8 +63,6 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
 
     _response_key = TaurusIngredientRun.typ  # 'ingredient_run'
 
-    _client_keys = ["audit_info"]
-
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
     notes = PropertyOptional(String(), 'notes')
@@ -93,9 +92,8 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
                  absolute_quantity: Optional[ContinuousValue] = None,
                  labels: Optional[List[str]] = None,
                  spec: Optional[TaurusIngredientSpec] = None,
-                 file_links: Optional[List[FileLink]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusIngredientRun.typ, audit_info=audit_info)
+                 file_links: Optional[List[FileLink]] = None):
+        DataConcepts.__init__(self, TaurusIngredientRun.typ)
         TaurusIngredientRun.__init__(self, uids=set_default_uid(uids), tags=tags, notes=notes,
                                      material=material, process=process,
                                      mass_fraction=mass_fraction, volume_fraction=volume_fraction,

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -59,6 +59,8 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
 
     _response_key = TaurusIngredientSpec.typ  # 'ingredient_spec'
 
+    _client_keys = ["audit_info"]
+
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
     notes = PropertyOptional(String(), 'notes')

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -1,5 +1,5 @@
 """Resources that represent ingredient spec data objects."""
-from typing import List, Dict, Optional, Type
+from typing import List, Dict, Optional, Type, Any
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
@@ -88,8 +88,9 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
                  number_fraction: Optional[ContinuousValue] = None,
                  absolute_quantity: Optional[ContinuousValue] = None,
                  labels: Optional[List[str]] = None,
-                 file_links: Optional[List[FileLink]] = None):
-        DataConcepts.__init__(self, TaurusIngredientSpec.typ)
+                 file_links: Optional[List[FileLink]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusIngredientSpec.typ, audit_info=audit_info)
         TaurusIngredientSpec.__init__(self, uids=set_default_uid(uids), tags=tags, notes=notes,
                                       material=material, process=process,
                                       mass_fraction=mass_fraction, volume_fraction=volume_fraction,

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -1,9 +1,10 @@
 """Resources that represent ingredient spec data objects."""
-from typing import List, Dict, Optional, Type, Any
+from typing import List, Dict, Optional, Type
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
 from citrine.resources.data_concepts import DataConceptsCollection, DataConcepts
+from citrine.resources.storable import Storable
 from citrine._serialization.properties import Mapping, String, LinkOrElse, Object
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
@@ -14,7 +15,7 @@ from taurus.entity.object.material_spec import MaterialSpec as TaurusMaterialSpe
 from taurus.entity.value.continuous_value import ContinuousValue
 
 
-class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientSpec):
+class IngredientSpec(Storable, Resource['IngredientSpec'], TaurusIngredientSpec):
     """
     An ingredient specification.
 
@@ -59,8 +60,6 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
 
     _response_key = TaurusIngredientSpec.typ  # 'ingredient_spec'
 
-    _client_keys = ["audit_info"]
-
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
     notes = PropertyOptional(String(), 'notes')
@@ -88,9 +87,8 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
                  number_fraction: Optional[ContinuousValue] = None,
                  absolute_quantity: Optional[ContinuousValue] = None,
                  labels: Optional[List[str]] = None,
-                 file_links: Optional[List[FileLink]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusIngredientSpec.typ, audit_info=audit_info)
+                 file_links: Optional[List[FileLink]] = None):
+        DataConcepts.__init__(self, TaurusIngredientSpec.typ)
         TaurusIngredientSpec.__init__(self, uids=set_default_uid(uids), tags=tags, notes=notes,
                                       material=material, process=process,
                                       mass_fraction=mass_fraction, volume_fraction=volume_fraction,

--- a/src/citrine/resources/material_run.py
+++ b/src/citrine/resources/material_run.py
@@ -1,5 +1,5 @@
 """Resources that represent material run data objects."""
-from typing import List, Dict, Optional, Type, Any
+from typing import List, Dict, Optional, Type
 import os
 import json
 
@@ -7,6 +7,7 @@ from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
 from citrine._session import Session
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from citrine._serialization.properties import String, LinkOrElse, Mapping, Object
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
@@ -18,7 +19,7 @@ from taurus.entity.object.material_spec import MaterialSpec as TaurusMaterialSpe
 from taurus.client.json_encoder import loads
 
 
-class MaterialRun(DataConcepts, Resource['MaterialRun'], TaurusMaterialRun):
+class MaterialRun(Storable, Resource['MaterialRun'], TaurusMaterialRun):
     """
     A material run.
 
@@ -56,8 +57,6 @@ class MaterialRun(DataConcepts, Resource['MaterialRun'], TaurusMaterialRun):
 
     _response_key = TaurusMaterialRun.typ  # 'material_run'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
@@ -76,9 +75,8 @@ class MaterialRun(DataConcepts, Resource['MaterialRun'], TaurusMaterialRun):
                  process: Optional[TaurusProcessRun] = None,
                  sample_type: Optional[str] = "unknown",
                  spec: Optional[TaurusMaterialSpec] = None,
-                 file_links: Optional[List[FileLink]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusMaterialRun.typ, audit_info=audit_info)
+                 file_links: Optional[List[FileLink]] = None):
+        DataConcepts.__init__(self, TaurusMaterialRun.typ)
         TaurusMaterialRun.__init__(self, name=name, uids=set_default_uid(uids),
                                    tags=tags, process=process,
                                    sample_type=sample_type, spec=spec,

--- a/src/citrine/resources/material_run.py
+++ b/src/citrine/resources/material_run.py
@@ -1,5 +1,5 @@
 """Resources that represent material run data objects."""
-from typing import List, Dict, Optional, Type
+from typing import List, Dict, Optional, Type, Any
 import os
 import json
 
@@ -76,8 +76,9 @@ class MaterialRun(DataConcepts, Resource['MaterialRun'], TaurusMaterialRun):
                  process: Optional[TaurusProcessRun] = None,
                  sample_type: Optional[str] = "unknown",
                  spec: Optional[TaurusMaterialSpec] = None,
-                 file_links: Optional[List[FileLink]] = None):
-        DataConcepts.__init__(self, TaurusMaterialRun.typ)
+                 file_links: Optional[List[FileLink]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusMaterialRun.typ, audit_info=audit_info)
         TaurusMaterialRun.__init__(self, name=name, uids=set_default_uid(uids),
                                    tags=tags, process=process,
                                    sample_type=sample_type, spec=spec,

--- a/src/citrine/resources/material_run.py
+++ b/src/citrine/resources/material_run.py
@@ -56,6 +56,8 @@ class MaterialRun(DataConcepts, Resource['MaterialRun'], TaurusMaterialRun):
 
     _response_key = TaurusMaterialRun.typ  # 'material_run'
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')

--- a/src/citrine/resources/material_spec.py
+++ b/src/citrine/resources/material_spec.py
@@ -1,9 +1,10 @@
 """Resources that represent material spec data objects."""
-from typing import List, Dict, Optional, Type, Any
+from typing import List, Dict, Optional, Type
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from citrine._serialization.properties import String, LinkOrElse, Mapping, Object
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
@@ -14,7 +15,7 @@ from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 from taurus.entity.template.material_template import MaterialTemplate as TaurusMaterialTemplate
 
 
-class MaterialSpec(DataConcepts, Resource['MaterialSpec'], TaurusMaterialSpec):
+class MaterialSpec(Storable, Resource['MaterialSpec'], TaurusMaterialSpec):
     """
     A material specification.
 
@@ -46,8 +47,6 @@ class MaterialSpec(DataConcepts, Resource['MaterialSpec'], TaurusMaterialSpec):
 
     _response_key = TaurusMaterialSpec.typ  # 'material_spec'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
@@ -66,9 +65,8 @@ class MaterialSpec(DataConcepts, Resource['MaterialSpec'], TaurusMaterialSpec):
                  process: Optional[TaurusProcessSpec] = None,
                  properties: Optional[List[PropertyAndConditions]] = None,
                  template: Optional[TaurusMaterialTemplate] = None,
-                 file_links: Optional[List[FileLink]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusMaterialSpec.typ, audit_info=audit_info)
+                 file_links: Optional[List[FileLink]] = None):
+        DataConcepts.__init__(self, TaurusMaterialSpec.typ)
         TaurusMaterialSpec.__init__(self, name=name, uids=set_default_uid(uids),
                                     tags=tags, process=process, properties=properties,
                                     template=template, file_links=file_links, notes=notes)

--- a/src/citrine/resources/material_spec.py
+++ b/src/citrine/resources/material_spec.py
@@ -46,6 +46,8 @@ class MaterialSpec(DataConcepts, Resource['MaterialSpec'], TaurusMaterialSpec):
 
     _response_key = TaurusMaterialSpec.typ  # 'material_spec'
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')

--- a/src/citrine/resources/material_spec.py
+++ b/src/citrine/resources/material_spec.py
@@ -1,5 +1,5 @@
 """Resources that represent material spec data objects."""
-from typing import List, Dict, Optional, Type
+from typing import List, Dict, Optional, Type, Any
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
@@ -66,8 +66,9 @@ class MaterialSpec(DataConcepts, Resource['MaterialSpec'], TaurusMaterialSpec):
                  process: Optional[TaurusProcessSpec] = None,
                  properties: Optional[List[PropertyAndConditions]] = None,
                  template: Optional[TaurusMaterialTemplate] = None,
-                 file_links: Optional[List[FileLink]] = None):
-        DataConcepts.__init__(self, TaurusMaterialSpec.typ)
+                 file_links: Optional[List[FileLink]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusMaterialSpec.typ, audit_info=audit_info)
         TaurusMaterialSpec.__init__(self, name=name, uids=set_default_uid(uids),
                                     tags=tags, process=process, properties=properties,
                                     template=template, file_links=file_links, notes=notes)

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -1,5 +1,5 @@
 """Resources that represent material templates."""
-from typing import List, Dict, Optional, Union, Sequence, Type, Any
+from typing import List, Dict, Optional, Union, Sequence, Type
 
 from citrine._rest.resource import Resource
 from citrine._session import Session
@@ -8,6 +8,7 @@ from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from citrine.resources.property_template import PropertyTemplate
 from taurus.client.json_encoder import loads, dumps
 from taurus.entity.template.material_template import MaterialTemplate as TaurusMaterialTemplate
@@ -15,7 +16,7 @@ from taurus.entity.bounds.base_bounds import BaseBounds
 from taurus.entity.link_by_uid import LinkByUID
 
 
-class MaterialTemplate(DataConcepts, Resource['MaterialTemplate'], TaurusMaterialTemplate):
+class MaterialTemplate(Storable, Resource['MaterialTemplate'], TaurusMaterialTemplate):
     """
     A material template.
 
@@ -47,8 +48,6 @@ class MaterialTemplate(DataConcepts, Resource['MaterialTemplate'], TaurusMateria
 
     _response_key = TaurusMaterialTemplate.typ  # 'material_template'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')
@@ -66,12 +65,11 @@ class MaterialTemplate(DataConcepts, Resource['MaterialTemplate'], TaurusMateria
                                                                     BaseBounds]]
                                                      ]]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
+                 tags: Optional[List[str]] = None):
         # properties is a list, each element of which is a PropertyTemplate OR is a list with
         # 2 entries: [PropertyTemplate, BaseBounds]. Python typing is not expressive enough, so
         # the typing above is more general.
-        DataConcepts.__init__(self, TaurusMaterialTemplate.typ, audit_info=audit_info)
+        DataConcepts.__init__(self, TaurusMaterialTemplate.typ)
         TaurusMaterialTemplate.__init__(self, name=name, properties=properties,
                                         uids=set_default_uid(uids), tags=tags,
                                         description=description)

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -76,7 +76,7 @@ class MaterialTemplate(DataConcepts, Resource['MaterialTemplate'], TaurusMateria
                                         description=description)
 
     @classmethod
-    def _build_child_objects(cls, data: dict, session: Session = None):
+    def _build_child_objects(cls, data: dict, data_with_soft_links, session: Session = None):
         """
         Build the property templates and bounds.
 

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -47,6 +47,8 @@ class MaterialTemplate(DataConcepts, Resource['MaterialTemplate'], TaurusMateria
 
     _response_key = TaurusMaterialTemplate.typ  # 'material_template'
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -1,5 +1,5 @@
 """Resources that represent material templates."""
-from typing import List, Dict, Optional, Union, Sequence, Type
+from typing import List, Dict, Optional, Union, Sequence, Type, Any
 
 from citrine._rest.resource import Resource
 from citrine._session import Session
@@ -66,11 +66,12 @@ class MaterialTemplate(DataConcepts, Resource['MaterialTemplate'], TaurusMateria
                                                                     BaseBounds]]
                                                      ]]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None):
+                 tags: Optional[List[str]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
         # properties is a list, each element of which is a PropertyTemplate OR is a list with
         # 2 entries: [PropertyTemplate, BaseBounds]. Python typing is not expressive enough, so
         # the typing above is more general.
-        DataConcepts.__init__(self, TaurusMaterialTemplate.typ)
+        DataConcepts.__init__(self, TaurusMaterialTemplate.typ, audit_info=audit_info)
         TaurusMaterialTemplate.__init__(self, name=name, properties=properties,
                                         uids=set_default_uid(uids), tags=tags,
                                         description=description)

--- a/src/citrine/resources/measurement_run.py
+++ b/src/citrine/resources/measurement_run.py
@@ -56,6 +56,8 @@ class MeasurementRun(DataConcepts, Resource['MeasurementRun'], TaurusMeasurement
 
     _response_key = TaurusMeasurementRun.typ  # 'measurement_run'
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')

--- a/src/citrine/resources/measurement_run.py
+++ b/src/citrine/resources/measurement_run.py
@@ -83,7 +83,6 @@ class MeasurementRun(Storable, Resource['MeasurementRun'], TaurusMeasurementRun)
                  file_links: Optional[List[FileLink]] = None,
                  source: Optional[PerformedSource] = None):
         DataConcepts.__init__(self, TaurusMeasurementRun.typ)
-        self._audit_info = None
         TaurusMeasurementRun.__init__(self, name=name, uids=set_default_uid(uids),
                                       material=material,
                                       tags=tags, conditions=conditions, properties=properties,

--- a/src/citrine/resources/measurement_run.py
+++ b/src/citrine/resources/measurement_run.py
@@ -1,5 +1,5 @@
 """Resources that represent measurement run data objects."""
-from typing import List, Dict, Optional, Type
+from typing import List, Dict, Optional, Type, Any
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
@@ -82,8 +82,9 @@ class MeasurementRun(DataConcepts, Resource['MeasurementRun'], TaurusMeasurement
                  spec: Optional[TaurusMeasurementSpec] = None,
                  material: Optional[TaurusMaterialRun] = None,
                  file_links: Optional[List[FileLink]] = None,
-                 source: Optional[PerformedSource] = None):
-        DataConcepts.__init__(self, TaurusMeasurementRun.typ)
+                 source: Optional[PerformedSource] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusMeasurementRun.typ, audit_info=audit_info)
         TaurusMeasurementRun.__init__(self, name=name, uids=set_default_uid(uids),
                                       material=material,
                                       tags=tags, conditions=conditions, properties=properties,

--- a/src/citrine/resources/measurement_run.py
+++ b/src/citrine/resources/measurement_run.py
@@ -1,5 +1,5 @@
 """Resources that represent measurement run data objects."""
-from typing import List, Dict, Optional, Type, Any
+from typing import List, Dict, Optional, Type
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
@@ -7,6 +7,7 @@ from citrine._serialization.properties import String, Object, Mapping, LinkOrEls
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from taurus.entity.file_link import FileLink
 from citrine.attributes.condition import Condition
 from citrine.attributes.parameter import Parameter
@@ -17,7 +18,7 @@ from taurus.entity.object.measurement_spec import MeasurementSpec as TaurusMeasu
 from taurus.entity.source.performed_source import PerformedSource
 
 
-class MeasurementRun(DataConcepts, Resource['MeasurementRun'], TaurusMeasurementRun):
+class MeasurementRun(Storable, Resource['MeasurementRun'], TaurusMeasurementRun):
     """
     A measurement run.
 
@@ -56,8 +57,6 @@ class MeasurementRun(DataConcepts, Resource['MeasurementRun'], TaurusMeasurement
 
     _response_key = TaurusMeasurementRun.typ  # 'measurement_run'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
@@ -82,9 +81,9 @@ class MeasurementRun(DataConcepts, Resource['MeasurementRun'], TaurusMeasurement
                  spec: Optional[TaurusMeasurementSpec] = None,
                  material: Optional[TaurusMaterialRun] = None,
                  file_links: Optional[List[FileLink]] = None,
-                 source: Optional[PerformedSource] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusMeasurementRun.typ, audit_info=audit_info)
+                 source: Optional[PerformedSource] = None):
+        DataConcepts.__init__(self, TaurusMeasurementRun.typ)
+        self._audit_info = None
         TaurusMeasurementRun.__init__(self, name=name, uids=set_default_uid(uids),
                                       material=material,
                                       tags=tags, conditions=conditions, properties=properties,

--- a/src/citrine/resources/measurement_spec.py
+++ b/src/citrine/resources/measurement_spec.py
@@ -1,5 +1,5 @@
 """Resources that represent measurement spec data objects."""
-from typing import List, Dict, Optional, Type
+from typing import List, Dict, Optional, Type, Any
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
@@ -67,8 +67,9 @@ class MeasurementSpec(DataConcepts, Resource['MeasurementSpec'], TaurusMeasureme
                  conditions: Optional[List[Condition]] = None,
                  parameters: Optional[List[Parameter]] = None,
                  template: Optional[TaurusMeasurementTemplate] = None,
-                 file_links: Optional[List[FileLink]] = None):
-        DataConcepts.__init__(self, TaurusMeasurementSpec.typ)
+                 file_links: Optional[List[FileLink]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusMeasurementSpec.typ, audit_info=audit_info)
         TaurusMeasurementSpec.__init__(self, name=name, uids=set_default_uid(uids),
                                        tags=tags, conditions=conditions, parameters=parameters,
                                        template=template, file_links=file_links, notes=notes)

--- a/src/citrine/resources/measurement_spec.py
+++ b/src/citrine/resources/measurement_spec.py
@@ -1,5 +1,5 @@
 """Resources that represent measurement spec data objects."""
-from typing import List, Dict, Optional, Type, Any
+from typing import List, Dict, Optional, Type
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
@@ -7,6 +7,7 @@ from citrine._serialization.properties import String, Object, Mapping, LinkOrEls
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from taurus.entity.file_link import FileLink
 from citrine.attributes.condition import Condition
 from citrine.attributes.parameter import Parameter
@@ -15,7 +16,7 @@ from taurus.entity.template.measurement_template import \
     MeasurementTemplate as TaurusMeasurementTemplate
 
 
-class MeasurementSpec(DataConcepts, Resource['MeasurementSpec'], TaurusMeasurementSpec):
+class MeasurementSpec(Storable, Resource['MeasurementSpec'], TaurusMeasurementSpec):
     """
     A measurement specification.
 
@@ -47,8 +48,6 @@ class MeasurementSpec(DataConcepts, Resource['MeasurementSpec'], TaurusMeasureme
 
     _response_key = TaurusMeasurementSpec.typ  # 'measurement_spec'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
@@ -67,9 +66,8 @@ class MeasurementSpec(DataConcepts, Resource['MeasurementSpec'], TaurusMeasureme
                  conditions: Optional[List[Condition]] = None,
                  parameters: Optional[List[Parameter]] = None,
                  template: Optional[TaurusMeasurementTemplate] = None,
-                 file_links: Optional[List[FileLink]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusMeasurementSpec.typ, audit_info=audit_info)
+                 file_links: Optional[List[FileLink]] = None):
+        DataConcepts.__init__(self, TaurusMeasurementSpec.typ)
         TaurusMeasurementSpec.__init__(self, name=name, uids=set_default_uid(uids),
                                        tags=tags, conditions=conditions, parameters=parameters,
                                        template=template, file_links=file_links, notes=notes)

--- a/src/citrine/resources/measurement_spec.py
+++ b/src/citrine/resources/measurement_spec.py
@@ -47,6 +47,8 @@ class MeasurementSpec(DataConcepts, Resource['MeasurementSpec'], TaurusMeasureme
 
     _response_key = TaurusMeasurementSpec.typ  # 'measurement_spec'
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -1,5 +1,5 @@
 """Resources that represent measurement templates."""
-from typing import List, Dict, Optional, Union, Sequence, Type
+from typing import List, Dict, Optional, Union, Sequence, Type, Any
 
 from citrine._rest.resource import Resource
 from citrine._session import Session
@@ -94,8 +94,9 @@ class MeasurementTemplate(DataConcepts, Resource['MeasurementTemplate'],
                                                                     BaseBounds]]
                                                      ]]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None):
-        DataConcepts.__init__(self, TaurusMeasurementTemplate.typ)
+                 tags: Optional[List[str]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusMeasurementTemplate.typ, audit_info=audit_info)
         TaurusMeasurementTemplate.__init__(self, name=name, properties=properties,
                                            conditions=conditions, parameters=parameters, tags=tags,
                                            uids=set_default_uid(uids), description=description)

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -61,6 +61,8 @@ class MeasurementTemplate(DataConcepts, Resource['MeasurementTemplate'],
 
     _response_key = TaurusMeasurementTemplate.typ  # 'measurement_template'
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -101,7 +101,7 @@ class MeasurementTemplate(DataConcepts, Resource['MeasurementTemplate'],
                                            uids=set_default_uid(uids), description=description)
 
     @classmethod
-    def _build_child_objects(cls, data: dict, session: Session = None):
+    def _build_child_objects(cls, data: dict, data_with_soft_links, session: Session = None):
         """
         Build the condition, parameter, and property templates and bounds.
 

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -1,5 +1,5 @@
 """Resources that represent measurement templates."""
-from typing import List, Dict, Optional, Union, Sequence, Type, Any
+from typing import List, Dict, Optional, Union, Sequence, Type
 
 from citrine._rest.resource import Resource
 from citrine._session import Session
@@ -8,6 +8,7 @@ from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from citrine.resources.property_template import PropertyTemplate
 from citrine.resources.parameter_template import ParameterTemplate
 from citrine.resources.condition_template import ConditionTemplate
@@ -18,8 +19,7 @@ from taurus.entity.bounds.base_bounds import BaseBounds
 from taurus.entity.link_by_uid import LinkByUID
 
 
-class MeasurementTemplate(DataConcepts, Resource['MeasurementTemplate'],
-                          TaurusMeasurementTemplate):
+class MeasurementTemplate(Storable, Resource['MeasurementTemplate'], TaurusMeasurementTemplate):
     """
     A measurement template.
 
@@ -61,8 +61,6 @@ class MeasurementTemplate(DataConcepts, Resource['MeasurementTemplate'],
 
     _response_key = TaurusMeasurementTemplate.typ  # 'measurement_template'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')
@@ -94,9 +92,8 @@ class MeasurementTemplate(DataConcepts, Resource['MeasurementTemplate'],
                                                                     BaseBounds]]
                                                      ]]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusMeasurementTemplate.typ, audit_info=audit_info)
+                 tags: Optional[List[str]] = None):
+        DataConcepts.__init__(self, TaurusMeasurementTemplate.typ)
         TaurusMeasurementTemplate.__init__(self, name=name, properties=properties,
                                            conditions=conditions, parameters=parameters, tags=tags,
                                            uids=set_default_uid(uids), description=description)

--- a/src/citrine/resources/parameter_template.py
+++ b/src/citrine/resources/parameter_template.py
@@ -36,6 +36,8 @@ class ParameterTemplate(DataConcepts, Resource['ParameterTemplate'], TaurusParam
 
     _response_key = TaurusParameterTemplate.typ  # 'parameter_template'
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')

--- a/src/citrine/resources/parameter_template.py
+++ b/src/citrine/resources/parameter_template.py
@@ -1,5 +1,5 @@
 """Resources that represent parameter templates."""
-from typing import List, Dict, Optional, Type, Any
+from typing import List, Dict, Optional, Type
 
 from citrine._rest.resource import Resource
 from citrine._serialization.properties import String, Mapping, Object
@@ -7,11 +7,12 @@ from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from taurus.entity.template.parameter_template import ParameterTemplate as TaurusParameterTemplate
 from taurus.entity.bounds.base_bounds import BaseBounds
 
 
-class ParameterTemplate(DataConcepts, Resource['ParameterTemplate'], TaurusParameterTemplate):
+class ParameterTemplate(Storable, Resource['ParameterTemplate'], TaurusParameterTemplate):
     """
     A parameter template.
 
@@ -36,8 +37,6 @@ class ParameterTemplate(DataConcepts, Resource['ParameterTemplate'], TaurusParam
 
     _response_key = TaurusParameterTemplate.typ  # 'parameter_template'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')
@@ -50,9 +49,8 @@ class ParameterTemplate(DataConcepts, Resource['ParameterTemplate'], TaurusParam
                  bounds: BaseBounds,
                  uids: Optional[Dict[str, str]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusParameterTemplate.typ, audit_info=audit_info)
+                 tags: Optional[List[str]] = None):
+        DataConcepts.__init__(self, TaurusParameterTemplate.typ)
         TaurusParameterTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
                                          uids=set_default_uid(uids), description=description)
 

--- a/src/citrine/resources/parameter_template.py
+++ b/src/citrine/resources/parameter_template.py
@@ -1,5 +1,5 @@
 """Resources that represent parameter templates."""
-from typing import List, Dict, Optional, Type
+from typing import List, Dict, Optional, Type, Any
 
 from citrine._rest.resource import Resource
 from citrine._serialization.properties import String, Mapping, Object
@@ -50,8 +50,9 @@ class ParameterTemplate(DataConcepts, Resource['ParameterTemplate'], TaurusParam
                  bounds: BaseBounds,
                  uids: Optional[Dict[str, str]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None):
-        DataConcepts.__init__(self, TaurusParameterTemplate.typ)
+                 tags: Optional[List[str]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusParameterTemplate.typ, audit_info=audit_info)
         TaurusParameterTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
                                          uids=set_default_uid(uids), description=description)
 

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -61,6 +61,8 @@ class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
 
     _response_key = TaurusProcessRun.typ  # 'process_run'
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -1,5 +1,5 @@
 """Resources that represent process run data objects."""
-from typing import List, Dict, Optional, Type, Any
+from typing import List, Dict, Optional, Type
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
@@ -8,6 +8,7 @@ from citrine._serialization.properties import String, Mapping, Object, LinkOrEls
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from citrine.attributes.condition import Condition
 from citrine.attributes.parameter import Parameter
 from taurus.entity.file_link import FileLink
@@ -16,7 +17,7 @@ from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 from taurus.entity.source.performed_source import PerformedSource
 
 
-class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
+class ProcessRun(Storable, Resource['ProcessRun'], TaurusProcessRun):
     """
     A process run.
 
@@ -61,8 +62,6 @@ class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
 
     _response_key = TaurusProcessRun.typ  # 'process_run'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
@@ -83,9 +82,8 @@ class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
                  parameters: Optional[List[Parameter]] = None,
                  spec: Optional[TaurusProcessSpec] = None,
                  file_links: Optional[List[FileLink]] = None,
-                 source: Optional[PerformedSource] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusProcessRun.typ, audit_info=audit_info)
+                 source: Optional[PerformedSource] = None):
+        DataConcepts.__init__(self, TaurusProcessRun.typ)
         TaurusProcessRun.__init__(self, name=name, uids=set_default_uid(uids),
                                   tags=tags, conditions=conditions, parameters=parameters,
                                   spec=spec, file_links=file_links, notes=notes, source=source)

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -1,5 +1,5 @@
 """Resources that represent process run data objects."""
-from typing import List, Dict, Optional, Type
+from typing import List, Dict, Optional, Type, Any
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
@@ -83,8 +83,9 @@ class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
                  parameters: Optional[List[Parameter]] = None,
                  spec: Optional[TaurusProcessSpec] = None,
                  file_links: Optional[List[FileLink]] = None,
-                 source: Optional[PerformedSource] = None):
-        DataConcepts.__init__(self, TaurusProcessRun.typ)
+                 source: Optional[PerformedSource] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusProcessRun.typ, audit_info=audit_info)
         TaurusProcessRun.__init__(self, name=name, uids=set_default_uid(uids),
                                   tags=tags, conditions=conditions, parameters=parameters,
                                   spec=spec, file_links=file_links, notes=notes, source=source)

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -58,6 +58,8 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
 
     _response_key = TaurusProcessSpec.typ  # 'process_spec"
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -56,7 +56,7 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
 
     """
 
-    _response_key = TaurusProcessSpec.typ  # 'process_spec"
+    _response_key = TaurusProcessSpec.typ  # 'process_spec'
 
     _client_keys = ["audit_info"]
 

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -1,5 +1,5 @@
 """Resources that represent process spec objects."""
-from typing import Optional, Dict, List, Type
+from typing import Optional, Dict, List, Type, Any
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
@@ -78,8 +78,9 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
                  conditions: Optional[List[Condition]] = None,
                  parameters: Optional[List[Parameter]] = None,
                  template: Optional[TaurusProcessTemplate] = None,
-                 file_links: Optional[List[FileLink]] = None):
-        DataConcepts.__init__(self, TaurusProcessSpec.typ)
+                 file_links: Optional[List[FileLink]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusProcessSpec.typ, audit_info=audit_info)
         TaurusProcessSpec.__init__(self, name=name, uids=set_default_uid(uids),
                                    tags=tags, conditions=conditions, parameters=parameters,
                                    template=template, file_links=file_links, notes=notes)

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -1,5 +1,5 @@
 """Resources that represent process spec objects."""
-from typing import Optional, Dict, List, Type, Any
+from typing import Optional, Dict, List, Type
 
 from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
@@ -8,6 +8,7 @@ from citrine._serialization.properties import String, Mapping, Object, LinkOrEls
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from citrine.attributes.condition import Condition
 from citrine.attributes.parameter import Parameter
 from taurus.entity.file_link import FileLink
@@ -15,7 +16,7 @@ from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 from taurus.entity.template.process_template import ProcessTemplate as TaurusProcessTemplate
 
 
-class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
+class ProcessSpec(Storable, Resource['ProcessSpec'], TaurusProcessSpec):
     """
     A process specification.
 
@@ -58,8 +59,6 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
 
     _response_key = TaurusProcessSpec.typ  # 'process_spec'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
@@ -78,9 +77,8 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
                  conditions: Optional[List[Condition]] = None,
                  parameters: Optional[List[Parameter]] = None,
                  template: Optional[TaurusProcessTemplate] = None,
-                 file_links: Optional[List[FileLink]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusProcessSpec.typ, audit_info=audit_info)
+                 file_links: Optional[List[FileLink]] = None):
+        DataConcepts.__init__(self, TaurusProcessSpec.typ)
         TaurusProcessSpec.__init__(self, name=name, uids=set_default_uid(uids),
                                    tags=tags, conditions=conditions, parameters=parameters,
                                    template=template, file_links=file_links, notes=notes)

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -53,6 +53,8 @@ class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTe
 
     _response_key = TaurusProcessTemplate.typ  # 'process_template'
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -1,5 +1,5 @@
 """Resources that represent process templates."""
-from typing import List, Dict, Optional, Union, Sequence, Type
+from typing import List, Dict, Optional, Union, Sequence, Type, Any
 
 from citrine._rest.resource import Resource
 from citrine._session import Session
@@ -83,8 +83,9 @@ class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTe
                  allowed_labels: Optional[List[str]] = None,
                  allowed_names: Optional[List[str]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None):
-        DataConcepts.__init__(self, TaurusProcessTemplate.typ)
+                 tags: Optional[List[str]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusProcessTemplate.typ, audit_info=audit_info)
         TaurusProcessTemplate.__init__(self, name=name, uids=set_default_uid(uids),
                                        conditions=conditions, parameters=parameters, tags=tags,
                                        description=description, allowed_labels=allowed_labels,

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -91,7 +91,7 @@ class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTe
                                        allowed_names=allowed_names)
 
     @classmethod
-    def _build_child_objects(cls, data: dict, session: Session = None):
+    def _build_child_objects(cls, data: dict, data_with_soft_links, session: Session = None):
         """
         Build the condition and parameter templates and bounds.
 

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -1,5 +1,5 @@
 """Resources that represent process templates."""
-from typing import List, Dict, Optional, Union, Sequence, Type, Any
+from typing import List, Dict, Optional, Union, Sequence, Type
 
 from citrine._rest.resource import Resource
 from citrine._session import Session
@@ -8,6 +8,7 @@ from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from citrine.resources.parameter_template import ParameterTemplate
 from citrine.resources.condition_template import ConditionTemplate
 from taurus.client.json_encoder import loads, dumps
@@ -16,7 +17,7 @@ from taurus.entity.bounds.base_bounds import BaseBounds
 from taurus.entity.link_by_uid import LinkByUID
 
 
-class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTemplate):
+class ProcessTemplate(Storable, Resource['ProcessTemplate'], TaurusProcessTemplate):
     """
     A process template.
 
@@ -53,8 +54,6 @@ class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTe
 
     _response_key = TaurusProcessTemplate.typ  # 'process_template'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')
@@ -83,9 +82,8 @@ class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTe
                  allowed_labels: Optional[List[str]] = None,
                  allowed_names: Optional[List[str]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusProcessTemplate.typ, audit_info=audit_info)
+                 tags: Optional[List[str]] = None):
+        DataConcepts.__init__(self, TaurusProcessTemplate.typ)
         TaurusProcessTemplate.__init__(self, name=name, uids=set_default_uid(uids),
                                        conditions=conditions, parameters=parameters, tags=tags,
                                        description=description, allowed_labels=allowed_labels,

--- a/src/citrine/resources/property_template.py
+++ b/src/citrine/resources/property_template.py
@@ -1,5 +1,5 @@
 """Resources that represent property templates."""
-from typing import List, Dict, Optional, Type, Any
+from typing import List, Dict, Optional, Type
 
 from citrine._rest.resource import Resource
 from citrine._serialization.properties import String, Mapping, Object
@@ -7,11 +7,12 @@ from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.storable import Storable
 from taurus.entity.template.property_template import PropertyTemplate as TaurusPropertyTemplate
 from taurus.entity.bounds.base_bounds import BaseBounds
 
 
-class PropertyTemplate(DataConcepts, Resource['PropertyTemplate'], TaurusPropertyTemplate):
+class PropertyTemplate(Storable, Resource['PropertyTemplate'], TaurusPropertyTemplate):
     """
     A property template.
 
@@ -36,8 +37,6 @@ class PropertyTemplate(DataConcepts, Resource['PropertyTemplate'], TaurusPropert
 
     _response_key = TaurusPropertyTemplate.typ  # 'property_template'
 
-    _client_keys = ["audit_info"]
-
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')
@@ -50,9 +49,8 @@ class PropertyTemplate(DataConcepts, Resource['PropertyTemplate'], TaurusPropert
                  bounds: BaseBounds,
                  uids: Optional[Dict[str, str]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None,
-                 audit_info: Optional[Dict[str, Any]] = None):
-        DataConcepts.__init__(self, TaurusPropertyTemplate.typ, audit_info=audit_info)
+                 tags: Optional[List[str]] = None):
+        DataConcepts.__init__(self, TaurusPropertyTemplate.typ)
         TaurusPropertyTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
                                         uids=set_default_uid(uids), description=description)
 

--- a/src/citrine/resources/property_template.py
+++ b/src/citrine/resources/property_template.py
@@ -1,5 +1,5 @@
 """Resources that represent property templates."""
-from typing import List, Dict, Optional, Type
+from typing import List, Dict, Optional, Type, Any
 
 from citrine._rest.resource import Resource
 from citrine._serialization.properties import String, Mapping, Object
@@ -50,8 +50,9 @@ class PropertyTemplate(DataConcepts, Resource['PropertyTemplate'], TaurusPropert
                  bounds: BaseBounds,
                  uids: Optional[Dict[str, str]] = None,
                  description: Optional[str] = None,
-                 tags: Optional[List[str]] = None):
-        DataConcepts.__init__(self, TaurusPropertyTemplate.typ)
+                 tags: Optional[List[str]] = None,
+                 audit_info: Optional[Dict[str, Any]] = None):
+        DataConcepts.__init__(self, TaurusPropertyTemplate.typ, audit_info=audit_info)
         TaurusPropertyTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
                                         uids=set_default_uid(uids), description=description)
 

--- a/src/citrine/resources/property_template.py
+++ b/src/citrine/resources/property_template.py
@@ -36,6 +36,8 @@ class PropertyTemplate(DataConcepts, Resource['PropertyTemplate'], TaurusPropert
 
     _response_key = TaurusPropertyTemplate.typ  # 'property_template'
 
+    _client_keys = ["audit_info"]
+
     name = String('name')
     description = PropertyOptional(String(), 'description')
     uids = Mapping(String('scope'), String('id'), 'uids')

--- a/src/citrine/resources/storable.py
+++ b/src/citrine/resources/storable.py
@@ -1,0 +1,36 @@
+from citrine.resources.data_concepts import DataConcepts
+from citrine.resources.audit_info import AuditInfo
+
+
+class Storable(DataConcepts):
+    """
+    Data concepts objects that are stored in the data service.
+
+    Attributes
+    ----------
+    audit_info: AuditInfo
+        Holds platform-related metadata: when the object was created, who created it,
+        when the object was most recently updated, and who most recently updated it.
+
+    """
+
+    _client_keys = ["audit_info"]
+
+    @property
+    def audit_info(self):
+        """Get the audit info object."""
+        return self._audit_info
+
+    @audit_info.setter
+    def audit_info(self, audit_info):
+        if audit_info is None:
+            self._audit_info = None
+        elif isinstance(audit_info, AuditInfo):
+            self._audit_info = audit_info
+        elif isinstance(audit_info, dict):
+            self._audit_info = AuditInfo(created_by=audit_info.get('created_by', None),
+                                         created_at=audit_info.get('created_at', None),
+                                         updated_by=audit_info.get('updated_by', None),
+                                         updated_at=audit_info.get('updated_at', None))
+        else:
+            raise TypeError("Audit Info must be a dictionary or an AuditInfo object")

--- a/src/citrine/resources/storable.py
+++ b/src/citrine/resources/storable.py
@@ -28,9 +28,6 @@ class Storable(DataConcepts):
         elif isinstance(audit_info, AuditInfo):
             self._audit_info = audit_info
         elif isinstance(audit_info, dict):
-            self._audit_info = AuditInfo(created_by=audit_info.get('created_by', None),
-                                         created_at=audit_info.get('created_at', None),
-                                         updated_by=audit_info.get('updated_by', None),
-                                         updated_at=audit_info.get('updated_at', None))
+            self._audit_info = AuditInfo.build(audit_info)
         else:
             raise TypeError("Audit Info must be a dictionary or an AuditInfo object")

--- a/tests/resources/test_audit_info.py
+++ b/tests/resources/test_audit_info.py
@@ -1,8 +1,11 @@
+from uuid import uuid4
+from datetime import datetime
+
 from citrine.resources.audit_info import AuditInfo
 
 
 def test_audit_info_str():
-    audit_info_full = AuditInfo('user1', 1562338832488, 'user2', 1562358832488)
-    audit_info_part = AuditInfo('user1', 1562338832488)
+    audit_info_full = AuditInfo(uuid4(), datetime.now(), uuid4(), datetime.now())
+    audit_info_part = AuditInfo(uuid4(), datetime.now())
     assert 'Updated by' in str(audit_info_full) and 'Created by' in str(audit_info_full)
     assert 'Updated by' not in str(audit_info_part) and 'Created by' in str(audit_info_part)

--- a/tests/resources/test_audit_info.py
+++ b/tests/resources/test_audit_info.py
@@ -1,0 +1,8 @@
+from citrine.resources.audit_info import AuditInfo
+
+
+def test_audit_info_str():
+    audit_info_full = AuditInfo('user1', 1562338832488, 'user2', 1562358832488)
+    audit_info_part = AuditInfo('user1', 1562338832488)
+    assert 'Updated by' in str(audit_info_full) and 'Created by' in str(audit_info_full)
+    assert 'Updated by' not in str(audit_info_part) and 'Created by' in str(audit_info_part)

--- a/tests/resources/test_storable.py
+++ b/tests/resources/test_storable.py
@@ -1,0 +1,25 @@
+import pytest
+from uuid import uuid4
+
+from citrine.resources.audit_info import AuditInfo
+from citrine.resources.storable import Storable
+from citrine.resources.process_spec import ProcessSpec
+
+
+def test_assign_audit_info():
+    sample_object = ProcessSpec("A process spec")
+    assert isinstance(sample_object, Storable)
+    audit_info_dict = {'created_by': str(uuid4()), 'created_at': 1560033807392}
+    audit_info_obj = AuditInfo.build(audit_info_dict)
+
+    sample_object.audit_info = None
+    assert sample_object.audit_info is None
+
+    sample_object.audit_info = audit_info_dict
+    assert sample_object.audit_info == audit_info_obj
+
+    sample_object.audit_info = audit_info_obj
+    assert sample_object.audit_info == audit_info_obj
+
+    with pytest.raises(TypeError):
+        sample_object.audit_info = "Created by me, yesterday"

--- a/tests/serialization/test_measurement_run.py
+++ b/tests/serialization/test_measurement_run.py
@@ -54,7 +54,7 @@ def valid_data():
 
 
 def test_simple_deserialization(valid_data):
-    """Ensure that a deserialized Process Run looks sane."""
+    """Ensure that a deserialized Measurement Run looks sane."""
     measurement_run: MeasurementRun = MeasurementRun.build(valid_data)
     assert measurement_run.uids == {'id': valid_data['uids']['id']}
     assert measurement_run.name == 'Taste test'

--- a/tests/serialization/test_measurement_run.py
+++ b/tests/serialization/test_measurement_run.py
@@ -67,8 +67,10 @@ def test_simple_deserialization(valid_data):
     assert measurement_run.material == MaterialRun('sponge cake',
                                                    uids={'id': valid_data['material']['uids']['id']},
                                                    sample_type='experimental')
+    assert measurement_run.material.audit_info == {'created_by': 'user1'}
     assert measurement_run.spec is None
     assert measurement_run.typ == 'measurement_run'
+    assert measurement_run.audit_info == {'created_by': 'user2'}
 
 
 def test_serialization(valid_data):

--- a/tests/serialization/test_measurement_run.py
+++ b/tests/serialization/test_measurement_run.py
@@ -6,6 +6,7 @@ from citrine.attributes.property import Property
 from taurus.entity.value.nominal_integer import NominalInteger
 from citrine.resources.measurement_run import MeasurementRun
 from citrine.resources.material_run import MaterialRun
+from citrine.resources.audit_info import AuditInfo
 
 
 @pytest.fixture
@@ -35,7 +36,10 @@ def valid_data():
             'spec': None,
             'file_links': [],
             'type': 'material_run',
-            'audit_info': {'created_by': 'user1'}
+            'audit_info': {
+                'created_by': 'user1', 'created_at': 1559933807392,
+                'updated_by': 'user2', 'updated_at': 1560033807392
+            }
         },
         spec=None,
         file_links=[],
@@ -45,7 +49,7 @@ def valid_data():
             "performed_by": "Marie Curie",
             "performed_date": "1898-07-01"
         },
-        audit_info={'created_by': 'user2'}
+        audit_info={'created_by': 'user2', 'created_at': 1560033807392}
     )
 
 
@@ -67,10 +71,10 @@ def test_simple_deserialization(valid_data):
     assert measurement_run.material == MaterialRun('sponge cake',
                                                    uids={'id': valid_data['material']['uids']['id']},
                                                    sample_type='experimental')
-    assert measurement_run.material.audit_info == {'created_by': 'user1'}
+    assert measurement_run.material.audit_info == AuditInfo(**valid_data['material']['audit_info'])
     assert measurement_run.spec is None
     assert measurement_run.typ == 'measurement_run'
-    assert measurement_run.audit_info == {'created_by': 'user2'}
+    assert measurement_run.audit_info == AuditInfo(**valid_data['audit_info'])
 
 
 def test_serialization(valid_data):

--- a/tests/serialization/test_measurement_run.py
+++ b/tests/serialization/test_measurement_run.py
@@ -34,7 +34,8 @@ def valid_data():
             'sample_type': 'experimental',
             'spec': None,
             'file_links': [],
-            'type': 'material_run'
+            'type': 'material_run',
+            'audit_info': {'created_by': 'user1'}
         },
         spec=None,
         file_links=[],
@@ -43,7 +44,8 @@ def valid_data():
             "type": "performed_source",
             "performed_by": "Marie Curie",
             "performed_date": "1898-07-01"
-        }
+        },
+        audit_info={'created_by': 'user2'}
     )
 
 

--- a/tests/serialization/test_measurement_run.py
+++ b/tests/serialization/test_measurement_run.py
@@ -37,8 +37,8 @@ def valid_data():
             'file_links': [],
             'type': 'material_run',
             'audit_info': {
-                'created_by': 'user1', 'created_at': 1559933807392,
-                'updated_by': 'user2', 'updated_at': 1560033807392
+                'created_by': str(uuid4()), 'created_at': 1559933807392,
+                'updated_by': str(uuid4()), 'updated_at': 1560033807392
             }
         },
         spec=None,
@@ -49,7 +49,7 @@ def valid_data():
             "performed_by": "Marie Curie",
             "performed_date": "1898-07-01"
         },
-        audit_info={'created_by': 'user2', 'created_at': 1560033807392}
+        audit_info={'created_by': str(uuid4()), 'created_at': 1560133807392}
     )
 
 

--- a/tests/serialization/test_measurement_run.py
+++ b/tests/serialization/test_measurement_run.py
@@ -75,6 +75,8 @@ def test_serialization(valid_data):
     """Ensure that a serialized Measurement Run looks sane."""
     measurement_run: MeasurementRun = MeasurementRun.build(valid_data)
     serialized = measurement_run.dump()
+    valid_data['material'].pop('audit_info')
+    valid_data.pop('audit_info')
     assert serialized == valid_data
 
 

--- a/tests/serialization/test_process_spec.py
+++ b/tests/serialization/test_process_spec.py
@@ -87,4 +87,5 @@ def test_serialization(valid_data):
     """Ensure that a serialized Process Run looks sane."""
     process_spec: ProcessSpec = ProcessSpec.build(valid_data)
     serialized = process_spec.dump()
+    valid_data.pop('audit_info')  # this field is not serialized
     assert serialized == valid_data

--- a/tests/serialization/test_process_spec.py
+++ b/tests/serialization/test_process_spec.py
@@ -9,6 +9,7 @@ from citrine.attributes.parameter import Parameter
 from citrine.resources.process_spec import ProcessSpec
 from citrine.resources.process_template import ProcessTemplate
 from citrine.resources.parameter_template import ParameterTemplate
+from citrine.resources.audit_info import AuditInfo
 
 
 @pytest.fixture
@@ -80,7 +81,7 @@ def test_simple_deserialization(valid_data):
     assert process_spec.notes == 'make sure to use oven mitts'
     assert process_spec.file_links == [FileLink('cake_recipe.txt', 'www.baking.com')]
     assert process_spec.typ == 'process_spec'
-    assert process_spec.audit_info == valid_data['audit_info']
+    assert process_spec.audit_info == AuditInfo(**valid_data['audit_info'])
 
 
 def test_serialization(valid_data):

--- a/tests/serialization/test_process_spec.py
+++ b/tests/serialization/test_process_spec.py
@@ -51,6 +51,7 @@ def valid_data():
             'tags': []
         },
         file_links=[{'type': 'file_link', 'filename': 'cake_recipe.txt', 'url': 'www.baking.com'}],
+        audit_info={'created_by': str(uuid4()), 'created_at': 1559933807392},
         type='process_spec'
     )
 
@@ -79,6 +80,7 @@ def test_simple_deserialization(valid_data):
     assert process_spec.notes == 'make sure to use oven mitts'
     assert process_spec.file_links == [FileLink('cake_recipe.txt', 'www.baking.com')]
     assert process_spec.typ == 'process_spec'
+    assert process_spec.audit_info == valid_data['audit_info']
 
 
 def test_serialization(valid_data):


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR allows for the serialized data objects coming from the backend to have additional fields that are not in the data model. The specific example here is `audit_info`. These fields are not serialized , nor are they expected during deserialization. Instead they are intercepted at the beginning of the `build()` method and attached to the object later on. No warning is thrown and the deserialized object _does_ have an `audit_info` field (if it was in the backend response).

This change will quiet the warnings that currently appear in `DictSerializable`, as long as the serialized object is only one level deep. If deserializing nested objects the warnings will still get thrown. That's because the assumption "serialized objects returned by the backend correspond to the data model" is baked in pretty firmly, and the code is enthusiastic about using the Taurus serialization and deserialization code as much as possible. I don't see an easy way to change that.
If deserializing a full material history the warnings will also get thrown, but I do think that can be changed. That's because only top-level objects come back, so the code could go through them all and strip out `audit_info`. This would quiet the warnings, but the resulting rehydrated material history would *not* have `audit_info` as a field.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
