### PR TITLE
Add `Public` flag to Dataset

### DIFF
--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -60,6 +60,7 @@ class Dataset(Resource['Dataset']):
         Time the dataset was deleted, in seconds since epoch, if it is deleted.
     public: bool
         Flag indicating whether the dataset is publicly readable.
+
     """
 
     _response_key = 'dataset'

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -58,7 +58,8 @@ class Dataset(Resource['Dataset']):
         Time the dataset was most recently updated, in seconds since epoch.
     delete_time: int
         Time the dataset was deleted, in seconds since epoch, if it is deleted.
-
+    public: bool
+        Flag indicating whether the dataset is publicly readable.
     """
 
     _response_key = 'dataset'
@@ -74,6 +75,7 @@ class Dataset(Resource['Dataset']):
     create_time = properties.Optional(properties.Datetime(), 'create_time')
     update_time = properties.Optional(properties.Datetime(), 'update_time')
     delete_time = properties.Optional(properties.Datetime(), 'delete_time')
+    public = properties.Optional(properties.Boolean(), 'public')
 
     def __init__(self, name: str, summary: str, description: str):
         self.name: str = name
@@ -90,6 +92,7 @@ class Dataset(Resource['Dataset']):
         self.create_time = None
         self.update_time = None
         self.delete_time = None
+        self.public = None
 
     def __str__(self):
         return '<Dataset {!r}>'.format(self.name)

--- a/tests/serialization/test_dataset.py
+++ b/tests/serialization/test_dataset.py
@@ -19,7 +19,8 @@ def valid_data():
         deleted_by=None,
         create_time=1559933807392,
         update_time=None,
-        delete_time=None
+        delete_time=None,
+        public=False
     )
 
 

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -48,6 +48,7 @@ class DatasetDataFactory(factory.DictFactory):
     create_time = None
     update_time = None
     delete_time = None
+    public = False
 
 
 class IDDataFactory(factory.DictFactory):


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR complements work done in the data service which adds a `public` flag to DataSet to show whether it's publicly readable or not.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
