### PR TITLE
PLA-1615 Add cursor-based request method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sphinx==2.2.0
 sphinxcontrib-apidoc==0.3.0
 boto3==1.9.226
 botocore==1.12.226
+deprecation==2.0.7

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -131,9 +131,11 @@ class Session(requests.Session):
     @staticmethod
     def cursor_paged_resource(base_method: Callable[..., dict], path: str, *args,
                               forward: bool = True, per_page: int = 100, **kwargs):
-        """Returns a flat generator of results for an API query.
+        """
+        Returns a flat generator of results for an API query.
 
-        Results are fetched in chunks of size `per_page` and loaded lazily."""
+        Results are fetched in chunks of size `per_page` and loaded lazily.
+        """
         params = kwargs.get('params', {})
         params['forward'] = forward
         params['ascending'] = forward

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -1,5 +1,5 @@
 from os import environ
-from typing import Optional, Callable
+from typing import Optional, Callable, Iterator
 from logging import getLogger
 from datetime import datetime, timedelta
 
@@ -39,8 +39,10 @@ class Session(requests.Session):
         self.access_token_expiration: datetime = datetime.utcnow()
 
         # Following scheme:[//authority]path[?query][#fragment] (https://en.wikipedia.org/wiki/URL)
-        self.base_url = '{}://{}/api/v1/'.format(self.scheme, self.authority)
         self.headers.update({"Content-Type": "application/json"})
+
+    def versioned_base_url(self, version: str = 'v1'):
+        return '{}://{}/api/{}/'.format(self.scheme, self.authority, version)
 
     def _is_access_token_expired(self):
         return self.access_token_expiration - EXPIRATION_BUFFER_MILLIS <= datetime.utcnow()
@@ -48,7 +50,7 @@ class Session(requests.Session):
     def _refresh_access_token(self) -> None:
         """Optionally refresh our access token (if the previous one is about to expire)."""
         data = {'refresh_token': self.refresh_token}
-        response = super().request('POST', self.base_url + 'tokens/refresh', json=data)
+        response = super().request('POST', self.versioned_base_url() + 'tokens/refresh', json=data)
         if response.status_code != 200:
             raise UnauthorizedRefreshToken()
         self.access_token = response.json()['access_token']
@@ -56,11 +58,11 @@ class Session(requests.Session):
             jwt.decode(self.access_token, verify=False)['exp']
         )
 
-    def checked_request(self, method: str, path: str, *args, **kwargs) -> requests.Response:
+    def checked_request(self, method: str, path: str, *args, version: str = 'v1', **kwargs) -> requests.Response:
         """Check response status code and throw an exception if relevant."""
         if self._is_access_token_expired():
             self._refresh_access_token()
-        uri = self.base_url + path.lstrip('/')
+        uri = self.versioned_base_url(version) + path.lstrip('/')
         response = super().request(method, uri, *args, **kwargs)
 
         try:
@@ -130,7 +132,8 @@ class Session(requests.Session):
 
     @staticmethod
     def cursor_paged_resource(base_method: Callable[..., dict], path: str, *args,
-                              forward: bool = True, per_page: int = 100, **kwargs):
+                              forward: bool = True, per_page: int = 100,
+                              version: str = 'v2', **kwargs) -> Iterator[dict]:
         """
         Returns a flat generator of results for an API query.
 
@@ -142,7 +145,7 @@ class Session(requests.Session):
         params['per_page'] = per_page
         kwargs['params'] = params
         while True:
-            response_json = base_method(path, *args, **kwargs)
+            response_json = base_method(path, *args, version=version, **kwargs)
             for obj in response_json['contents']:
                 yield obj
             cursor = response_json.get('next')

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -423,6 +423,7 @@ class DataConceptsCollection(Collection[ResourceType]):
         data_concepts_object.session = self.session
         return data_concepts_object
 
+    @deprecated(details='Please use list_all')
     def list(self, page: Optional[int] = None, per_page: Optional[int] = None):
         """
         List all visible elements of the collection.
@@ -640,7 +641,7 @@ class DataConceptsCollection(Collection[ResourceType]):
             )
         return [self.build(content) for content in response["contents"]]
 
-    def list_by_name(self, name: str, exact: bool = False) -> Iterator[DataConcepts]:
+    def list_by_name(self, name: str, exact: bool = False, forward: bool = True, per_page: int = 100) -> Iterator[DataConcepts]:
         """
         Get all objects with specified name in this dataset.
 
@@ -651,6 +652,13 @@ class DataConceptsCollection(Collection[ResourceType]):
         exact: bool
             Set to True to change prefix search to exact search (but still case-insensitive).
             Default is False.
+        forward: bool
+            Set to False to reverse the order of results (i.e. return in descending order).
+        per_page: int
+            Controls how many results are fetched per request. Has no impact on the size of
+            the result set but will have some effect on performance. Lower gets results
+            faster but increases the total number of requests needed to fetch the entire
+            result set, which increases total latency across fetching the entire result set.
 
         Returns
         -------
@@ -665,12 +673,22 @@ class DataConceptsCollection(Collection[ResourceType]):
             self.session.get_resource,
             # "Ignoring" dataset because it is in the query params (and required)
             self._get_path(ignore_dataset=True) + "/filter-by-name",
+            forward=forward,
+            per_page=per_page,
             params=params)
         return (self.build(raw) for raw in raw_objects)
 
-    def list_all(self) -> Iterator[DataConcepts]:
+    def list_all(self, per_page: int = 100) -> Iterator[DataConcepts]:
         """
         Get all objects in the collection.
+
+        Parameters
+        ----------
+        per_page: int
+            Controls how many results are fetched per request. Has no impact on the size of
+            the result set but will have some effect on performance. Lower gets results
+            faster but increases the total number of requests needed to fetch the entire
+            result set, which increases total latency across fetching the entire result set.
 
         Returns
         -------
@@ -684,6 +702,7 @@ class DataConceptsCollection(Collection[ResourceType]):
         raw_objects = self.session.cursor_paged_resource(
             self.session.get_resource,
             self._get_path(ignore_dataset=True),
+            per_page=per_page,
             params=params)
         return (self.build(raw) for raw in raw_objects)
 

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -655,10 +655,9 @@ class DataConceptsCollection(Collection[ResourceType]):
         forward: bool
             Set to False to reverse the order of results (i.e. return in descending order).
         per_page: int
-            Controls how many results are fetched per request. Has no impact on the size of
-            the result set but will have some effect on performance. Lower gets results
-            faster but increases the total number of requests needed to fetch the entire
-            result set, which increases total latency across fetching the entire result set.
+            Controls the number of results fetched with each http request to the backend.
+            Typically, this is set to a sensible default and should not be modified. Consider
+            modifying this value only if you find this method is unacceptably latent.
 
         Returns
         -------
@@ -690,10 +689,9 @@ class DataConceptsCollection(Collection[ResourceType]):
         forward: bool
             Set to False to reverse the order of results (i.e. return in descending order).
         per_page: int
-            Controls how many results are fetched per request. Has no impact on the size of
-            the result set but will have some effect on performance. Lower gets results
-            faster but increases the total number of requests needed to fetch the entire
-            result set, which increases total latency across fetching the entire result set.
+            Controls the number of results fetched with each http request to the backend.
+            Typically, this is set to a sensible default and should not be modified. Consider
+            modifying this value only if you find this method is unacceptably latent.
 
         Returns
         -------

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -678,12 +678,17 @@ class DataConceptsCollection(Collection[ResourceType]):
             params=params)
         return (self.build(raw) for raw in raw_objects)
 
-    def list_all(self, per_page: int = 100) -> Iterator[DataConcepts]:
+    def list_all(self, forward: bool = True, per_page: int = 100) -> Iterator[DataConcepts]:
         """
         Get all objects in the collection.
 
+        The order of results should not be relied upon, but for now they are sorted by
+        dataset, object type, and creation time (in that order of priority).
+
         Parameters
         ----------
+        forward: bool
+            Set to False to reverse the order of results (i.e. return in descending order).
         per_page: int
             Controls how many results are fetched per request. Has no impact on the size of
             the result set but will have some effect on performance. Lower gets results
@@ -702,6 +707,7 @@ class DataConceptsCollection(Collection[ResourceType]):
         raw_objects = self.session.cursor_paged_resource(
             self.session.get_resource,
             self._get_path(ignore_dataset=True),
+            forward=forward,
             per_page=per_page,
             params=params)
         return (self.build(raw) for raw in raw_objects)

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -637,11 +637,11 @@ class DataConceptsCollection(Collection[ResourceType]):
         response = self.session.get_resource(
             # "Ignoring" dataset because it is in the query params (and required)
             self._get_path(ignore_dataset=True) + "/filter-by-name",
-            params=params,
-            )
+            params=params)
         return [self.build(content) for content in response["contents"]]
 
-    def list_by_name(self, name: str, exact: bool = False, forward: bool = True, per_page: int = 100) -> Iterator[DataConcepts]:
+    def list_by_name(self, name: str, exact: bool = False,
+                     forward: bool = True, per_page: int = 100) -> Iterator[DataConcepts]:
         """
         Get all objects with specified name in this dataset.
 

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -175,6 +175,9 @@ def test_list_by_name(collection, session):
     setattr(session, 'cursor_paged_resource', Session.cursor_paged_resource)
     # TODO: the results appear equal in the diff but fail equality check
     assert len(list(collection.list_by_name('unused', per_page=2))) == len(all_runs)
+    with pytest.raises(RuntimeError):
+        collection.dataset_id = None
+        collection.list_by_name('unused')
 
 
 def test_list_all(collection, session):

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -3,8 +3,9 @@ from uuid import UUID
 import pytest
 from taurus.entity.bounds.integer_bounds import IntegerBounds
 
+from citrine._session import Session
 from citrine.resources.material_run import MaterialRunCollection, MaterialRun
-from tests.utils.session import FakeSession, FakeCall
+from tests.utils.session import FakeSession, FakeCall, make_fake_cursor_request_function
 from tests.utils.factories import MaterialRunFactory, MaterialRunDataFactory, LinkByUIDFactory
 
 
@@ -162,6 +163,30 @@ def test_filter_by_name(collection, session):
     assert expected_call == session.last_call
     assert 1 == len(runs)
     assert sample_run['uids'] == runs[0].uids
+
+
+def test_list_by_name(collection, session):
+    all_runs = [
+        MaterialRunDataFactory(name="foo_{}".format(i)) for i in range(20)
+    ]
+    fake_request = make_fake_cursor_request_function(all_runs)
+    # lotta shady stuff going on in this test
+    setattr(session, 'get_resource', fake_request)
+    setattr(session, 'cursor_paged_resource', Session.cursor_paged_resource)
+    # TODO: the results appear equal in the diff but fail equality check
+    assert len(list(collection.list_by_name('unused', per_page=2))) == len(all_runs)
+
+
+def test_list_all(collection, session):
+    all_runs = [
+        MaterialRunDataFactory(name="foo_{}".format(i)) for i in range(20)
+    ]
+    fake_request = make_fake_cursor_request_function(all_runs)
+    # lotta shady stuff going on in this test
+    setattr(session, 'get_resource', fake_request)
+    setattr(session, 'cursor_paged_resource', Session.cursor_paged_resource)
+    # TODO: the results appear equal in the diff but fail equality check
+    assert len(list(collection.list_all(per_page=2))) == len(all_runs)
 
 
 def test_filter_by_attribute_bounds(collection, session):

--- a/tests/utils/session.py
+++ b/tests/utils/session.py
@@ -119,6 +119,7 @@ def make_fake_cursor_request_function(all_results: list):
     all_results: list
         All results in the result set to simulate paging
     """
+    # TODO add logic for `forward` and `ascending`
     def fake_cursor_request(*_, params=None, **__):
         page_size = params['per_page']
         if 'cursor' in params:

--- a/tests/utils/session.py
+++ b/tests/utils/session.py
@@ -108,3 +108,28 @@ class FakeRequestResponse:
 
     def __init__(self, content=None):
         self.content = content
+
+
+def make_fake_cursor_request_function(all_results: list):
+    """
+    Returns function which simulates request to cursor-paged endpoint.
+
+    Parameters
+    ---------
+    all_results: list
+        All results in the result set to simulate paging
+    """
+    def fake_cursor_request(*_, params=None, **__):
+        page_size = params['per_page']
+        if 'cursor' in params:
+            cursor = int(params['cursor'])
+            contents = all_results[cursor + 1:cursor + page_size + 1]
+        else:
+            contents = all_results[:page_size]
+        response = {'contents': contents}
+        if contents:
+            response['next'] = str(all_results.index(contents[-1]))
+            if 'cursor' in params:
+                response['previous'] = str(all_results.index(contents[0]))
+        return response
+    return fake_cursor_request


### PR DESCRIPTION
# Citrine Python PR

## Description 
At this point (pre- Product API passthrough and full implementation in backend) this PR is mainly just to demonstrate the complexity level of cursor-paging with the current interface. If this seems too annoying to implement for each client, the backend could return simple prev/next links instead of making the client explain how to get the next page (we would lose some flexibility but not a lot).

**EDIT**: The product API passthroughs are live and these methods have been tested against them. Would like to merge for demo.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
