### PR TITLE
PLA-2150:  Allowing module refs as input to workflow executions

### DIFF
--- a/src/citrine/informatics/modules.py
+++ b/src/citrine/informatics/modules.py
@@ -1,7 +1,9 @@
 """Tools for working with design spaces."""
 from typing import Type
 
+from citrine._serialization import properties
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
+from citrine._serialization.serializable import Serializable
 
 
 class Module(PolymorphicSerializable['Module']):
@@ -25,3 +27,12 @@ class Module(PolymorphicSerializable['Module']):
             'PROCESSOR': Processor,
             'PREDICTOR': Predictor
         }[data['module_type']].get_type(data)
+
+
+class ModuleRef(Serializable['ModuleRef']):
+    """A reference to a Module by UID."""
+
+    module_uid = properties.UUID('module_uid')
+
+    def __init__(self, module_uid: str):
+        self.module_uid = module_uid

--- a/src/citrine/resources/workflow_executions.py
+++ b/src/citrine/resources/workflow_executions.py
@@ -2,6 +2,7 @@
 from typing import Optional
 from uuid import UUID
 
+from citrine.informatics.modules import ModuleRef
 from citrine.informatics.scores import Score
 from citrine._rest.collection import Collection
 from citrine._rest.resource import Resource
@@ -71,9 +72,9 @@ class WorkflowExecutionCollection(Collection[WorkflowExecution]):
         execution.workflow_id = self.workflow_id
         return execution
 
-    def trigger(self, score: Score) -> WorkflowExecution:
+    def trigger(self, execution_input: [Score, ModuleRef]) -> WorkflowExecution:
         """Create a new workflow execution."""
-        return self.register(score)
+        return self.register(execution_input)
 
 
 class WorkflowExecutionStatus(Resource['WorkflowExecutionStatus']):

--- a/tests/serialization/test_modules.py
+++ b/tests/serialization/test_modules.py
@@ -1,9 +1,7 @@
 """Tests for citrine.informatics.design_spaces serialization."""
 import uuid
 
-import pytest
-
-from citrine.informatics.modules import Module
+from citrine.informatics.modules import Module, ModuleRef
 from citrine.informatics.design_spaces import ProductDesignSpace
 from citrine.informatics.predictors import SimpleMLPredictor
 from citrine.informatics.processors import GridProcessor
@@ -24,3 +22,15 @@ def test_polymorphic_predictor_deserialization(valid_simple_ml_predictor_data):
 def test_polymorphic_processor_deserialization(valid_grid_processor_data):
     module = Module.build(valid_grid_processor_data)
     assert type(module) == GridProcessor
+
+
+def test_module_ref_serialization():
+    # Given
+    m_uid = uuid.uuid4()
+    ref = ModuleRef(module_uid=m_uid)
+
+    # When
+    ref_data = ref.dump()
+
+    # Then
+    assert ref_data['module_uid'] == str(m_uid)


### PR DESCRIPTION
# Citrine Python PR

## Description 
Different workflow executions can take different inputs now that performance workflows are in the mix.  This simply adds the basic module ref to support that.

I ended up not duplicating the entire execution collection because there really wouldn't be *any* difference except for the input type hint, which actually does nothing in terms of type safety (Python is still a dynamically typed language).

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
