### PR TITLE
correct outdated audit info type hints

### DIFF
--- a/src/citrine/resources/audit_info.py
+++ b/src/citrine/resources/audit_info.py
@@ -12,13 +12,13 @@ class AuditInfo(Serializable):
 
     Parameters
     ----------
-    created_by: str
+    created_by: Optional[UUID]
         ID of the user who created the object
-    created_at: int
+    created_at: Optional[Datetime]
         Time, in ms since epoch, at which the object was created
-    updated_by: Optional[str]
+    updated_by: Optional[UUID]
         ID of the user who most recently updated the object
-    updated_at: Optional[int]
+    updated_at: Optional[Datetime]
         Time, in ms since epoch, at which the object was most recently updated
 
     """


### PR DESCRIPTION
# Citrine Python PR

## Description 
Turns out this was what was causing the pycharm yellow

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
