### PR TITLE
Add cursor-paged tag/attribute search methods

### DIFF
--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -816,7 +816,7 @@ class DataConceptsCollection(Collection[ResourceType]):
             raise TypeError('attribute_bounds must be a dict mapping template to bounds; '
                             'got {}'.format(attribute_bounds))
         if len(attribute_bounds) != 1:
-            raise NotImplementedError('Currently, once searches with exactly one template '
+            raise NotImplementedError('Currently, only searches with exactly one template '
                                       'to bounds mapping is supported; got {}'
                                       .format(attribute_bounds))
         return {

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -817,7 +817,7 @@ class DataConceptsCollection(Collection[ResourceType]):
                             'got {}'.format(attribute_bounds))
         if len(attribute_bounds) != 1:
             raise NotImplementedError('Currently, only searches with exactly one template '
-                                      'to bounds mapping is supported; got {}'
+                                      'to bounds mapping are supported; got {}'
                                       .format(attribute_bounds))
         return {
             'attribute_bounds': {

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -165,31 +165,38 @@ def test_filter_by_name(collection, session):
     assert sample_run['uids'] == runs[0].uids
 
 
-def test_list_by_name(collection, session):
+def test_cursor_paginated_searches(collection, session):
+    """
+    Tests that search methods using cursor-paginated are hooked up correctly.
+    There is no real search logic tested here.
+    """
     all_runs = [
         MaterialRunDataFactory(name="foo_{}".format(i)) for i in range(20)
     ]
     fake_request = make_fake_cursor_request_function(all_runs)
-    # lotta shady stuff going on in this test
+    # pretty shady, need to add these methods to the fake session to test their
+    # interactions with the actual search methods
     setattr(session, 'get_resource', fake_request)
+    setattr(session, 'post_resource', fake_request)
     setattr(session, 'cursor_paged_resource', Session.cursor_paged_resource)
-    # TODO: the results appear equal in the diff but fail equality check
+
     assert len(list(collection.list_by_name('unused', per_page=2))) == len(all_runs)
+    assert len(list(collection.list_all(per_page=2))) == len(all_runs)
+    assert len(list(collection.list_by_tag('unused', per_page=2))) == len(all_runs)
+    assert len(list(collection.list_by_attribute_bounds(
+        {LinkByUIDFactory(): IntegerBounds(1, 5)}, per_page=2))) == len(all_runs)
+
+    # invalid inputs
+    with pytest.raises(TypeError):
+        collection.list_by_attribute_bounds([1, 5], per_page=2)
+    with pytest.raises(NotImplementedError):
+        collection.list_by_attribute_bounds({
+            LinkByUIDFactory(): IntegerBounds(1, 5),
+            LinkByUIDFactory(): IntegerBounds(1, 5),
+        }, per_page=2)
     with pytest.raises(RuntimeError):
         collection.dataset_id = None
-        collection.list_by_name('unused')
-
-
-def test_list_all(collection, session):
-    all_runs = [
-        MaterialRunDataFactory(name="foo_{}".format(i)) for i in range(20)
-    ]
-    fake_request = make_fake_cursor_request_function(all_runs)
-    # lotta shady stuff going on in this test
-    setattr(session, 'get_resource', fake_request)
-    setattr(session, 'cursor_paged_resource', Session.cursor_paged_resource)
-    # TODO: the results appear equal in the diff but fail equality check
-    assert len(list(collection.list_all(per_page=2))) == len(all_runs)
+        collection.list_by_name('unused', per_page=2)
 
 
 def test_filter_by_attribute_bounds(collection, session):

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -167,7 +167,7 @@ def test_filter_by_name(collection, session):
 
 def test_cursor_paginated_searches(collection, session):
     """
-    Tests that search methods using cursor-paginated are hooked up correctly.
+    Tests that search methods using cursor-pagination are hooked up correctly.
     There is no real search logic tested here.
     """
     all_runs = [


### PR DESCRIPTION
# Citrine Python PR

## Description 
Add cursor-paged `list_by_tag` and `list_by_attribute_bounds` methods.

This PR should not be merged before the corresponding backend implementation is merged as well.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
