### PR TITLE
Add debug logging to checked_request

### DIFF
--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -85,6 +85,15 @@ class Session(requests.Session):
             self.logger.info('%s %s %s', response.status_code, method, path)
             return response
         else:
+            self.logger.debug('BEGIN request details:')
+            self.logger.debug('\tmethod: {}'.format(method))
+            self.logger.debug('\tpath: {}'.format(path))
+            self.logger.debug('\tversion: {}'.format(version))
+            for i, arg in enumerate(args):
+                self.logger.debug('\targs[{}]: {}'.format(i, arg))
+            for k, v in kwargs:
+                self.logger.debug('\t{}: {}'.format(k, v))
+            self.logger.debug('END request details.')
             stacktrace = self._extract_response_stacktrace(response)
             if stacktrace is not None:
                 self.logger.error('Response arrived with stacktrace:')

--- a/tests/utils/session.py
+++ b/tests/utils/session.py
@@ -54,27 +54,27 @@ class FakeSession:
     def last_call(self) -> FakeCall:
         return self.calls[-1]
 
-    def get_resource(self, path: str, *args, **kwargs) -> dict:
-        return self.checked_get(path, *args, **kwargs)
+    def get_resource(self, path: str, **kwargs) -> dict:
+        return self.checked_get(path, **kwargs)
 
-    def post_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
-        return self.checked_post(path, json, *args, **kwargs)
+    def post_resource(self, path: str, json: dict, **kwargs) -> dict:
+        return self.checked_post(path, json, **kwargs)
 
-    def put_resource(self, path: str, json: dict, *args, **kwargs) -> dict:
-        return self.checked_put(path, json, *args, **kwargs)
+    def put_resource(self, path: str, json: dict, **kwargs) -> dict:
+        return self.checked_put(path, json, **kwargs)
 
     def delete_resource(self, path: str) -> dict:
         return self.checked_delete(path)
 
-    def checked_get(self, path: str, *args, **kwargs) -> dict:
+    def checked_get(self, path: str, **kwargs) -> dict:
         self.calls.append(FakeCall('GET', path, params=kwargs.get('params')))
         return self._get_response()
 
-    def checked_post(self, path: str, json: dict, *args, **kwargs) -> dict:
+    def checked_post(self, path: str, json: dict, **kwargs) -> dict:
         self.calls.append(FakeCall('POST', path, json, params=kwargs.get('params')))
         return self._get_response()
 
-    def checked_put(self, path: str, json: dict, *args, **kwargs) -> dict:
+    def checked_put(self, path: str, json: dict, **kwargs) -> dict:
         self.calls.append(FakeCall('PUT', path, json))
         return self._get_response()
 


### PR DESCRIPTION
# Citrine Python PR

## Description 
Adds debug logging to checked request. Should help us troubleshoot potential client-side serialization issues (and hopefully other problems too).

Also removed `*args` from request passthrough methods. All args to `request` other than `method` and `url` are named and have default values, which makes position arguments a poor choice for specifying them. `kwargs` enables their usage in a more stable and readable way. `request` signature for context:
```
    def request(self, method, url,
            params=None, data=None, headers=None, cookies=None, files=None,
            auth=None, timeout=None, allow_redirects=True, proxies=None,
            hooks=None, stream=None, verify=None, cert=None, json=None):
```

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
