### PR TITLE
PLA-2298 get data object by ID without dataset

### DIFF
--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -504,9 +504,7 @@ class DataConceptsCollection(Collection[ResourceType]):
             An object with specified scope and uid
 
         """
-        if self.dataset_id is None:
-            raise RuntimeError("Must specify a dataset in order to get a data model object.")
-        path = self._get_path() + "/{}/{}".format(scope, uid)
+        path = self._get_path(ignore_dataset=self.dataset_id is None) + "/{}/{}".format(scope, uid)
         data = self.session.get_resource(path)
         return self.build(data)
 

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -273,13 +273,25 @@ def test_material_run_cannot_register_with_no_id(collection):
         collection.register(MaterialRunFactory())
 
 
-def test_material_run_cannot_get_with_no_id(collection):
+def test_material_run_can_get_with_no_id(collection, session):
     # Given
     collection.dataset_id = None
 
+    run_data = MaterialRunDataFactory(name='Cake 2')
+    mr_id = run_data['uids']['id']
+    session.set_response(run_data)
+
+    # When
+    run = collection.get(mr_id)
+
     # Then
-    with pytest.raises(RuntimeError):
-        collection.get('123')
+    assert 1 == session.num_calls
+    expected_call = FakeCall(
+        method='GET',
+        path='projects/{}/material-runs/id/{}'.format(collection.project_id, mr_id)
+    )
+    assert expected_call == session.last_call
+    assert 'Cake 2' == run.name
 
 
 def test_material_run_filter_by_name_with_no_id(collection):


### PR DESCRIPTION
# Citrine Python PR

## Description 
Enables ability to get data objects by a UID without a dataset.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
