### PR TITLE
Logging standardization and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ several log levels:
 * `DEBUG` - verbose information output that may assist the developer while debugging
 * `NOTSET` - no filtering whatsoever
 
-Each log level includes the previous. By default, the log level is set to `INFO`. However, it may be
-preferable to set the log level to `WARNING` or `ERROR` if your program's output should be concise
-and/or only produce actionable information. When debugging issues, increasing the verbosity to
-`DEBUG` may be helpful, particularly if seeking assistance from the Citrine team.
+Each log level includes the previous, i.e. `WARNING` includes itself, `ERROR`, and `FATAL`. By
+default, the log level is set to `INFO`. However, it may be preferable to set the log level to
+`WARNING` or `ERROR` if your program's output should be concise and/or only produce actionable
+information. When debugging issues, increasing the verbosity to `DEBUG` may be helpful,
+particularly if seeking assistance from the Citrine team.
 
 To set your log level, add
 ```python

--- a/README.md
+++ b/README.md
@@ -52,13 +52,14 @@ levels:
 * `WARNING` - indicates that something unusual is happening, often precedes failures
 * `INFO` - informational output unrelated to problems
 * `DEBUG` - verbose information output that may assist the developer while debugging
-* `NOTSET` - no filtering whatsoever
+* `NOTSET` - currently unused in Citrine code, typically *extremely* verbose output describing
+  the details of every operation being performed
 
-Each log level includes the previous, i.e. `WARNING` includes itself, `ERROR`, and `FATAL`. By
-default, the log level is set to `INFO`. However, it may be preferable to set the log level to
-`WARNING` or `ERROR` if your program's output should be concise and/or only produce actionable
-information. When debugging issues, increasing the verbosity to `DEBUG` may be helpful,
-particularly if seeking assistance from the Citrine team.
+As set, a logging level will return any logs at the set level and above, e.g. `WARNING` includes
+itself, `ERROR`, and `FATAL`. By default, the log level is set to `INFO`. However, it may be
+preferable to set the log level to `WARNING` or `ERROR` if your program's output should be concise
+and/or only produce actionable information. When debugging issues, increasing the verbosity to `DEBUG`
+may be helpful, particularly if seeking assistance from the Citrine team.
 
 To set your log level, add
 ```python

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ allowing other loggers to produce output of `WARNING` level and lower.
 Another example:
 ```python
 import logging
-import logging
+import citrine
 citrine._session.logger.setLevel(logging.DEBUG)
 ```
 will enable `DEBUG` level output in the for all activity relating to HTTP requests to Citrine APIs.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,63 @@ the current state of the docstrings in the source code.
 One of the outstanding features of sphinx is its support for arbitrarily organized documentation
 materials such as tutorials, introductions, and other context providing content. These items should
 be stored in source control under the `docs/source` directory in properly formatted `.rst` files.
+
+## Logging
+
+A number of our python classes and modules use python's built-in `logging module`, which supports
+several log levels:
+
+* `FATAL` - indicates a very serious (probably irrecoverable) failure has occurred
+* `ERROR` - indicates an error which by default will not be handled has occurred
+* `WARNING` - indicates that something unusual is happening, often precedes failures
+* `INFO` - informational output unrelated to problems
+* `DEBUG` - verbose information output that may assist the developer while debugging
+* `NOTSET` - no filtering whatsoever
+
+Each log level includes the previous. By default, the log level is set to `INFO`. However, it may be
+preferable to set the log level to `WARNING` or `ERROR` if your program's output should be concise
+and/or only produce actionable information. When debugging issues, increasing the verbosity to
+`DEBUG` may be helpful, particularly if seeking assistance from the Citrine team.
+
+To set your log level, add
+```python
+import logging
+logging.root.setLevel(level=logging.DEBUG)
+```
+with the desired log level to your script.
+
+### Fine-grained log level control
+
+In some scenarios, you may wish to increase or decrease the verbosity of a particular logger. For
+instance
+
+```python
+from taurus.entity.dict_serializable import logger
+import logging
+logger.setLevel(logging.ERROR)
+```
+will silence warnings about receiving unexpected data in responses from Citrine APIs, while still
+allowing other loggers to produce `INFO` level output.
+
+Another example:
+```python
+import logging
+citrine.session.logger.setLevel(logging.DEBUG)
+```
+will enable `DEBUG` level output in the for all activity relating to HTTP requests to Citrine APIs.
+This example assumes you've named your `Citrine` object instance `citrine`.
+
+In general, all log output originating from Citrine source code will include the module from which
+log output originates. By convention loggers are named `logger`, so the module + `.logger` will
+locate the correct instance, e.g. log line
+
+```
+INFO:citrine._session:200 GET /projects/fc568490-224a-4070-807f-1427c4f4dcd8
+```
+
+can be suppressed with
+```
+import citrine
+import logging
+citrine._session.logger.setLevel(logging.WARNING)
+```

--- a/README.md
+++ b/README.md
@@ -77,28 +77,22 @@ from taurus.entity.dict_serializable import logger
 import logging
 logger.setLevel(logging.ERROR)
 ```
-will silence warnings about receiving unexpected data in responses from Citrine APIs, while still
-allowing other loggers to produce `INFO` level output.
+will silence warnings about receiving superfluous data in responses from Citrine APIs, while still
+allowing other loggers to produce output of `WARNING` level and lower.
 
 Another example:
 ```python
 import logging
-citrine.session.logger.setLevel(logging.DEBUG)
+import logging
+citrine._session.logger.setLevel(logging.DEBUG)
 ```
 will enable `DEBUG` level output in the for all activity relating to HTTP requests to Citrine APIs.
-This example assumes you've named your `Citrine` object instance `citrine`.
 
 In general, all log output originating from Citrine source code will include the module from which
 log output originates. By convention loggers are named `logger`, so the module + `.logger` will
-locate the correct instance, e.g. log line
+locate the correct instance, e.g. the log line
 
 ```
 INFO:citrine._session:200 GET /projects/fc568490-224a-4070-807f-1427c4f4dcd8
 ```
-
-can be suppressed with
-```
-import citrine
-import logging
-citrine._session.logger.setLevel(logging.WARNING)
-```
+is an example of output from the logger in the previous example.

--- a/README.md
+++ b/README.md
@@ -81,16 +81,17 @@ will silence warnings about receiving superfluous data in responses from Citrine
 allowing other loggers to produce output of `WARNING` level and lower.
 
 Another example:
+
 ```python
+from citrine._session import logger
 import logging
-import citrine
-citrine._session.logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.DEBUG)
 ```
 will enable `DEBUG` level output in the for all activity relating to HTTP requests to Citrine APIs.
 
 In general, all log output originating from Citrine source code will include the module from which
-log output originates. By convention loggers are named `logger`, so the module + `.logger` will
-locate the correct instance, e.g. the log line
+log output originates. By convention loggers are named `logger`, so importing `logger` from the
+originating module will locate the correct instance, e.g. the log line
 
 ```
 INFO:citrine._session:200 GET /projects/fc568490-224a-4070-807f-1427c4f4dcd8

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ be stored in source control under the `docs/source` directory in properly format
 
 ## Logging
 
-A number of our python classes and modules use python's built-in `logging module`, which supports
-several log levels:
+A number of our python modules use python's built-in `logging` module, which supports several log
+levels:
 
 * `FATAL` - indicates a very serious (probably irrecoverable) failure has occurred
 * `ERROR` - indicates an error which by default will not be handled has occurred

--- a/src/citrine/__init__.py
+++ b/src/citrine/__init__.py
@@ -1,2 +1,5 @@
 # TODO: Add a docstring here
 from citrine.citrine import Citrine  # noqa: F401
+import logging
+
+logging.basicConfig(level=logging.INFO)

--- a/src/citrine/citrine.py
+++ b/src/citrine/citrine.py
@@ -2,7 +2,6 @@ from typing import Optional
 from citrine._session import Session
 from citrine.resources.project import ProjectCollection
 from citrine.resources.user import UserCollection
-import logging
 
 
 DEFAULT_HOST: str = 'citrine.io'

--- a/src/citrine/citrine.py
+++ b/src/citrine/citrine.py
@@ -17,7 +17,6 @@ class Citrine:
                  scheme: str = DEFAULT_SCHEME,
                  host: str = DEFAULT_HOST,
                  port: Optional[str] = None):
-        self.logger = logging.getLogger(__name__)
         self.session: Session = Session(api_key, scheme, host, port)
 
     @property

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -1,5 +1,4 @@
 """Top-level class for all data concepts objects and collections thereof."""
-from logging import getLogger
 from uuid import UUID
 from typing import TypeVar, Type, List, Dict, Union, Optional, Iterator
 from copy import deepcopy

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -395,7 +395,6 @@ class DataConceptsCollection(Collection[ResourceType]):
         self.project_id = project_id
         self.dataset_id = dataset_id
         self.session = session
-        self.logger = getLogger(type(self).__name__)
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
# Citrine Python PR

## Description 

* Moves all loggers to module level for ease of location for suppression
* Removes unused loggers
* Sets default log level to `INFO` and formats output to include logger module
* Explains logging levels in README (pretty: https://github.com/CitrineInformatics/citrine-python/tree/feature/logging-docs)

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
