### PR TITLE
Check if continuous dimension bounds are None 

### DIFF
--- a/src/citrine/informatics/dimensions.py
+++ b/src/citrine/informatics/dimensions.py
@@ -54,8 +54,8 @@ class ContinuousDimension(Serializable['ContinuousDimension'], Dimension):
                  upper_bound: Optional[float] = None,
                  template_id: Optional[UUID] = None):
         self.descriptor: RealDescriptor = descriptor
-        self.lower_bound: float = lower_bound or descriptor.lower_bound
-        self.upper_bound: float = upper_bound or descriptor.upper_bound
+        self.lower_bound: float = lower_bound if lower_bound is not None else descriptor.lower_bound
+        self.upper_bound: float = upper_bound if upper_bound is not None else descriptor.upper_bound
         self.template_id: UUID = template_id or uuid4()
 
 

--- a/src/citrine/informatics/dimensions.py
+++ b/src/citrine/informatics/dimensions.py
@@ -54,8 +54,14 @@ class ContinuousDimension(Serializable['ContinuousDimension'], Dimension):
                  upper_bound: Optional[float] = None,
                  template_id: Optional[UUID] = None):
         self.descriptor: RealDescriptor = descriptor
-        self.lower_bound: float = lower_bound if lower_bound is not None else descriptor.lower_bound
-        self.upper_bound: float = upper_bound if upper_bound is not None else descriptor.upper_bound
+        if lower_bound is not None:
+            self.lower_bound: float = lower_bound
+        else:
+            self.lower_bound: float = descriptor.lower_bound
+        if upper_bound is not None:
+            self.upper_bound: float = upper_bound
+        else:
+            self.upper_bound: float = descriptor.upper_bound
         self.template_id: UUID = template_id or uuid4()
 
 

--- a/tests/informatics/test_dimensions.py
+++ b/tests/informatics/test_dimensions.py
@@ -26,6 +26,18 @@ def test_continuous_initialization(continuous_dimension):
     assert continuous_dimension.upper_bound == 33
 
 
+def test_continuous_bounds():
+    """Test bounds are assigned correctly, even when bounds are == 0"""
+    beta = RealDescriptor('beta', -10, 10)
+    lower_none = ContinuousDimension(beta, upper_bound=0)
+    assert lower_none.lower_bound == -10
+    assert lower_none.upper_bound == 0
+
+    upper_none = ContinuousDimension(beta, lower_bound=0)
+    assert upper_none.lower_bound == 0
+    assert upper_none.upper_bound == 10
+
+
 def test_enumerated_initialization(enumerated_dimension):
     """Make sure the correct fields go to the correct places."""
     assert enumerated_dimension.descriptor.key == 'color'


### PR DESCRIPTION
If the lower or upper bounds are == 0, the previous code would assign the corresponding bound from the descriptor. With this PR, the code checks if the provided bound is not `None` instead of checking whether the boolean-cast bound value is false. (Here, `if` statements are expanded into multiple lines because using a ternary expression was > 99 character limit imposed by flake8.)
