### PR TITLE
List of ingredients gets jumbled during material history building

### DIFF
--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -291,6 +291,11 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
         if linked_objects is None:
             return
 
+        # Make `linked_objects` point to the list of linked objects themselves, as opposed to the
+        # attribute of `obj_with_soft_links`. The list in `obj_with_soft_links` will be modified
+        # in the loop below, and we don't want to modify a list while iterating over it.
+        linked_objects = [l for l in linked_objects]
+
         # Cycle through linked objects in obj_with_soft_link and if they are not LinkByUID,
         # build them and then set their `reverse_field` field to dc_obj
         for linked_obj in linked_objects:

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -1,7 +1,7 @@
 """Top-level class for all data concepts objects and collections thereof."""
 from uuid import UUID
 from typing import TypeVar, Type, List, Dict, Union, Optional, Iterator
-from copy import deepcopy
+from copy import copy, deepcopy
 from abc import abstractmethod
 
 from citrine._session import Session
@@ -291,10 +291,10 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
         if linked_objects is None:
             return
 
-        # Make `linked_objects` point to the list of linked objects themselves, as opposed to the
+        # Make `linked_objects` point to a copy of the list of linked objects, as opposed to the
         # attribute of `obj_with_soft_links`. The list in `obj_with_soft_links` will be modified
         # in the loop below, and we don't want to modify a list while iterating over it.
-        linked_objects = [l for l in linked_objects]
+        linked_objects = copy(linked_objects)
 
         # Cycle through linked objects in obj_with_soft_link and if they are not LinkByUID,
         # build them and then set their `reverse_field` field to dc_obj

--- a/tests/serialization/test_material_run.py
+++ b/tests/serialization/test_material_run.py
@@ -8,6 +8,7 @@ from citrine.resources.ingredient_spec import IngredientSpec
 from citrine.resources.measurement_run import MeasurementRun
 from taurus.client.json_encoder import LinkByUID
 from taurus.client.json_encoder import loads, dumps
+from taurus.demo.cake import make_cake
 from taurus.entity.object import MeasurementRun as TaurusMeasurementRun
 from taurus.entity.object import MaterialRun as TaurusMaterialRun
 from taurus.entity.object import MaterialSpec as TaurusMaterialSpec
@@ -140,3 +141,30 @@ def test_measurement_material_connection_rehydration():
     assert isinstance(copy_ingredient.material.measurements[0].spec, MeasurementSpec), \
         "copy of ending_mat should have a process with an ingredient derived from a material " \
         "that has one measurement that has a spec"
+
+
+def test_cake():
+    """Test that the cake example from taurus can be built without modification."""
+    # def _recursive_check_equivalence(obj1, obj2, seen=None):
+    #     if seen is None:
+    #         seen = set()
+    #     if obj1.__hash__ is not None:
+    #         if obj1 in seen:
+    #             return True
+    #         else:
+    #             seen.add(obj1)
+    #
+    #     if isinstance(obj1, (list, tuple)):
+    #         return len(obj1) == len(obj2) and \
+    #                all([_recursive_check_equivalence(obj1[i], obj2[i], seen) for i, _ in enumerate(obj1)])
+    #     elif isinstance(obj1, DictSerializable):
+    #         keys = {x.lstrip('_') for x in vars(obj1)}
+    #         return all([_recursive_check_equivalence(getattr(obj1, key), getattr(obj2, key), seen) for key in keys])
+    #     else:
+    #         return obj1 == obj2
+
+    taurus_cake = make_cake()
+    cake = MaterialRun.build(taurus_cake)
+    # assert _recursive_check_equivalence(taurus_cake, cake)
+    assert [ingred.name for ingred in cake.process.ingredients] == \
+           [ingred.name for ingred in taurus_cake.process.ingredients]


### PR DESCRIPTION
# Citrine Python PR

## Description 
Fixes a bug in which building a material history (converting from taurus objects to citrine-python objects) jumbled the list of ingredients in a process. The cause was as follows: the taurus process has a list of taurus ingredients, and we iterate over that list, building each ingredient as a citrine-python object and attaching it to the citrine-python version of the process. This action temporarily severs the link between the taurus process and ingredient, and when they are re-connected, the list is permuted (the newly-attached object is added to the end of the list). We were iterating over the list as it was being modified. The fix is to create a copy of the list of ingredients and iterate over that.

This work surfaced another bug, which is that the `build` method creates "dangling links." Given a material, `mat`, `mat.spec.process` points to a process spec, and `mat.process.spec` points to a _different version_ of that process spec, one that is not connected to the material spec. Therefore, `mat.spec.process.output_material` is `None`, when it should equal `mat.spec`. I spent most of the day trying to close that loop and was able to make it work, but could not fix the comparable problem for the ingredient/process run/spec square. 

I believe that the `build` method as it is currently structured cannot solve this problem. It attempts to traverse the tree of Taurus objects, without explicitly keeping track of where it has been. I had hoped that we could leverage the fact that the Taurus objects were already connected correctly to simplify the `build()` logic, but at this point it has become more complicated and is working less well, so I think we should refactor the way material histories are built. One option is to essentially copy Taurus's deserialization code (keep a list of all objects, substitute links for objects one by one), but for citrine-python objects.

I think that the question of how to refactor `build()` is separate from this PR, which is narrowly scoped to fixing PLA-2266.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
