### PR TITLE
PLA-2404 make name optional in ingredient runs

### DIFF
--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -50,10 +50,12 @@ class IngredientRun(Storable, Resource['IngredientRun'], TaurusIngredientRun):
     absolute_quantity: :py:class:`ContinuousValue \
     <taurus.entity.value.continuous_value.ContinuousValue>`, optional
         The absolute quantity of the ingredient in the process.
-    name: str
-        Label on the ingredient that is unique within the process that contains it.
+    name: str, optional
+        Label on the ingredient that is unique within the process that contains it. This property
+        will be overwritten by its value in `spec` if it is present.
     labels: List[str], optional
-        Additional labels on the ingredient.
+        Additional labels on the ingredient. This property will be overwritten by its value in
+        `spec` if it is present.
     spec: IngredientSpec
         The specification of which this ingredient is a realization.
     file_links: List[FileLink], optional
@@ -73,14 +75,14 @@ class IngredientRun(Storable, Resource['IngredientRun'], TaurusIngredientRun):
     number_fraction = PropertyOptional(Object(ContinuousValue), 'number_fraction')
     absolute_quantity = PropertyOptional(
         Object(ContinuousValue), 'absolute_quantity')
-    name = String('name')
+    name = PropertyOptional(String(), 'name')
     labels = PropertyOptional(PropertyList(String()), 'labels')
     spec = PropertyOptional(LinkOrElse(), 'spec')
     file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
     typ = String('type')
 
     def __init__(self,
-                 name: str,
+                 name: Optional[str] = None,
                  uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,

--- a/tests/resources/test_object_setters.py
+++ b/tests/resources/test_object_setters.py
@@ -59,12 +59,11 @@ def test_object_validation():
 
 def test_list_validation():
     """Test that lists are validated by taurus."""
-    mat = MaterialRun("A material")
     with pytest.raises(TypeError):
         # labels must be a list of string, but contains an int
-        IngredientRun(material=mat, labels=["Label 1", 17], name="foo")
+        IngredientSpec(labels=["Label 1", 17], name="foo")
 
-    ingredient = IngredientRun(material=mat, labels=["Label 1", "label 2"], name="foo")
+    ingredient = IngredientSpec(labels=["Label 1", "label 2"], name="foo")
     with pytest.raises(TypeError):
         # cannot append an int to a list of strings
         ingredient.labels.append(17)

--- a/tests/serialization/test_ingredient_run.py
+++ b/tests/serialization/test_ingredient_run.py
@@ -64,8 +64,7 @@ def test_material_attachment():
     Check that the ingredient can be built, and that the connection survives ser/de.
     """
     flour = MaterialRun("flour", sample_type='unknown')
-    flour_ingredient = IngredientRun(material=flour, absolute_quantity=NominalReal(500, 'g'),
-                                     name='500 g flour')
+    flour_ingredient = IngredientRun(material=flour, absolute_quantity=NominalReal(500, 'g'))
 
     flour_ingredient_copy = IngredientRun.build(flour_ingredient.dump())
     assert flour_ingredient_copy == flour_ingredient

--- a/tests/serialization/test_material_run.py
+++ b/tests/serialization/test_material_run.py
@@ -66,7 +66,7 @@ def test_nested_serialization():
 
     # helper
     def make_ingredient(material: MaterialRun):
-        return IngredientRun(name=material.name, material=material)
+        return IngredientRun(material=material)
 
     icing = ProcessRun(name="Icing")
     cake = MaterialRun(name='Final cake', process=icing)
@@ -101,8 +101,7 @@ def test_measurement_material_connection_rehydration():
     process = TaurusProcessRun("Transformative process", spec=process_spec)
     ingredient_spec = TaurusIngredientSpec(name="ingredient", material=starting_mat_spec,
                                            process=process_spec)
-    ingredient = TaurusIngredientRun(name="ingredient", material=starting_mat, process=process,
-                                     spec=ingredient_spec)
+    ingredient = TaurusIngredientRun(material=starting_mat, process=process, spec=ingredient_spec)
 
     ending_mat_spec = TaurusMaterialSpec("ending material", process=process_spec)
     ending_mat = TaurusMaterialRun("ending material", process=process, spec=ending_mat_spec)


### PR DESCRIPTION
# Citrine Python PR

## Description 
Goes with https://github.com/CitrineInformatics/taurus/pull/61. Makes name optional now that ingredient runs inherit their name and labels from their spec.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
