### PR TITLE
PLA-2335 Revert log level to WARNING

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ levels:
   the details of every operation being performed
 
 As set, a logging level will return any logs at the set level and above, e.g. `WARNING` includes
-itself, `ERROR`, and `FATAL`. By default, the log level is set to `INFO`. However, it may be
-preferable to set the log level to `WARNING` or `ERROR` if your program's output should be concise
+itself, `ERROR`, and `FATAL`. By default, the log level is set to `WARNING`. However, it may be
+preferable to set the log level to `ERROR` if your program's output should be particularly concise
 and/or only produce actionable information. When debugging issues, increasing the verbosity to `DEBUG`
 may be helpful, particularly if seeking assistance from the Citrine team.
 

--- a/src/citrine/__init__.py
+++ b/src/citrine/__init__.py
@@ -2,4 +2,4 @@
 from citrine.citrine import Citrine  # noqa: F401
 import logging
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.WARNING)


### PR DESCRIPTION
Log level was mistakenly changed to INFO.

# Citrine Python PR

## Description 
Please briefly explain the goal of the changes/this PR.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
