### PR TITLE
Added description to cross-validation configuration code example.

### DIFF
--- a/docs/source/workflows/performance_workflows.rst
+++ b/docs/source/workflows/performance_workflows.rst
@@ -17,6 +17,7 @@ The following example demonstrates how to use the python SDK to register a perfo
            name='Demo Performance Workflow',
            analysis=CrossValidationAnalysisConfiguration(
                name='analysis_settings',
+               description='2-fold cross-validation',
                n_folds=2,
                n_trials=3,
                max_rows=200,


### PR DESCRIPTION
The code example from the performance workflow documentation that demonstrates how to create a cross-validation analysis configuration module was missing a description, and hence an error would be thrown if a user tried to run the example. This PR adds the required description parameter.