### PR TITLE
Proposed bugfix for PLA-2416: using pagination for listing collections

### DIFF
--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -60,6 +60,7 @@ class Collection(Generic[ResourceType]):
                     per_page: Optional[int] = None) -> Iterable[ResourceType]:
         """
         Fetch visible elements in the collection.  This does not handle pagination.
+
         This method will return the first page of results using the default page/per_page
         behaviour of the backend service.  Specify page/per_page to override these defaults
         which are passed to the backend service.
@@ -107,9 +108,10 @@ class Collection(Generic[ResourceType]):
              page: Optional[int] = None,
              per_page: Optional[int] = None) -> Iterable[ResourceType]:
         """
-        List all visible elements in the collection.  Leaving page and per_page as
-        default values will yield all elements in the collection, paginating over
-        all available pages.
+        List all visible elements in the collection.
+
+        Leaving page and per_page as default values will yield all elements in the
+        collection, paginating over all available pages.
 
         Parameters
         ---------
@@ -127,9 +129,8 @@ class Collection(Generic[ResourceType]):
             Resources in this collection.
 
         """
-
-        # Do an initial fetch of the first page using supplied args.  If more results expected, proceed with paginated
-        # calls
+        # Do an initial fetch of the first page using supplied args.
+        # If more results expected, proceed with paginated calls.
         first_page = self._fetch_page(page=page, per_page=per_page)
         first_page_count = 0
         first_uid = None
@@ -151,8 +152,8 @@ class Collection(Generic[ResourceType]):
             subset = self._fetch_page(page=next_page, per_page=per_page)
             count = 0
             for idx, element in enumerate(subset):
-                # escaping from infinite loops where page/per_page are not honored and are returning the
-                # same results regardless of page:
+                # escaping from infinite loops where page/per_page are not
+                # honored and are returning the same results regardless of page:
                 uid = getattr(element, 'uid', None)
                 if first_uid is not None and first_uid == uid:
                     break

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -13,6 +13,8 @@ ResourceType = TypeVar('ResourceType', bound='Resource')
 # have subclasses override the create method.
 CreationType = TypeVar('CreationType', bound='Resource')
 
+DEFAULT_PER_PAGE = 20
+
 
 class Collection(Generic[ResourceType]):
     """Abstract class for representing collections of REST resources."""
@@ -53,11 +55,14 @@ class Collection(Generic[ResourceType]):
         except NonRetryableException as e:
             raise ModuleRegistrationFailedException(model.__class__.__name__, e)
 
-    def list(self,
-             page: Optional[int] = None,
-             per_page: Optional[int] = None) -> Iterable[ResourceType]:
+    def _fetch_page(self,
+                    page: Optional[int] = None,
+                    per_page: Optional[int] = None) -> Iterable[ResourceType]:
         """
-        List all visible elements in the collection.
+        Fetch visible elements in the collection.  This does not handle pagination.
+        This method will return the first page of results using the default page/per_page
+        behaviour of the backend service.  Specify page/per_page to override these defaults
+        which are passed to the backend service.
 
         Parameters
         ---------
@@ -97,6 +102,70 @@ class Collection(Generic[ResourceType]):
                 # Module collections are not filtering on module type
                 # properly, so we are filtering client-side.
                 pass
+
+    def list(self,
+             page: Optional[int] = None,
+             per_page: Optional[int] = None) -> Iterable[ResourceType]:
+        """
+        List all visible elements in the collection.  Leaving page and per_page as
+        default values will yield all elements in the collection, paginating over
+        all available pages.
+
+        Parameters
+        ---------
+        page: int, optional
+            The "page" of results to list. Default is to read all pages and yield
+            all results.
+        per_page: int, optional
+            Max number of results to return per page. Default is 20.  If the page
+            parameter is specified this will limit the number of results in that
+            response.
+
+        Returns
+        -------
+        Iterable[ResourceType]
+            Resources in this collection.
+
+        """
+
+        # Do an initial fetch of the first page using supplied args.  If more results expected, proceed with paginated
+        # calls
+        first_page = self._fetch_page(page=page, per_page=per_page)
+        first_page_count = 0
+        first_uid = None
+        for idx, element in enumerate(first_page):
+            yield element
+
+            uid = getattr(element, 'uid', None)
+            if idx == 0 and not first_uid and uid:
+                first_uid = uid
+
+            first_page_count += 1
+
+        if page is not None or first_page_count != (per_page or DEFAULT_PER_PAGE):
+            return
+
+        # Read extra pages until nothing is left to read
+        next_page = 2
+        while True:
+            subset = self._fetch_page(page=next_page, per_page=per_page)
+            count = 0
+            for idx, element in enumerate(subset):
+                # escaping from infinite loops where page/per_page are not honored and are returning the
+                # same results regardless of page:
+                uid = getattr(element, 'uid', None)
+                if first_uid is not None and first_uid == uid:
+                    break
+
+                yield element
+
+                count += 1
+
+            # Handle the case where we get an unexpected number of results (e.g. last page)
+            if count == 0 or count < first_page_count:
+                break
+
+            next_page += 1
 
     def update(self, model: CreationType) -> CreationType:
         """Update a particular element of the collection."""

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -425,7 +425,7 @@ class DataConceptsCollection(Collection[ResourceType]):
         data_concepts_object.session = self.session
         return data_concepts_object
 
-    def list(self, page: Optional[int] = None, per_page: Optional[int] = None):
+    def _fetch_page(self, page: Optional[int] = None, per_page: Optional[int] = None):
         """
         List all visible elements of the collection.
 

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -79,9 +79,9 @@ class FileCollection(Collection[FileLink]):
         """Build an instance of FileLink."""
         return FileLink.build(data)
 
-    def list(self,
-             page: Optional[int] = None,
-             per_page: Optional[int] = None) -> Iterable[FileLink]:
+    def _fetch_page(self,
+                    page: Optional[int] = None,
+                    per_page: Optional[int] = None) -> Iterable[FileLink]:
         """
         List all visible files in the collection.
 

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -82,7 +82,7 @@ def test_list_material_runs(collection, session):
     })
 
     # When
-    runs = collection.list(page=1, per_page=10)
+    runs = collection._fetch_page(page=1, per_page=10)
 
     # Then
     assert 1 == session.num_calls

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -232,7 +232,7 @@ def test_list_projects(collection, session):
 
     # Then
     assert 1 == session.num_calls
-    expected_call = FakeCall(method='GET', path='/projects')
+    expected_call = FakeCall(method='GET', path='/projects', params={'per_page': 100})
     assert expected_call == session.last_call
     assert 5 == len(projects)
 
@@ -248,7 +248,7 @@ def test_list_projects_filters_non_projects(collection, session):
 
     # Then
     assert 1 == session.num_calls
-    expected_call = FakeCall(method='GET', path='/projects')
+    expected_call = FakeCall(method='GET', path='/projects', params={'per_page': 100})
     assert expected_call == session.last_call
     assert 5 == len(projects)   # The non-project data is filtered out
 

--- a/tests/resources/test_user.py
+++ b/tests/resources/test_user.py
@@ -92,6 +92,7 @@ def test_list_users(collection, session):
     expected_call = FakeCall(
         method='GET',
         path='/users',
+        params={'per_page': 100}
     )
 
     assert expected_call == session.last_call

--- a/tests/utils/session.py
+++ b/tests/utils/session.py
@@ -95,6 +95,32 @@ class FakeSession:
         return self.responses[0]
 
 
+class FakePaginatedSession(FakeSession):
+    """Fake version of Session used to test API interaction, with support for pagination params page and per_page."""
+    def checked_get(self, path: str, **kwargs) -> dict:
+        params = kwargs.get('params')
+        self.calls.append(FakeCall('GET', path, params=params))
+        return self._get_response(**params)
+
+    def checked_post(self, path: str, json: dict, **kwargs) -> dict:
+        params = kwargs.get('params')
+        self.calls.append(FakeCall('POST', path, json, params=params))
+        return self._get_response(**params)
+
+    def _get_response(self, **kwargs):
+        """
+        Returns responses using the page and per_page parameters (if supplied).  This emulates a paginated API response.
+        """
+        if not self.responses:
+            return {}
+
+        page = kwargs.get('page', 1)
+        per_page = kwargs.get('per_page', 20)
+
+        start_idx = (page - 1) * per_page
+        return self.responses[0][start_idx:start_idx + per_page]
+
+
 class FakeS3Client:
     """A fake version of the S3 client that has a put_object method."""
 


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR resolves https://citrine.atlassian.net/browse/PLA-2416 (failing platform end to end tests).  This is caused by the list method from the Collection class.  It is not using pagination when making calls to the backend API services.

This bug was difficult to reproduce locally.  It requires more than 20 elements in a collection before the tests will fail.  This also explains why the tests started failing in Jenkins without a change to the code to cause this.  Test data persists in the test DB between tests so it took days/weeks for this data to reach more than 20 elements in a collection.

This PR changes the default operation of list() to return all elements of a collection instead of the first page.  If the 'page' option is supplied then it will only return a response for that page.  As a user, I would expect a .list() method to list all elements, not just the first page or elements.

The new list() method has the same signature and return values as before so this should not break any existing code.  Any subclasses of Collection outside citrine-python that overload list() should rename this method to _fetch_page() if they wish to use pagination.  _fetch_page() can return an iteratable; so an iterator, list or tuple are acceptable responses.

All list() methods in the base class and subclasses have been renamed to _fetch_page().  A new list() method has been created on the base class that calls _fetch_page() as many times as required to fetch all elements in the collection.  This includes some logic to avoid infinite loops from API calls that ignore the page/per_page options.

The unit test for listing datasets was modified to include pagination.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
