### PR TITLE
Overloading list() in DataConceptsCollection to return a list instead of an iterator

### DIFF
--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -427,7 +427,7 @@ class DataConceptsCollection(Collection[ResourceType]):
 
     def _fetch_page(self, page: Optional[int] = None, per_page: Optional[int] = None):
         """
-        List all visible elements of the collection.
+        List all visible elements of the collection.  Does not handle pagination.
 
         Parameters
         ----------
@@ -443,6 +443,34 @@ class DataConceptsCollection(Collection[ResourceType]):
 
         """
         return self.filter_by_tags([], page, per_page)
+
+    def list(self,
+             page: Optional[int] = None,
+             per_page: Optional[int] = None) -> List[DataConcepts]:
+        """
+        List all visible elements of the collection.
+
+        Leaving page and per_page as default values will return a list of all elements
+        in the collection, paginating over all available pages.
+
+        Parameters
+        ---------
+        page: int, optional
+            The "page" of results to list. Default is to read all pages and return
+            all results.  This option is deprecated.
+        per_page: int, optional
+            Max number of results to return per page.  This parameter is used when
+            making requests to the backend service.  If the page parameter is
+            specified it limits the maximum number of elements in the response.
+
+        Returns
+        -------
+        List[DataConcepts]
+            Every object in this collection.
+
+        """
+        # Convert the iterator to a list to avoid breaking existing client relying on lists
+        return list(super().list(page=page, per_page=per_page))
 
     def register(self, model: ResourceType):
         """

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -82,7 +82,7 @@ def test_list_material_runs(collection, session):
     })
 
     # When
-    runs = collection._fetch_page(page=1, per_page=10)
+    runs = collection.list(page=1, per_page=10)
 
     # Then
     assert 1 == session.num_calls


### PR DESCRIPTION
# Citrine Python PR

## Description 
This is a follow up to #164.  This converts the return type of DataConceptsCollection.list() from an iterator to a list.  This will avoid breaking any existing code that assumes this object is a list, e.g. uses len(response) or uses indexing.  In the long term it may be nice to switch to an iterator for consistency.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
