### PR TITLE
Added type hints for Taurus objects for DataConcepts.register()

### DIFF
--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -17,6 +17,7 @@ from citrine._utils.functions import (
 from taurus.client.json_encoder import loads, dumps, LinkByUID
 from taurus.entity.dict_serializable import DictSerializable
 from taurus.entity.bounds.base_bounds import BaseBounds
+from taurus.entity.object.base_object import BaseObject
 from taurus.entity.template.attribute_template import AttributeTemplate
 
 from citrine.resources.response import Response
@@ -376,7 +377,7 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
 ResourceType = TypeVar('ResourceType', bound='DataConcepts')
 # A Taurus entity that is a subclass of taurus.entity.object.base_object.BaseObject
 # e.g. MaterialRun, MaterialSpec, etc.
-TaurusEntityType = TypeVar('TaurusEntityType', bound='BaseObject')
+TaurusEntityType = TypeVar('TaurusEntityType', bound=BaseObject)
 
 
 class DataConceptsCollection(Collection[ResourceType]):

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -374,6 +374,9 @@ class DataConcepts(PolymorphicSerializable['DataConcepts']):
 
 
 ResourceType = TypeVar('ResourceType', bound='DataConcepts')
+# A Taurus entity that is a subclass of taurus.entity.object.base_object.BaseObject
+# e.g. MaterialRun, MaterialSpec, etc.
+TaurusEntityType = TypeVar('TaurusEntityType', bound='BaseObject')
 
 
 class DataConceptsCollection(Collection[ResourceType]):
@@ -472,7 +475,7 @@ class DataConceptsCollection(Collection[ResourceType]):
         # Convert the iterator to a list to avoid breaking existing client relying on lists
         return list(super().list(page=page, per_page=per_page))
 
-    def register(self, model: ResourceType):
+    def register(self, model: Union[ResourceType, TaurusEntityType]):
         """
         Create a new element of the collection or update an existing element.
 
@@ -489,8 +492,8 @@ class DataConceptsCollection(Collection[ResourceType]):
 
         Parameters
         ----------
-        model: DataConcepts
-            The DataConcepts object.
+        model: DataConcepts or Taurus object
+            The DataConcepts object or compatible Taurus entity that inherits from BaseObject.
 
         Returns
         -------


### PR DESCRIPTION
# Citrine Python PR

## Description 
Adding type hints to the DataConcepts.register method.  This should make it more obvious that this method can accept Taurus objects.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
