### PR TITLE
Making created_by field optional to match API

### DIFF
--- a/src/citrine/informatics/workflows.py
+++ b/src/citrine/informatics/workflows.py
@@ -67,7 +67,7 @@ class DesignWorkflow(Resource['DesignWorkflow'], Workflow):
         serializable=False
     )
     active = properties.Boolean('active', default=True)
-    created_by = properties.UUID('created_by', serializable=False)
+    created_by = properties.Optional(properties.UUID, 'created_by', serializable=False)
     create_time = properties.Datetime('create_time', serializable=False)
     design_space_id = properties.UUID('config.design_space_id')
     processor_id = properties.UUID('config.processor_id')
@@ -121,7 +121,7 @@ class PerformanceWorkflow(Resource['PerformanceWorkflow'], Workflow):
         serializable=False
     )
     active = properties.Boolean('active', default=True)
-    created_by = properties.UUID('created_by', serializable=False)
+    created_by = properties.Optional(properties.UUID, 'created_by', serializable=False)
     create_time = properties.Datetime('create_time', serializable=False)
     analysis = properties.Object(CrossValidationAnalysisConfiguration, 'config.analysis')
     module_type = properties.String('module_type', default='PERFORMANCE_WORKFLOW')

--- a/tests/serialization/test_workflow.py
+++ b/tests/serialization/test_workflow.py
@@ -39,6 +39,15 @@ def test_simple_deserialization(valid_data):
     assert workflow.predictor_id == UUID(valid_data['config']['predictor_id'])
 
 
+def test_deserialization_missing_created_by(valid_data):
+    """Ensure a DesignWorkflow can be deserialized with no created_by field."""
+    valid_data['created_by'] = None
+    workflow: DesignWorkflow = DesignWorkflow.build(valid_data)
+
+    assert workflow.design_space_id == UUID(valid_data['config']['design_space_id'])
+    assert workflow.created_by is None
+
+
 def test_polymorphic_deserialization(valid_data):
     """Ensure a polymorphically deserialized designWorkflow looks sane."""
     workflow: DesignWorkflow = Workflow.build(valid_data)


### PR DESCRIPTION
# Citrine Python PR

## Description 
This is breaking local integration tests.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
