### PR TITLE
Made the default per_page param for DataConcepts.list 100

### DIFF
--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -446,7 +446,7 @@ class DataConceptsCollection(Collection[ResourceType]):
 
     def list(self,
              page: Optional[int] = None,
-             per_page: Optional[int] = None) -> List[DataConcepts]:
+             per_page: Optional[int] = 100) -> List[DataConcepts]:
         """
         List all visible elements of the collection.
 

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -82,7 +82,7 @@ def test_list_material_runs(collection, session):
     })
 
     # When
-    runs = collection.list(page=1, per_page=10)
+    runs = collection.list()
 
     # Then
     assert 1 == session.num_calls
@@ -92,8 +92,7 @@ def test_list_material_runs(collection, session):
         params={
             'dataset_id': str(collection.dataset_id),
             'tags': [],
-            'page': 1,
-            'per_page': 10
+            'per_page': 100
         }
     )
     assert expected_call == session.last_call


### PR DESCRIPTION
# Citrine Python PR

## Description 
This is a bugfix to avoid passing per_page=None to Collection.list() which expects an integer (default 100).

Currently the following code snippet raises an exception:
`prj.material_runs.list()`.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
