### PR TITLE
PLA-2626:  Moving to training data with hard-coded version

### DIFF
--- a/src/citrine/informatics/data_tables.py
+++ b/src/citrine/informatics/data_tables.py
@@ -3,6 +3,15 @@ from citrine._serialization.serializable import Serializable
 
 
 class DataTable(Serializable['DataTable']):
+    """A specification for a data table, generally used to identify source data for some process.
+
+    Parameters
+    ----------
+    table_id: uuid
+        the UUID of the table to use
+
+    """
+
     table_id = properties.UUID('table_id')
     table_version = properties.String('table_version')
 

--- a/src/citrine/informatics/data_tables.py
+++ b/src/citrine/informatics/data_tables.py
@@ -1,0 +1,11 @@
+from citrine._serialization import properties
+from citrine._serialization.serializable import Serializable
+
+
+class DataTable(Serializable['DataTable']):
+    table_id = properties.UUID('table_id')
+    table_version = properties.String('table_version')
+
+    def __init__(self, table_id: str):
+        self.table_id = table_id
+        self.table_version = 'latest'   # This will be writable once the API does something with it

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -115,11 +115,6 @@ class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
 
     def _post_dump(self, data: dict) -> dict:
         data['display_name'] = data['config']['name']
-
-        # Temp
-        print('Predictor dump!')
-        print(data)
-
         return data
 
     def __str__(self):

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -8,6 +8,7 @@ from citrine._serialization.serializable import Serializable
 from citrine._session import Session
 from citrine.informatics.descriptors import Descriptor
 from citrine.informatics.reports import Report
+from citrine.informatics.data_tables import DataTable
 from citrine.resources.report import ReportResource
 from citrine.informatics.modules import Module
 
@@ -78,7 +79,7 @@ class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
     inputs = properties.List(properties.Object(Descriptor), 'config.inputs')
     outputs = properties.List(properties.Object(Descriptor), 'config.outputs')
     latent_variables = properties.List(properties.Object(Descriptor), 'config.latent_variables')
-    training_data = properties.String('config.training_data')
+    training_data = properties.Object(DataTable, 'config.training_data')
     typ = properties.String('config.type', default='Simple', deserializable=False)
     status = properties.String('status', serializable=False)
     status_info = properties.Optional(
@@ -98,7 +99,7 @@ class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
                  inputs: List[Descriptor],
                  outputs: List[Descriptor],
                  latent_variables: List[Descriptor],
-                 training_data: str,
+                 training_data: DataTable,
                  session: Optional[Session] = None,
                  report: Optional[Report] = None,
                  active: bool = True):
@@ -107,13 +108,18 @@ class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
         self.inputs: List[Descriptor] = inputs
         self.outputs: List[Descriptor] = outputs
         self.latent_variables: List[Descriptor] = latent_variables
-        self.training_data: str = training_data
+        self.training_data: DataTable = training_data
         self.session: Optional[Session] = session
         self.report: Optional[Report] = report
         self.active: bool = active
 
     def _post_dump(self, data: dict) -> dict:
         data['display_name'] = data['config']['name']
+
+        # Temp
+        print('Predictor dump!')
+        print(data)
+
         return data
 
     def __str__(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,7 +104,10 @@ def valid_simple_ml_predictor_data():
             inputs=[x.dump()],
             outputs=[z.dump()],
             latent_variables=[y.dump()],
-            training_data='training_data_key'
+            training_data=dict(
+                table_id='e5c51369-8e71-4ec6-b027-1f92bdc14762',
+                table_version='latest'
+            )
         )
     )
 

--- a/tests/informatics/test_predictors.py
+++ b/tests/informatics/test_predictors.py
@@ -5,6 +5,7 @@ import uuid
 
 from citrine.informatics.descriptors import RealDescriptor
 from citrine.informatics.predictors import ExpressionPredictor, GraphPredictor, SimpleMLPredictor
+from citrine.informatics.data_tables import DataTable
 
 x = RealDescriptor("x", 0, 100, "")
 y = RealDescriptor("y", 0, 100, "")
@@ -20,7 +21,7 @@ def simple_predictor() -> SimpleMLPredictor:
                              inputs=[x],
                              outputs=[z],
                              latent_variables=[y],
-                             training_data='training_data_key')
+                             training_data=DataTable('e5c51369-8e71-4ec6-b027-1f92bdc14762'))
 
 
 @pytest.fixture
@@ -53,7 +54,7 @@ def test_simple_initialization(simple_predictor):
     assert simple_predictor.outputs[0] == z
     assert len(simple_predictor.latent_variables) == 1
     assert simple_predictor.latent_variables[0] == y
-    assert simple_predictor.training_data == 'training_data_key'
+    assert simple_predictor.training_data.table_id == uuid.UUID('e5c51369-8e71-4ec6-b027-1f92bdc14762')
     assert str(simple_predictor) == '<SimplePredictor \'ML predictor\'>'
     assert hasattr(simple_predictor, 'report')
 

--- a/tests/serialization/test_predictors.py
+++ b/tests/serialization/test_predictors.py
@@ -1,5 +1,6 @@
 """Tests for citrine.informatics.predictors serialization."""
 import pytest
+from uuid import UUID
 
 from citrine.informatics.predictors import ExpressionPredictor, GraphPredictor, Predictor, SimpleMLPredictor
 from citrine.informatics.descriptors import RealDescriptor
@@ -20,7 +21,7 @@ def test_simple_legacy_deserialization(valid_simple_ml_predictor_data):
     assert predictor.outputs[0] == RealDescriptor("z", 0, 100, "")
     assert len(predictor.latent_variables) == 1
     assert predictor.latent_variables[0] == RealDescriptor("y", 0, 100, "")
-    assert predictor.training_data == 'training_data_key'
+    assert predictor.training_data.table_id == UUID('e5c51369-8e71-4ec6-b027-1f92bdc14762')
 
 
 def test_polymorphic_legacy_deserialization(valid_simple_ml_predictor_data):
@@ -34,7 +35,7 @@ def test_polymorphic_legacy_deserialization(valid_simple_ml_predictor_data):
     assert predictor.outputs[0] == RealDescriptor("z", 0, 100, "")
     assert len(predictor.latent_variables) == 1
     assert predictor.latent_variables[0] == RealDescriptor("y", 0, 100, "")
-    assert predictor.training_data == 'training_data_key'
+    assert predictor.training_data.table_id == UUID('e5c51369-8e71-4ec6-b027-1f92bdc14762')
 
 
 def test_legacy_serialization(valid_simple_ml_predictor_data):


### PR DESCRIPTION
# Citrine Python PR

## Description 
This changes the structure of specifying input data for predictors.  Currently `table_version` sends a hard-coded "latest" value, but this field will become writable once we move Orion to contact the data service.

### PR Type:
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
