### PR TITLE
Adding version upper bounds in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ class PostDevelopCommand(develop):
 
 
 setup(name='citrine',
-      version='0.7.0',
+      version='0.7.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',
@@ -36,15 +36,14 @@ setup(name='citrine',
       package_dir={'': 'src'},
       packages=find_packages(where='src'),
       install_requires=[
-          "requests",
-          "pyjwt",
-          "arrow",
-          "pytest>=4.3",
-          "strip-hints>=0.1.5",
-          "taurus-citrine>=0.4.0",
-          "boto3",
-          "botocore",
-          "deprecation"
+          "requests>=2.22.0,<3",
+          "pyjwt>=1.7.1,<2",
+          "arrow>=0.15.4,<0.16",
+          "strip-hints>=0.1.5,<=0.1.7",
+          "taurus-citrine>=0.4.0,<0.5",
+          "boto3>=1.9.226,<2",
+          "botocore>=1.12.226,<2",
+          "deprecation>=2.0.7,<3"
       ],
       cmdclass={
           'install': PostInstallCommand,


### PR DESCRIPTION
Our version upper bound on taurus-citrine was removed
with the last release, making any upstream breaking changes breaking
to this package as well.  This hotpatch adds the upper version bound
back (on the minor rather than major version since taurus-citrine
is pre-release) and also adds very generous upper bounds to the
rest of the dependencies.

py.test was removed as a install_requires because it is actually
a tests_require.  An issue has been opened to add those dependencies: #181 