### PR TITLE
Fixed key-value order in expression aliases.

### DIFF
--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -119,8 +119,8 @@ The following example demonstrates how to use the python SDK to create a :class:
        expression = 'Y / (2 * (1 + v))',
        output = shear_modulus,
        aliases = {
-           "Property~Young's modulus": 'Y',
-           "Property~Poisson's ratio": 'v'
+           'Y': "Property~Young's modulus",
+           'v': "Property~Poisson's ratio"
        }
    )
 

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -196,7 +196,7 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
     output: Descriptor
         the Descriptor that represents the output relation
     aliases: dict
-        a mapping from descriptor key to expression argument
+        a mapping from expression argument to descriptor key
 
     """
 

--- a/tests/informatics/test_predictors.py
+++ b/tests/informatics/test_predictors.py
@@ -39,8 +39,8 @@ def expression_predictor() -> ExpressionPredictor:
         expression='Y / (2 * (1 + v))',
         output=shear_modulus,
         aliases = {
-            "Property~Young's modulus": 'Y',
-            "Property~Poisson's ratio": 'v'
+             'Y': "Property~Young's modulus",
+             'v': "Property~Poisson's ratio"
         })
 
 
@@ -96,7 +96,7 @@ def test_expression_initialization(expression_predictor):
     assert expression_predictor.name == 'Expression predictor'
     assert expression_predictor.output.key == 'Property~Shear modulus'
     assert expression_predictor.expression == 'Y / (2 * (1 + v))'
-    assert expression_predictor.aliases == {"Property~Young's modulus": 'Y', "Property~Poisson's ratio": 'v'}
+    assert expression_predictor.aliases == {'Y': "Property~Young's modulus", 'v': "Property~Poisson's ratio"}
     assert str(expression_predictor) == '<ExpressionPredictor \'Expression predictor\'>'
 
 


### PR DESCRIPTION
The expression predictor expects a map from alias to descriptor key. This was reversed in citrine-python.
