### PR TITLE
Adding preview route for AraDefinitions

### DIFF
--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -3,6 +3,7 @@ from typing import Optional, Dict, List, Union
 from uuid import UUID
 
 from citrine._session import Session
+from citrine.resources.ara_definition import AraDefinitionCollection
 from citrine.resources.module import ModuleCollection
 from citrine.resources.design_space import DesignSpaceCollection
 from citrine.resources.processor import ProcessorCollection
@@ -186,6 +187,11 @@ class Project(Resource['Project']):
     def ingredient_specs(self) -> IngredientSpecCollection:
         """Return a resource representing all ingredient specs in this dataset."""
         return IngredientSpecCollection(self.uid, None, self.session)
+
+    @property
+    def ara_definitions(self) -> AraDefinitionCollection:
+        """Return a resource representing all ara definitions in the project."""
+        return AraDefinitionCollection(self.uid, self.session)
 
     def share(self,
               project_id: str,

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -171,6 +171,10 @@ def test_workflows_get_project_id(project):
     assert project.uid == project.workflows.project_id
 
 
+def test_ara_definitions_get_project_id(project):
+    assert project.uid == project.ara_definitions.project_id
+
+
 def test_project_registration(collection, session):
     # Given
     create_time = parse('2019-09-10T00:00:00+00:00')


### PR DESCRIPTION
# Citrine Python PR

## Description 
This adds `AraDefinitionCollection.preview` and `AraDefinition.add_columns`, both of which are ALPHA.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
