### PR TITLE
Align MeanColumn.type with backend

### DIFF
--- a/src/citrine/ara/columns.py
+++ b/src/citrine/ara/columns.py
@@ -55,7 +55,7 @@ class MeanColumn(Serializable['MeanColumn'], Column):
 
     data_source = properties.String('data_source')
     target_units = properties.Optional(properties.String, "target_units")
-    typ = properties.String('type', default="real_mean_column", deserializable=False)
+    typ = properties.String('type', default="mean_column", deserializable=False)
 
     def _attrs(self) -> List[str]:
         return ["data_source", "target_units", "typ"]


### PR DESCRIPTION
We changed the `typ` string in the backend to [`mean_column`](https://github.com/CitrineInformatics/platform-backend/blob/develop/code/ara/model/src/main/scala/io/citrine/ara/model/column/RealColumnDefinition.scala#L31).  This reflects that change.