### PR TITLE
Reproduction steps for flattening bug on taurus-extended objects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-taurus-citrine==0.4.0
+git+https://github.com/CitrineInformatics/taurus.git@bugfix/flatten-fails-empty-history
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.15.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/CitrineInformatics/taurus.git@develop
+taurus-citrine==0.5.0
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.15.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/CitrineInformatics/taurus.git@bugfix/flatten-fails-empty-history
+git+https://github.com/CitrineInformatics/taurus.git@develop
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.15.4

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='citrine',
           "pyjwt>=1.7.1,<2",
           "arrow>=0.15.4,<0.16",
           "strip-hints>=0.1.5,<=0.1.7",
-          "taurus-citrine>=0.4.0,<0.5",
+          "taurus-citrine>=0.5.0,<0.6",
           "boto3>=1.9.226,<2",
           "botocore>=1.12.226,<2",
           "deprecation>=2.0.7,<3"

--- a/tests/_serialization/test_taurus_interop.py
+++ b/tests/_serialization/test_taurus_interop.py
@@ -1,0 +1,24 @@
+from citrine.resources.condition_template import ConditionTemplate
+from citrine.resources.process_spec import ProcessSpec
+from citrine.resources.process_template import ProcessTemplate
+
+from taurus.entity.bounds.categorical_bounds import CategoricalBounds
+from taurus.util import flatten
+
+
+def test_flatten():
+    """Test that taurus utility methods can be applied to citrine-python objects.
+
+    Citrine-python resources extend the taurus data model, so the taurus operations
+    should work on them.
+    """
+
+    bounds = CategoricalBounds(categories=["foo", "bar"])
+    template = ProcessTemplate(
+        "spam",
+        conditions=[(ConditionTemplate(name="eggs", bounds=bounds), bounds)]
+    )
+    spec = ProcessSpec(name="spec", template=template)
+
+    flat = flatten(spec)
+    assert len(flat) == 2, "Expected 2 flattened objects"


### PR DESCRIPTION
There was an exception being thrown when flatten was called because of inconsistencies in the logic of `as_dict` and `build`.  This was resolvable in taurus, so we just pulled the new version here.