### PR TITLE
Modified Taurus version bounds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='citrine',
           "pyjwt>=1.7.1,<2",
           "arrow>=0.15.4,<0.16",
           "strip-hints>=0.1.5,<=0.1.7",
-          "taurus-citrine>=0.4.0,<0.5",
+          "taurus-citrine>=0.4.0,<0.6",
           "boto3>=1.9.226,<2",
           "botocore>=1.12.226,<2",
           "deprecation>=2.0.7,<3"


### PR DESCRIPTION
# Citrine Python PR

## Description 
The version limit rollback created issues with data access.  This broadens the compatibility statement to include 0.5.0 or Taurus.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [X] I have communicated the downstream consequences of the PR to others.
