### PR TITLE
Bumping the taurus version to 0.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-taurus-citrine==0.4.0
+taurus-citrine==0.4.1
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.15.4


### PR DESCRIPTION
Older version should still work, so we're not pulling up the lower bound in setup.py (no bugfixes).