### PR TITLE
PLA-2567 Switch ara path template /ara -> /ara-definitions

### DIFF
--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -125,7 +125,7 @@ class AraDefinition(Resource["AraDefinition"]):
 class AraDefinitionCollection(Collection[AraDefinition]):
     """[ALPHA] Represents the collection of all Ara Definitions associated with a project."""
 
-    _path_template = 'projects/{project_id}/ara'
+    _path_template = 'projects/{project_id}/ara-definitions'
 
     def __init__(self, project_id: UUID, session: Session):
         self.project_id = project_id

--- a/tests/resources/test_ara_definition.py
+++ b/tests/resources/test_ara_definition.py
@@ -50,7 +50,7 @@ def test_get_ara_definition_metadata(collection, session):
     assert 1 == session.num_calls
     expect_call = FakeCall(
         method="GET",
-        path="projects/{}/ara/{}/versions/{}".format(project_id, ara_definition["id"], ara_definition["version"])
+        path="projects/{}/ara-definitions/{}/versions/{}".format(project_id, ara_definition["id"], ara_definition["version"])
     )
     assert session.last_call == expect_call
     assert str(retrieved_ara_definition.uid) == ara_definition["id"]
@@ -134,7 +134,7 @@ def test_preview(collection, session):
     assert 1 == session.num_calls
     expect_call = FakeCall(
         method="POST",
-        path="projects/{}/ara/preview".format(project_id),
+        path="projects/{}/ara-definitions/preview".format(project_id),
         json={"definition": empty_defn().dump(), "rows": []}
     )
     assert session.last_call == expect_call


### PR DESCRIPTION
# Citrine Python PR (PLA-2567)

## Description 
Switch ara path template /ara -> /ara-definitions to make it easier to add future endpoints that use /ara-definitions

### PR Type:
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [x] I have communicated the downstream consequences of the PR to others.
