### PR TITLE
PLA-2567 Add AraDefinitionCollection.register()

### DIFF
--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -192,6 +192,29 @@ class AraDefinitionCollection(Collection[AraDefinition]):
             data = data[self._individual_key] if self._individual_key else data
             return self.build(data)
         else:
+            # Implement update as a part of register both because:
+            # 1) The validation requirements are the same for updating and registering an
+            #    AraDefinition
+            # 2) This prevents users from accidentally registering duplicate AraDefinitions
             data = self.session.put_resource(self._get_path(defn.definition_uid), body)
             data = data[self._individual_key] if self._individual_key else data
             return self.build(data)
+
+    def update(self, defn: AraDefinition) -> AraDefinition:
+        """
+        [ALPHA] Update an AraDefinition.
+
+        If the provided AraDefinition does have a uid, update (replace) the AraDefinition at that
+        uid with the provided AraDefinition.
+
+        Raise a ValueError if the provided AraDefinition does not have a definition_uid.
+
+        :param defn: The AraDefinition to updated
+        :return: The updated AraDefinition with updated metadata
+        """
+        if defn.definition_uid is None:
+            raise ValueError("Cannot update Ara Definition without a definition_uid."
+                             " Please either use register() to initially register this"
+                             " Ara Definition or retrieve the registered details before calling"
+                             " update()")
+        return self.register(defn)

--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -40,8 +40,9 @@ class AraDefinition(Resource["AraDefinition"]):
     def _get_dups(lst: List) -> List:
         return [x for x in lst if lst.count(x) > 1]
 
-    uid = properties.Optional(properties.UUID(), 'id')
-    version = properties.Optional(properties.Integer, 'version')
+    definition_uid = properties.Optional(properties.UUID(), 'definition_id')
+    version_uid = properties.Optional(properties.UUID(), 'id')
+    version_number = properties.Optional(properties.Integer, 'version_number')
     name = properties.String("name")
     description = properties.String("description")
     datasets = properties.List(properties.UUID, "datasets")
@@ -51,15 +52,17 @@ class AraDefinition(Resource["AraDefinition"]):
 
     def __init__(self, *, name: str, description: str, datasets: List[UUID],
                  variables: List[Variable], rows: List[Row], columns: List[Column],
-                 uid: Optional[UUID] = None, version: Optional[int] = None):
+                 version_uid: Optional[UUID] = None, version_number: Optional[int] = None,
+                 definition_uid: Optional[UUID] = None):
         self.name = name
         self.description = description
         self.datasets = datasets
         self.rows = rows
         self.variables = variables
         self.columns = columns
-        self.uid = uid
-        self.version = version
+        self.version_uid = version_uid
+        self.version_number = version_number
+        self.definition_uid = definition_uid
 
         # Note that these validations only apply at construction time. The current intended usage
         # is for this object to be created holistically; if changed, then these will need
@@ -126,20 +129,25 @@ class AraDefinitionCollection(Collection[AraDefinition]):
     """[ALPHA] Represents the collection of all Ara Definitions associated with a project."""
 
     _path_template = 'projects/{project_id}/ara-definitions'
+    _individual_key = 'version'
 
     def __init__(self, project_id: UUID, session: Session):
         self.project_id = project_id
         self.session: Session = session
 
-    def get(self, uid: Union[UUID, str], version: int) -> AraDefinition:
-        """Get an Ara Definition."""
-        path = self._get_path(uid) + "/versions/{}".format(version)
+    def get_with_version(self, definition_uid: Union[UUID, str],
+                         version_number: int) -> AraDefinition:
+        """[ALPHA] Get an Ara Definition at a specific version."""
+        path = self._get_path(definition_uid) + "/versions/{}".format(version_number)
         data = self.session.get_resource(path)
         return self.build(data)
 
     def build(self, data: dict) -> AraDefinition:
-        """Build an individual Ara Definition from a dictionary."""
-        defn = AraDefinition.build(data)
+        """[ALPHA] Build an individual Ara Definition from a dictionary."""
+        defn = AraDefinition.build(data['ara_definition'])
+        defn.definition_uid = data['definition_id']
+        defn.version_number = data['version_number']
+        defn.version_uid = data['id']
         defn.project_id = self.project_id
         defn.session = self.session
         return defn
@@ -161,3 +169,29 @@ class AraDefinitionCollection(Collection[AraDefinition]):
             "rows": [x.as_dict() for x in preview_roots]
         }
         return self.session.post_resource(path, body)
+
+    def register(self, defn: AraDefinition) -> AraDefinition:
+        """
+        [ALPHA] Register an Ara Definition.
+
+        If the provided AraDefinition does not have a definition_uid, create a new element of the
+        AraDefinitionCollection by registering the provided AraDefinition. If the provided
+        AraDefinition does have a uid, update (replace) the AraDefinition at that uid with the
+        provided AraDefinition.
+
+        :param defn: The AraDefinition to register
+
+        :return: The registered AraDefinition with updated metadata
+
+        TODO: Consider validating that a resource exists at the given uid before updating.
+            The code to do so is not yet implemented on the backend
+        """
+        body = {"definition": defn.dump()}
+        if defn.definition_uid is None:
+            data = self.session.post_resource(self._get_path(), body)
+            data = data[self._individual_key] if self._individual_key else data
+            return self.build(data)
+        else:
+            data = self.session.put_resource(self._get_path(defn.definition_uid), body)
+            data = data[self._individual_key] if self._individual_key else data
+            return self.build(data)

--- a/tests/resources/test_ara_definition.py
+++ b/tests/resources/test_ara_definition.py
@@ -213,3 +213,40 @@ def test_register_existing(collection, session):
         json={"definition": collection.build(ara_definition).dump()}
     )
     assert session.last_call == expect_call
+
+
+def test_update(collection, session):
+    """Test the behavior of AraDefinitionCollection.update() on a registered AraDefinition"""
+    # Given
+    project_id = '6b608f78-e341-422c-8076-35adc8828545'
+    ara_definition = AraDefinitionFactory()
+    definition_uid = ara_definition["definition_id"]
+    assert definition_uid is not None
+    session.set_response({"version": ara_definition})
+
+    # When
+    collection.update(collection.build(ara_definition))
+
+    # Then
+    assert 1 == session.num_calls
+    expect_call = FakeCall(
+        method="PUT",
+        path="projects/{}/ara-definitions/{}".format(project_id, definition_uid),
+        json={"definition": collection.build(ara_definition).dump()}
+    )
+    assert session.last_call == expect_call
+
+
+def test_update_unregistered_fail(collection, session):
+    """Test that AraDefinitionCollection.update() fails on an unregistered AraDefinition"""
+    # Given
+    project_id = '6b608f78-e341-422c-8076-35adc8828545'
+    ara_definition = AraDefinitionFactory()
+    ara_definition["definition_id"] = None
+    ara_definition["id"] = None
+    ara_definition["version_number"] = None
+    session.set_response({"version": ara_definition})
+
+    # When
+    with pytest.raises(ValueError, match="Cannot update Ara Definition without a definition_uid."):
+        collection.update(collection.build(ara_definition))

--- a/tests/resources/test_ara_definition.py
+++ b/tests/resources/test_ara_definition.py
@@ -2,6 +2,7 @@ import json
 from uuid import UUID, uuid4
 
 import pytest
+from citrine.exceptions import ModuleRegistrationFailedException
 from taurus.entity.link_by_uid import LinkByUID
 
 from citrine.ara.columns import MeanColumn, OriginalUnitsColumn, StdDevColumn, IdentityColumn
@@ -44,23 +45,23 @@ def test_get_ara_definition_metadata(collection, session):
     session.set_response(ara_definition)
 
     # When
-    retrieved_ara_definition: AraDefinition = collection.get(ara_definition["id"], ara_definition["version"])
+    retrieved_ara_definition: AraDefinition = collection.get_with_version(ara_definition["definition_id"], ara_definition["version_number"])
 
     # Then
     assert 1 == session.num_calls
     expect_call = FakeCall(
         method="GET",
-        path="projects/{}/ara-definitions/{}/versions/{}".format(project_id, ara_definition["id"], ara_definition["version"])
+        path="projects/{}/ara-definitions/{}/versions/{}".format(project_id, ara_definition["definition_id"], ara_definition["version_number"])
     )
     assert session.last_call == expect_call
-    assert str(retrieved_ara_definition.uid) == ara_definition["id"]
-    assert retrieved_ara_definition.version == ara_definition["version"]
+    assert str(retrieved_ara_definition.definition_uid) == ara_definition["definition_id"]
+    assert retrieved_ara_definition.version_number == ara_definition["version_number"]
 
 
 def test_init_ara_definition():
     ara_definition = AraDefinition(name="foo", description="bar", rows=[], columns=[], variables=[], datasets=[])
-    assert ara_definition.uid is None
-    assert ara_definition.version is None
+    assert ara_definition.definition_uid is None
+    assert ara_definition.version_number is None
 
 
 def test_dup_names():
@@ -167,3 +168,48 @@ def test_add_columns():
             columns=[IdentityColumn(data_source="name")]
         )
     assert "already used" in str(excinfo.value)
+
+
+def test_register_new(collection, session):
+    """Test the behavior of AraDefinitionCollection.register() on an unregistered AraDefinition"""
+    # Given
+    project_id = '6b608f78-e341-422c-8076-35adc8828545'
+    ara_definition = AraDefinitionFactory()
+    ara_definition["definition_id"] = None
+    ara_definition["id"] = None
+    ara_definition["version_number"] = None
+    session.set_response({"version": ara_definition})
+
+    # When
+    collection.register(collection.build(ara_definition))
+
+    # Then
+    assert 1 == session.num_calls
+    expect_call = FakeCall(
+        method="POST",
+        path="projects/{}/ara-definitions".format(project_id),
+        json={"definition": collection.build(ara_definition).dump()}
+    )
+    assert session.last_call == expect_call
+
+
+def test_register_existing(collection, session):
+    """Test the behavior of AraDefinitionCollection.register() on a registered AraDefinition"""
+    # Given
+    project_id = '6b608f78-e341-422c-8076-35adc8828545'
+    ara_definition = AraDefinitionFactory()
+    definition_uid = ara_definition["definition_id"]
+    assert definition_uid is not None
+    session.set_response({"version": ara_definition})
+
+    # When
+    collection.register(collection.build(ara_definition))
+
+    # Then
+    assert 1 == session.num_calls
+    expect_call = FakeCall(
+        method="PUT",
+        path="projects/{}/ara-definitions/{}".format(project_id, definition_uid),
+        json={"definition": collection.build(ara_definition).dump()}
+    )
+    assert session.last_call == expect_call

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -38,15 +38,20 @@ class TableDataFactory(factory.DictFactory):
     signed_download_url = factory.Faker('uri')
 
 
-class AraDefinitionFactory(factory.DictFactory):
-    id = factory.Faker('uuid4')
-    version = randrange(10)
+class AraDefinitionDataFactory(factory.DictFactory):
     name = factory.Faker("company")
     description = factory.Faker('bs')
     rows = []
     columns = []
     variables = []
     datasets = []
+
+
+class AraDefinitionFactory(factory.DictFactory):
+    ara_definition = factory.SubFactory(AraDefinitionDataFactory)
+    id = factory.Faker('uuid4')
+    version_number = randrange(10)
+    definition_id = factory.Faker('uuid4')
 
 
 class DatasetDataFactory(factory.DictFactory):


### PR DESCRIPTION
Covers both creating a new Ara Definition and updating an existing one

# Citrine Python PR

## Description 
Adds citrine-python method corresponding to the endpoints to create and update an AraDefinition

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
