### PR TITLE
Adding attribute_constraints to AttributeByTemplate

### DIFF
--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -100,7 +100,7 @@ class AttributeByTemplate(Serializable['AttributeByTemplate'], Variable):
         attribute template that identifies the attribute to assign to the variable
     attribute_constraints: list[(LinkByUID, Bounds)]
         constraints on object attributes in the target object that must be satisfied. Constraints
-        are expressed as Bounds.  Attributes are expressed with links. The attribute that the 
+        are expressed as Bounds.  Attributes are expressed with links. The attribute that the
         variable is being set to may be the target of a constraint as well.
 
     """
@@ -144,7 +144,7 @@ class AttributeByTemplateAfterProcessTemplate(
         process template that identifies the originating process
     attribute_constraints: list[(LinkByUID, Bounds)]
         constraints on object attributes in the target object that must be satisfied. Constraints
-        are expressed as Bounds.  Attributes are expressed with links. The attribute that the 
+        are expressed as Bounds.  Attributes are expressed with links. The attribute that the
         variable is being set to may be the target of a constraint as well.
 
     """

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -1,7 +1,8 @@
 """Variable definitions for Ara."""
 from abc import abstractmethod
-from typing import Type, Optional, List  # noqa: F401
+from typing import Type, Optional, List, Tuple  # noqa: F401
 
+from taurus.entity.bounds.base_bounds import BaseBounds
 from taurus.entity.link_by_uid import LinkByUID
 from taurus.enumeration.base_enumeration import BaseEnumeration
 
@@ -97,12 +98,20 @@ class AttributeByTemplate(Serializable['AttributeByTemplate'], Variable):
         sequence of column headers
     template: LinkByUID
         attribute template that identifies the attribute to assign to the variable
+    attribute_constraints: list[tuple[LinkByUID, Bounds]]
+        constraints, expressed as Bounds, on attributes, expressed with links, in the object that
+        contains the target attribute.  The attribute that the variable is being set to may
+        be the target of a constraint as well.
 
     """
 
     name = properties.String('name')
     headers = properties.List(properties.String, 'headers')
     template = properties.Object(LinkByUID, 'template')
+    attribute_constraints = properties.Optional(
+        properties.List(
+            properties.MixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
+        ), 'attribute_constraints')
     typ = properties.String('type', default="attribute_by_template", deserializable=False)
 
     def _attrs(self) -> List[str]:
@@ -111,10 +120,12 @@ class AttributeByTemplate(Serializable['AttributeByTemplate'], Variable):
     def __init__(self, *,
                  name: str,
                  headers: List[str],
-                 template: LinkByUID):
+                 template: LinkByUID,
+                 attribute_constraints: List[Tuple[LinkByUID, BaseBounds]] = None):
         self.name = name
         self.headers = headers
         self.template = template
+        self.attribute_constraints = [list(x) for x in attribute_constraints or []]
 
 
 class AttributeByTemplateAfterProcessTemplate(

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -99,9 +99,9 @@ class AttributeByTemplate(Serializable['AttributeByTemplate'], Variable):
     template: LinkByUID
         attribute template that identifies the attribute to assign to the variable
     attribute_constraints: list[(LinkByUID, Bounds)]
-        constraints, expressed as Bounds, on attributes, expressed with links, in the object that
-        contains the target attribute.  The attribute that the variable is being set to may
-        be the target of a constraint as well.
+        constraints on object attributes in the target object that must be satisfied. Constraints
+        are expressed as Bounds.  Attributes are expressed with links. The attribute that the 
+        variable is being set to may be the target of a constraint as well.
 
     """
 
@@ -143,9 +143,9 @@ class AttributeByTemplateAfterProcessTemplate(
     process_template: LinkByUID
         process template that identifies the originating process
     attribute_constraints: list[(LinkByUID, Bounds)]
-        constraints, expressed as Bounds, on attributes, expressed with links, in the object that
-        contains the target attribute.  The attribute that the variable is being set to may
-        be the target of a constraint as well.
+        constraints on object attributes in the target object that must be satisfied. Constraints
+        are expressed as Bounds.  Attributes are expressed with links. The attribute that the 
+        variable is being set to may be the target of a constraint as well.
 
     """
 
@@ -195,9 +195,9 @@ class AttributeByTemplateAndObjectTemplate(
     object_template: LinkByUID
         template that identifies the associated object
     attribute_constraints: list[(LinkByUID, Bounds)]
-        constraints, expressed as Bounds, on attributes, expressed with links, in the object that
-        contains the target attribute.  The attribute that the variable is being set to may
-        be the target of a constraint as well.
+        constraints on object attributes in the target object that must be satisfied. Constraints
+        are expressed as Bounds.  Attributes are expressed with links. The attribute that the
+        variable is being set to may be the target of a constraint as well.
 
     """
 

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -1,6 +1,6 @@
 """Variable definitions for Ara."""
 from abc import abstractmethod
-from typing import Type, Optional, List, Tuple  # noqa: F401
+from typing import Type, Optional, List, Tuple, Union  # noqa: F401
 
 from taurus.entity.bounds.base_bounds import BaseBounds
 from taurus.entity.link_by_uid import LinkByUID
@@ -98,7 +98,7 @@ class AttributeByTemplate(Serializable['AttributeByTemplate'], Variable):
         sequence of column headers
     template: LinkByUID
         attribute template that identifies the attribute to assign to the variable
-    attribute_constraints: list[tuple[LinkByUID, Bounds]]
+    attribute_constraints: list[(LinkByUID, Bounds)]
         constraints, expressed as Bounds, on attributes, expressed with links, in the object that
         contains the target attribute.  The attribute that the variable is being set to may
         be the target of a constraint as well.
@@ -121,11 +121,11 @@ class AttributeByTemplate(Serializable['AttributeByTemplate'], Variable):
                  name: str,
                  headers: List[str],
                  template: LinkByUID,
-                 attribute_constraints: List[Tuple[LinkByUID, BaseBounds]] = None):
+                 attribute_constraints: Optional[List[List[Union[LinkByUID, BaseBounds]]]] = None):
         self.name = name
         self.headers = headers
         self.template = template
-        self.attribute_constraints = [list(x) for x in attribute_constraints or []]
+        self.attribute_constraints = attribute_constraints
 
 
 class AttributeByTemplateAfterProcessTemplate(
@@ -142,6 +142,10 @@ class AttributeByTemplateAfterProcessTemplate(
         attribute template that identifies the attribute to assign to the variable
     process_template: LinkByUID
         process template that identifies the originating process
+    attribute_constraints: list[(LinkByUID, Bounds)]
+        constraints, expressed as Bounds, on attributes, expressed with links, in the object that
+        contains the target attribute.  The attribute that the variable is being set to may
+        be the target of a constraint as well.
 
     """
 
@@ -149,6 +153,10 @@ class AttributeByTemplateAfterProcessTemplate(
     headers = properties.List(properties.String, 'headers')
     attribute_template = properties.Object(LinkByUID, 'attribute_template')
     process_template = properties.Object(LinkByUID, 'process_template')
+    attribute_constraints = properties.Optional(
+        properties.List(
+            properties.MixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
+        ), 'attribute_constraints')
     typ = properties.String('type', default="attribute_after_process", deserializable=False)
 
     def _attrs(self) -> List[str]:
@@ -158,11 +166,13 @@ class AttributeByTemplateAfterProcessTemplate(
                  name: str,
                  headers: List[str],
                  attribute_template: LinkByUID,
-                 process_template: LinkByUID):
+                 process_template: LinkByUID,
+                 attribute_constraints: Optional[List[List[Union[LinkByUID, BaseBounds]]]] = None):
         self.name = name
         self.headers = headers
         self.attribute_template = attribute_template
         self.process_template = process_template
+        self.attribute_constraints = attribute_constraints
 
 
 class AttributeByTemplateAndObjectTemplate(
@@ -184,7 +194,10 @@ class AttributeByTemplateAndObjectTemplate(
         attribute template that identifies the attribute to assign to the variable
     object_template: LinkByUID
         template that identifies the associated object
-
+    attribute_constraints: list[(LinkByUID, Bounds)]
+        constraints, expressed as Bounds, on attributes, expressed with links, in the object that
+        contains the target attribute.  The attribute that the variable is being set to may
+        be the target of a constraint as well.
 
     """
 
@@ -192,6 +205,10 @@ class AttributeByTemplateAndObjectTemplate(
     headers = properties.List(properties.String, 'headers')
     attribute_template = properties.Object(LinkByUID, 'attribute_template')
     object_template = properties.Object(LinkByUID, 'object_template')
+    attribute_constraints = properties.Optional(
+        properties.List(
+            properties.MixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
+        ), 'attribute_constraints')
     typ = properties.String('type', default="attribute_by_object", deserializable=False)
 
     def _attrs(self) -> List[str]:
@@ -201,11 +218,13 @@ class AttributeByTemplateAndObjectTemplate(
                  name: str,
                  headers: List[str],
                  attribute_template: LinkByUID,
-                 object_template: LinkByUID):
+                 object_template: LinkByUID,
+                 attribute_constraints: List[List[Union[LinkByUID, BaseBounds]]] = None):
         self.name = name
         self.headers = headers
         self.attribute_template = attribute_template
         self.object_template = object_template
+        self.attribute_constraints = attribute_constraints
 
 
 class IngredientIdentifierByProcessTemplateAndName(

--- a/tests/ara/test_variables.py
+++ b/tests/ara/test_variables.py
@@ -8,7 +8,7 @@ from taurus.entity.link_by_uid import LinkByUID
 
 @pytest.fixture(params=[
     RootInfo(name="root name", headers=["Root", "Name"], field="name"),
-    AttributeByTemplate(name="density", headers=["density"], template=LinkByUID(scope="templates", id="density"), attribute_constraints=[(LinkByUID(scope="templates", id="density"), RealBounds(0, 100, "g/cm**3"))]),
+    AttributeByTemplate(name="density", headers=["density"], template=LinkByUID(scope="templates", id="density"), attribute_constraints=[[LinkByUID(scope="templates", id="density"), RealBounds(0, 100, "g/cm**3")]]),
     AttributeByTemplateAfterProcessTemplate(name="density", headers=["density"], attribute_template=LinkByUID(scope="template", id="density"), process_template=LinkByUID(scope="template", id="process")),
     AttributeByTemplateAndObjectTemplate(name="density", headers=["density"], attribute_template=LinkByUID(scope="template", id="density"), object_template=LinkByUID(scope="template", id="object")),
     IngredientIdentifierByProcessTemplateAndName(name="ingredient id", headers=["density"], process_template=LinkByUID(scope="template", id="process"), ingredient_name="ingredient", scope="scope"),

--- a/tests/ara/test_variables.py
+++ b/tests/ara/test_variables.py
@@ -1,5 +1,6 @@
 """Tests for citrine.informatics.variables."""
 import pytest
+from taurus.entity.bounds.real_bounds import RealBounds
 
 from citrine.ara.variables import *
 from taurus.entity.link_by_uid import LinkByUID
@@ -7,7 +8,7 @@ from taurus.entity.link_by_uid import LinkByUID
 
 @pytest.fixture(params=[
     RootInfo(name="root name", headers=["Root", "Name"], field="name"),
-    AttributeByTemplate(name="density", headers=["density"], template=LinkByUID(scope="templates", id="density")),
+    AttributeByTemplate(name="density", headers=["density"], template=LinkByUID(scope="templates", id="density"), attribute_constraints=[(LinkByUID(scope="templates", id="density"), RealBounds(0, 100, "g/cm**3"))]),
     AttributeByTemplateAfterProcessTemplate(name="density", headers=["density"], attribute_template=LinkByUID(scope="template", id="density"), process_template=LinkByUID(scope="template", id="process")),
     AttributeByTemplateAndObjectTemplate(name="density", headers=["density"], attribute_template=LinkByUID(scope="template", id="density"), object_template=LinkByUID(scope="template", id="object")),
     IngredientIdentifierByProcessTemplateAndName(name="ingredient id", headers=["density"], process_template=LinkByUID(scope="template", id="process"), ingredient_name="ingredient", scope="scope"),


### PR DESCRIPTION
# Citrine Python PR

## Description 
These constraints apply to the attributes in the object template
that contains the target attribute.  This is client support for the backend feature added in https://github.com/CitrineInformatics/platform-backend/pull/885

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
