### PR TITLE
Adding citrine.attributes __init__.py file back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 - pip install --no-deps -e .
 script:
 - pytest --cov=src/ --cov-report term-missing --cov-report term:skip-covered
-  --cov-fail-under=100 -s -r .
+  --cov-config=tox.ini --cov-fail-under=100 -s -r .
 - flake8 src
 - cd docs; make html; cd ..;
 - touch ./docs/_build/html/.nojekyll

--- a/src/citrine/attributes/__init__.py
+++ b/src/citrine/attributes/__init__.py
@@ -1,0 +1,1 @@
+"""Resources that represent attributes."""

--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,8 @@ exclude = tests/*
 
 [pytest]
 testpaths = tests
+
+[run]
+omit =
+    # skip deprecated sources
+    src/citrine/attributes/*


### PR DESCRIPTION
SSIA.  Since we're deprecating the previous locations, we need this to define the module still