### PR TITLE
PLA-3160: add ALPHA tag to documentation

### DIFF
--- a/docs/source/workflows/index.rst
+++ b/docs/source/workflows/index.rst
@@ -1,7 +1,7 @@
 .. _workflows:
 
-Workflows
-=========
+[ALPHA] Workflows
+=================
 
 The Citrine Platform provides tools to make data-driven decisions for materials research and development using artificial intelligence (AI) workflows.
 AI Workflows are composed of modules, which provide the ability to programmatically codify domain knowledge, research capabilities and experimental objectives.


### PR DESCRIPTION
Add ALPHA tag to Orion Workflow documentation.

https://citrine.atlassian.net/browse/PLA-3160

