### PR TITLE
Change scores MLI and MEI to LI and EI

### DIFF
--- a/docs/source/workflows/design_workflows.rst
+++ b/docs/source/workflows/design_workflows.rst
@@ -54,7 +54,7 @@ The ``i`` th candidate corresponds to the ``i`` th score.
 Each candidate and score is a dictionary.
 The former contains descriptor key-value pairs and uncertainty in descriptor values.
 The latter contains a key-value pair for each score.
-For example, if input materials contain an input ``x`` and are scored by using MLI for predicted output ``z`` the execution results would have the form:
+For example, if input materials contain an input ``x`` and are scored by using LI for predicted output ``z`` the execution results would have the form:
 
 .. code:: python
 
@@ -65,7 +65,7 @@ For example, if input materials contain an input ``x`` and are scored by using M
                # ...
            ],
            "scores": [
-               {"mli_z": 0.8},
+               {"li_z": 0.8},
                # ...
            ]
        }
@@ -81,10 +81,10 @@ The following demonstrates how to trigger workflow execution, wait for the desig
 
    from time import sleep
    from citrine.informatics.objectives import ScalarMaxObjective
-   from citrine.informatics.scores import MLIScore
+   from citrine.informatics.scores import LIScore
 
    # create a score with the desired objectives and baselines
-   score = MLIScore(
+   score = LIScore(
        name='Example score',
        description='Used to rank materials',
        # create an objective to maximize shear modulus

--- a/docs/source/workflows/scores.rst
+++ b/docs/source/workflows/scores.rst
@@ -15,36 +15,36 @@ Higher scores represent “better” materials.
 
 Currently, there are two scores:
 
--  `Maximum expected improvement <#maximum-expected-improvement>`__
--  `Maximum likelihood of improvement <#maximum-likelihood-of-improvement>`__
+-  `Expected improvement <#expected-improvement>`__
+-  `Likelihood of improvement <#likelihood-of-improvement>`__
 
-Maximum expected improvement
-----------------------------
+Expected improvement
+---------------------
 
-Maximum expected improvement (MEI) is the magnitude of expected improvement calculated from the integral from the best training objective (i.e. baseline) to infinity of ``p(x)(x-a)``, where ``a`` is the best objective value in the training set.
-:class:`~citrine.informatics.scores.MEIScore` supports 0 or 1 objective.
+Expected improvement (EI) is the magnitude of the expected value of improvement calculated as the integral from the best training objective (i.e. baseline) to infinity of ``p(x)(x-a)``, where ``a`` is the best objective value in the training set.
+:class:`~citrine.informatics.scores.EIScore` supports 0 or 1 objective.
 If no objective is provided, the score is the probability of satisfying all constraints.
 
-MEI is calculated from two components: predicted value and uncertainty.
+EI is calculated from two components: predicted value and uncertainty.
 Higher scores result from a more optimal predicted value, higher uncertainty or both.
 Higher predicted values exploit information known about the current dataset, e.g. materials of a given type are known to perform well.
 Higher uncertainty leads to exploration of a design space, e.g. little is known about a certain class materials, but materials from this region of the design space could perform well.
 
-Maximum likelihood of improvement
----------------------------------
+Likelihood of improvement
+-------------------------
 
-Maximum likelihood of improvement (MLI) is the probability that a candidate satisfies a set of constraints and is an improvement over known objective values.
-:class:`~citrine.informatics.scores.MLIScore` supports 0 or more objectives.
-If no objectives are provided, the MLI score is 0.
+Likelihood of improvement (LI) is the probability that a candidate satisfies a set of constraints and is an improvement over known objective values.
+:class:`~citrine.informatics.scores.LIScore` supports 0 or more objectives.
+If no objectives are provided, the LI score is 0.
 When multiple objectives are present, the score is the probability of the objective that is most likely to be improved.
-MLI scores are bounded by 0 and 1.
+LI scores are bounded by 0 and 1.
 
-The following demonstrates how to create an MLI score and use it when triggering a design workflow:
+The following demonstrates how to create an LI score and use it when triggering a design workflow:
 
 .. code:: python
 
    from citrine.informatics.objectives import ScalarMaxObjective
-   from citrine.informatics.scores import MLIScore
+   from citrine.informatics.scores import LIScore
 
    # create an objective to maximize Shear modulus
    objective = ScalarMaxObjective(descriptor_key='Shear modulus')
@@ -53,9 +53,9 @@ The following demonstrates how to create an MLI score and use it when triggering
    # (assumed to be 150 here)
    baseline = 150.0
 
-   # Create an MLI score from the objective and baseline
-   score = MLIScore(
-       name='MLI(Shear modulus)',
+   # Create an LI score from the objective and baseline
+   score = LIScore(
+       name='LI(Shear modulus)',
        description='Experimental design score for shear modulus',
        objectives=[objective],
        baselines=[150.0]

--- a/src/citrine/informatics/scores.py
+++ b/src/citrine/informatics/scores.py
@@ -8,7 +8,7 @@ from citrine._session import Session
 from citrine.informatics.constraints import Constraint
 from citrine.informatics.objectives import Objective
 
-__all__ = ['Score', 'MLIScore', 'MEIScore']
+__all__ = ['Score', 'LIScore', 'EIScore']
 
 
 class Score(PolymorphicSerializable['Score']):
@@ -23,12 +23,12 @@ class Score(PolymorphicSerializable['Score']):
     def get_type(cls, data):
         """Return the subtype."""
         return {
-            'MLI': MLIScore,
-            'MEI': MEIScore
+            'MLI': LIScore,
+            'MEI': EIScore
         }[data['type']]
 
 
-class MLIScore(Serializable['MLIScore'], Score):
+class LIScore(Serializable['LIScore'], Score):
     """[ALPHA] Evaluates the likelihood of scoring better than some baselines for given objectives.
 
     Parameters
@@ -68,10 +68,10 @@ class MLIScore(Serializable['MLIScore'], Score):
         self.session: Optional[Session] = session
 
     def __str__(self):
-        return '<MLIScore {!r}>'.format(self.name)
+        return '<LIScore {!r}>'.format(self.name)
 
 
-class MEIScore(Serializable['MEIScore'], Score):
+class EIScore(Serializable['EIScore'], Score):
     """
     [ALPHA] Evaluates the expected magnitude of improvement beyond baselines for given objectives.
 
@@ -112,4 +112,4 @@ class MEIScore(Serializable['MEIScore'], Score):
         self.session: Optional[Session] = session
 
     def __str__(self):
-        return '<MEIScore {!r}>'.format(self.name)
+        return '<EIScore {!r}>'.format(self.name)

--- a/tests/informatics/test_informatics.py
+++ b/tests/informatics/test_informatics.py
@@ -4,7 +4,7 @@ from citrine.informatics.constraints import ScalarRangeConstraint, CategoricalCo
 from citrine.informatics.design_spaces import ProductDesignSpace, EnumeratedDesignSpace
 from citrine.informatics.objectives import ScalarMaxObjective, ScalarMinObjective
 from citrine.informatics.processors import GridProcessor, EnumeratedProcessor
-from citrine.informatics.scores import MLIScore, MEIScore
+from citrine.informatics.scores import LIScore, EIScore
 
 
 informatics_string_data = [
@@ -16,8 +16,8 @@ informatics_string_data = [
     (ScalarMinObjective('z', 1.0, 10.0), "<ScalarMinObjective 'z'>"),
     (GridProcessor('my thing', 'does a thing', dict(x=1)), "<GridProcessor 'my thing'>"),
     (EnumeratedProcessor('my enumerated thing', 'enumerates', 10), "<EnumeratedProcessor 'my enumerated thing'>"),
-    (MLIScore("MLI(z)", "score for z", [], []), "<MLIScore 'MLI(z)'>"),
-    (MEIScore("MEI(x)", "score for x", [], [], []), "<MEIScore 'MEI(x)'>"),
+    (LIScore("LI(z)", "score for z", [], []), "<LIScore 'LI(z)'>"),
+    (EIScore("EI(x)", "score for x", [], [], []), "<EIScore 'EI(x)'>"),
 ]
 
 

--- a/tests/informatics/test_scores.py
+++ b/tests/informatics/test_scores.py
@@ -3,13 +3,13 @@ import pytest
 
 from citrine.informatics.constraints import ScalarRangeConstraint
 from citrine.informatics.objectives import ScalarMaxObjective
-from citrine.informatics.scores import MLIScore, MEIScore
+from citrine.informatics.scores import LIScore, EIScore
 
 
 @pytest.fixture
-def mli_score() -> MLIScore:
+def mli_score() -> LIScore:
     """Build an MLIScore."""
-    return MLIScore(
+    return LIScore(
         name="MLI(z)",
         description="experimental design score for z",
         objectives=[
@@ -22,9 +22,9 @@ def mli_score() -> MLIScore:
 
 
 @pytest.fixture
-def mei_score() -> MEIScore:
+def mei_score() -> EIScore:
     """Build an MEIScore."""
-    return MEIScore(
+    return EIScore(
         name="MEI(x)",
         description="experimental design score for x",
         objectives=[

--- a/tests/serialization/test_scorers.py
+++ b/tests/serialization/test_scorers.py
@@ -2,13 +2,13 @@
 import pytest
 
 from citrine.informatics.objectives import ScalarMaxObjective
-from citrine.informatics.scores import Score, MEIScore, MLIScore
+from citrine.informatics.scores import Score, EIScore, LIScore
 
 
 @pytest.fixture
-def mli_score() -> MLIScore:
+def mli_score() -> LIScore:
     """Build an MLIScore."""
-    return MLIScore(
+    return LIScore(
         name="MLI(z)",
         description="experimental design score for z",
         objectives=[
@@ -21,9 +21,9 @@ def mli_score() -> MLIScore:
 
 
 @pytest.fixture
-def mei_score() -> MEIScore:
+def mei_score() -> EIScore:
     """Build an MEIScore."""
-    return MEIScore(
+    return EIScore(
         name="MEI(x)",
         description="experimental design score for x",
         objectives=[
@@ -48,7 +48,7 @@ def test_mli_dumps(mli_score):
 def test_get_mli_type(mli_score):
     """Ensure correct type is returned."""
     typ = Score.get_type(mli_score.dump())
-    assert typ == MLIScore
+    assert typ == LIScore
 
 
 def test_mei_dumps(mei_score):
@@ -64,4 +64,4 @@ def test_mei_dumps(mei_score):
 def test_get_mei_type(mei_score):
     """Ensure correct type is returned."""
     typ = Score.get_type(mei_score.dump())
-    assert typ == MEIScore
+    assert typ == EIScore

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -9,7 +9,7 @@ from citrine.resources.material_spec import MaterialSpec
 from citrine.resources.material_template import MaterialTemplate
 from taurus.entity.link_by_uid import LinkByUID
 
-from citrine.informatics.scores import MLIScore
+from citrine.informatics.scores import LIScore
 from citrine.resources.file_link import _Uploader
 from citrine.resources.dataset import Dataset
 from citrine.resources.material_run import MaterialRun
@@ -146,7 +146,7 @@ class _UploaderFactory(factory.Factory):
 
 class MLIScoreFactory(factory.Factory):
     class Meta:
-        model = MLIScore
+        model = LIScore
 
     name = factory.Faker('bs')
     description = factory.Faker('catch_phrase')


### PR DESCRIPTION
# Citrine Python PR

## Description 
The Scores "MLI" and "MEI" are actually scoring the likelihood of improvement and expected improvement. The addition of "Maximum" is a misnomer.

**Note** this change is non-breaking with respect to the API and doesn't require modifying backend code. The backend code can continue to refer to these objects as "MLI" and "MEI."

### PR Type:
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [X] I have communicated the downstream consequences of the PR to others.
