### PR TITLE
Adding Ara columns for Composition values

### DIFF
--- a/docs/source/data_extraction.rst
+++ b/docs/source/data_extraction.rst
@@ -151,11 +151,18 @@ There are several ways to define columns, depending on the type of the attribute
  * :class:`~citrine.ara.columns.QuantileColumn`: for a user-defined quantile of the numeric distribution, or empty if the value is *nominal*
  * :class:`~citrine.ara.columns.OriginalUnitsColumn`: for getting the units, as entered by the data author, from the specific attribute value; valid for continuous values only
 
-* Enumerated values, like :class:`~taurus.entity.categorical_value.CategoricalValue`
+* Enumerated attribute values, like :class:`~taurus.entity.categorical_value.CategoricalValue`
 
  * :class:`~citrine.ara.columns.MostLikelyCategoryColumn`: for getting the mode
  * :class:`~citrine.ara.columns.MostLikelyProbabilityColumn`: for getting the probability of the mode
 
-* String and boolean valued fields
+* Composition and chemical formula attribute values, like :class:`~taurus.entity.composition_value.CompositionValue`
+
+ * :class:`~citrine.ara.columns.FlatCompositionColumn`: for flattening the composition into a chemical-formula-like string
+ * :class:`~citrine.ara.columns.ComponentQuantityColumn`: for getting the quantity of a specific component, by name
+ * :class:`~citrine.ara.columns.NthBiggestComponentNameColumn`: for getting the name of the n-th biggest component (by quantity)
+ * :class:`~citrine.ara.columns.NthBiggestComponentQuantityColumn`: for getting the quantity of the n-th biggest component (by quantity)
+
+* String and boolean valued fields, like identifiers and non-attribute fields
 
  * :class:`~citrine.ara.columns.IdentityColumn`: for simply casting the value to a string, which doesn't work on values from attributes

--- a/src/citrine/ara/columns.py
+++ b/src/citrine/ara/columns.py
@@ -10,7 +10,7 @@ from citrine._serialization import properties
 
 
 class CompositionSortOrder(BaseEnumeration):
-    """[ALPHA] Order to use when sorting the components in a composition
+    """[ALPHA] Order to use when sorting the components in a composition.
 
     * ALPHABETICAL is alpha-numeric order by the component name
     * QUANTITY is ordered from the largest to smallest quantity, with ties broken alphabetically
@@ -301,7 +301,8 @@ class NthBiggestComponentQuantityColumn(Serializable["NthBiggestComponentQuantit
 
     data_source = properties.String('data_source')
     n = properties.Integer("n")
-    typ = properties.String('type', default="biggest_component_quantity_column", deserializable=False)
+    typ = properties.String('type',
+                            default="biggest_component_quantity_column", deserializable=False)
 
     def _attrs(self) -> List[str]:
         return ["data_source", "n", "typ"]

--- a/src/citrine/ara/columns.py
+++ b/src/citrine/ara/columns.py
@@ -212,6 +212,10 @@ class MostLikelyProbabilityColumn(Serializable["MostLikelyProbabilityColumn"], C
 class FlatCompositionColumn(Serializable["FlatCompositionColumn"], Column):
     """[ALPHA] Column that flattens the composition into a string of names and quantities.
 
+    The numeric formatting tries to be human readable. For example, if all of the quantities
+    are round numbers like {"spam": 4.0, "eggs": 1.0} then the result omit the decimal points like
+    "(spam)4(eggs)1" (if sort_order is by quantity).
+
     Parameters
     ----------
     data_source: str
@@ -237,6 +241,8 @@ class FlatCompositionColumn(Serializable["FlatCompositionColumn"], Column):
 
 class ComponentQuantityColumn(Serializable["ComponentQuantityColumn"], Column):
     """[ALPHA] Column that extracts the quantity of a given component.
+
+    If the component is not present in the composition, then the value in the column will be 0.0.
 
     Parameters
     ----------
@@ -264,6 +270,8 @@ class ComponentQuantityColumn(Serializable["ComponentQuantityColumn"], Column):
 class NthBiggestComponentNameColumn(Serializable["NthBiggestComponentNameColumn"], Column):
     """[ALPHA] Name of the Nth biggest component.
 
+    If there are not N components in the composition, then this column will be empty.
+
     Parameters
     ----------
     data_source: str
@@ -289,6 +297,8 @@ class NthBiggestComponentNameColumn(Serializable["NthBiggestComponentNameColumn"
 
 class NthBiggestComponentQuantityColumn(Serializable["NthBiggestComponentQuantityColumn"], Column):
     """[ALPHA] Quantity of the Nth biggest component.
+
+    If there are not N components in the composition, then this column will be empty.
 
     Parameters
     ----------

--- a/src/citrine/ara/columns.py
+++ b/src/citrine/ara/columns.py
@@ -2,9 +2,22 @@
 from typing import Type, Optional, List  # noqa: F401
 from abc import abstractmethod
 
+from taurus.enumeration.base_enumeration import BaseEnumeration
+
 from citrine._serialization.serializable import Serializable
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
 from citrine._serialization import properties
+
+
+class CompositionSortOrder(BaseEnumeration):
+    """[ALPHA] Order to use when sorting the components in a composition
+
+    * ALPHABETICAL is alpha-numeric order by the component name
+    * QUANTITY is ordered from the largest to smallest quantity, with ties broken alphabetically
+    """
+
+    ALPHABETICAL = "alphabetical"
+    QUANTITY = "quantity"
 
 
 class Column(PolymorphicSerializable['Column']):
@@ -33,7 +46,9 @@ class Column(PolymorphicSerializable['Column']):
         types: List[Type[Serializable]] = [
             IdentityColumn,
             MeanColumn, StdDevColumn, QuantileColumn, OriginalUnitsColumn,
-            MostLikelyCategoryColumn, MostLikelyProbabilityColumn
+            MostLikelyCategoryColumn, MostLikelyProbabilityColumn,
+            FlatCompositionColumn, ComponentQuantityColumn,
+            NthBiggestComponentNameColumn, NthBiggestComponentQuantityColumn
         ]
         res = next((x for x in types if x.typ == data["type"]), None)
         if res is None:
@@ -192,6 +207,110 @@ class MostLikelyProbabilityColumn(Serializable["MostLikelyProbabilityColumn"], C
     def __init__(self, *,
                  data_source: str):
         self.data_source = data_source
+
+
+class FlatCompositionColumn(Serializable["FlatCompositionColumn"], Column):
+    """[ALPHA] Column that flattens the composition into a string of names and quantities.
+
+    Parameters
+    ----------
+    data_source: str
+        name of the variable to use when populating the column
+    sort_order: CompositionSortOrder
+        order with which to sort the components when generating the flat string
+
+    """
+
+    data_source = properties.String('data_source')
+    sort_order = properties.Enumeration(CompositionSortOrder, 'sort_order')
+    typ = properties.String('type', default="flat_composition_column", deserializable=False)
+
+    def _attrs(self) -> List[str]:
+        return ["data_source", "sort_order", "typ"]
+
+    def __init__(self, *,
+                 data_source: str,
+                 sort_order: CompositionSortOrder):
+        self.data_source = data_source
+        self.sort_order = sort_order
+
+
+class ComponentQuantityColumn(Serializable["ComponentQuantityColumn"], Column):
+    """[ALPHA] Column that extracts the quantity of a given component.
+
+    Parameters
+    ----------
+    data_source: str
+        name of the variable to use when populating the column
+    component_name: str
+        name of the component from which to extract the quantity
+
+    """
+
+    data_source = properties.String('data_source')
+    component_name = properties.String("component_name")
+    typ = properties.String('type', default="component_quantity_column", deserializable=False)
+
+    def _attrs(self) -> List[str]:
+        return ["data_source", "component_name", "typ"]
+
+    def __init__(self, *,
+                 data_source: str,
+                 component_name: str):
+        self.data_source = data_source
+        self.component_name = component_name
+
+
+class NthBiggestComponentNameColumn(Serializable["NthBiggestComponentNameColumn"], Column):
+    """[ALPHA] Name of the Nth biggest component.
+
+    Parameters
+    ----------
+    data_source: str
+        name of the variable to use when populating the column
+    n: int
+        index of the component name to extract, starting with 1 for the biggest
+
+    """
+
+    data_source = properties.String('data_source')
+    n = properties.Integer("n")
+    typ = properties.String('type', default="biggest_component_name_column", deserializable=False)
+
+    def _attrs(self) -> List[str]:
+        return ["data_source", "n", "typ"]
+
+    def __init__(self, *,
+                 data_source: str,
+                 n: int):
+        self.data_source = data_source
+        self.n = n
+
+
+class NthBiggestComponentQuantityColumn(Serializable["NthBiggestComponentQuantityColumn"], Column):
+    """[ALPHA] Quantity of the Nth biggest component.
+
+    Parameters
+    ----------
+    data_source: str
+        name of the variable to use when populating the column
+    n: int
+        index of the component quantity to extract, starting with 1 for the biggest
+
+    """
+
+    data_source = properties.String('data_source')
+    n = properties.Integer("n")
+    typ = properties.String('type', default="biggest_component_quantity_column", deserializable=False)
+
+    def _attrs(self) -> List[str]:
+        return ["data_source", "n", "typ"]
+
+    def __init__(self, *,
+                 data_source: str,
+                 n: int):
+        self.data_source = data_source
+        self.n = n
 
 
 class IdentityColumn(Serializable['IdentityColumn'], Column):

--- a/tests/ara/test_columns.py
+++ b/tests/ara/test_columns.py
@@ -2,7 +2,9 @@
 import pytest
 
 from citrine.ara.columns import MeanColumn, IdentityColumn, Column, StdDevColumn, QuantileColumn, \
-    OriginalUnitsColumn, MostLikelyProbabilityColumn, MostLikelyCategoryColumn
+    OriginalUnitsColumn, MostLikelyProbabilityColumn, MostLikelyCategoryColumn, \
+    FlatCompositionColumn, CompositionSortOrder, ComponentQuantityColumn, \
+    NthBiggestComponentNameColumn, NthBiggestComponentQuantityColumn
 
 
 @pytest.fixture(params=[
@@ -13,6 +15,10 @@ from citrine.ara.columns import MeanColumn, IdentityColumn, Column, StdDevColumn
     OriginalUnitsColumn(data_source="density"),
     MostLikelyCategoryColumn(data_source="color"),
     MostLikelyProbabilityColumn(data_source="color"),
+    FlatCompositionColumn(data_source="formula", sort_order=CompositionSortOrder.QUANTITY),
+    ComponentQuantityColumn(data_source="formula", component_name="Si"),
+    NthBiggestComponentNameColumn(data_source="formula", n=1),
+    NthBiggestComponentQuantityColumn(data_source="formula", n=2),
 ])
 def column(request):
     return request.param


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR adds four column definitions for composition-valued variables in Ara definitions.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
