### PR TITLE
Adding dataset.register method that takes any data concept

### DIFF
--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -4,12 +4,8 @@ from uuid import UUID
 
 from taurus.entity.object import MeasurementSpec, MeasurementRun, MaterialSpec, MaterialRun, \
     ProcessSpec, ProcessRun, IngredientSpec, IngredientRun
-from taurus.entity.template.condition_template import ConditionTemplate
-from taurus.entity.template.material_template import MaterialTemplate
-from taurus.entity.template.measurement_template import MeasurementTemplate
-from taurus.entity.template.parameter_template import ParameterTemplate
-from taurus.entity.template.process_template import ProcessTemplate
-from taurus.entity.template.property_template import PropertyTemplate
+from taurus.entity.template import MaterialTemplate, ProcessTemplate, MeasurementTemplate, \
+    PropertyTemplate, ParameterTemplate, ConditionTemplate
 
 from citrine._session import Session
 from citrine._rest.collection import Collection

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -4,8 +4,12 @@ from uuid import UUID
 
 from taurus.entity.object import MeasurementSpec, MeasurementRun, MaterialSpec, MaterialRun, \
     ProcessSpec, ProcessRun, IngredientSpec, IngredientRun
-from taurus.entity.template import MaterialTemplate, ProcessTemplate, MeasurementTemplate, \
-    PropertyTemplate, ParameterTemplate, ConditionTemplate
+from taurus.entity.template.condition_template import ConditionTemplate
+from taurus.entity.template.material_template import MaterialTemplate
+from taurus.entity.template.measurement_template import MeasurementTemplate
+from taurus.entity.template.parameter_template import ParameterTemplate
+from taurus.entity.template.process_template import ProcessTemplate
+from taurus.entity.template.property_template import PropertyTemplate
 
 from citrine._session import Session
 from citrine._rest.collection import Collection

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -1,5 +1,15 @@
 """Resources that represent both individual and collections of datasets."""
+from typing import TypeVar
 from uuid import UUID
+
+from taurus.entity.object import MeasurementSpec, MeasurementRun, MaterialSpec, MaterialRun, \
+    ProcessSpec, ProcessRun, IngredientSpec, IngredientRun
+from taurus.entity.template.condition_template import ConditionTemplate
+from taurus.entity.template.material_template import MaterialTemplate
+from taurus.entity.template.measurement_template import MeasurementTemplate
+from taurus.entity.template.parameter_template import ParameterTemplate
+from taurus.entity.template.process_template import ProcessTemplate
+from taurus.entity.template.property_template import PropertyTemplate
 
 from citrine._session import Session
 from citrine._rest.collection import Collection
@@ -21,6 +31,9 @@ from citrine.resources.material_spec import MaterialSpecCollection
 from citrine.resources.ingredient_run import IngredientRunCollection
 from citrine.resources.ingredient_spec import IngredientSpecCollection
 from citrine.resources.file_link import FileCollection
+
+
+ResourceType = TypeVar('ResourceType', bound='DataConcepts')
 
 
 class Dataset(Resource['Dataset']):
@@ -172,6 +185,41 @@ class Dataset(Resource['Dataset']):
     def files(self) -> FileCollection:
         """Return a resource representing all files in the dataset."""
         return FileCollection(self.project_id, self.uid, self.session)
+
+    def register(self, data_concepts_resource: ResourceType) -> ResourceType:
+        """Register a data concepts resource to the appropriate collection."""
+        if isinstance(data_concepts_resource, MeasurementTemplate):
+            return self.measurement_templates.register(data_concepts_resource)
+        if isinstance(data_concepts_resource, MeasurementSpec):
+            return self.measurement_specs.register(data_concepts_resource)
+        if isinstance(data_concepts_resource, MeasurementRun):
+            return self.measurement_runs.register(data_concepts_resource)
+
+        if isinstance(data_concepts_resource, MaterialTemplate):
+            return self.material_templates.register(data_concepts_resource)
+        if isinstance(data_concepts_resource, MaterialSpec):
+            return self.material_specs.register(data_concepts_resource)
+        if isinstance(data_concepts_resource, MaterialRun):
+            return self.material_runs.register(data_concepts_resource)
+
+        if isinstance(data_concepts_resource, ProcessTemplate):
+            return self.process_templates.register(data_concepts_resource)
+        if isinstance(data_concepts_resource, ProcessSpec):
+            return self.process_specs.register(data_concepts_resource)
+        if isinstance(data_concepts_resource, ProcessRun):
+            return self.process_runs.register(data_concepts_resource)
+
+        if isinstance(data_concepts_resource, IngredientSpec):
+            return self.ingredient_specs.register(data_concepts_resource)
+        if isinstance(data_concepts_resource, IngredientRun):
+            return self.ingredient_runs.register(data_concepts_resource)
+
+        if isinstance(data_concepts_resource, PropertyTemplate):
+            return self.property_templates.register(data_concepts_resource)
+        if isinstance(data_concepts_resource, ParameterTemplate):
+            return self.parameter_templates.register(data_concepts_resource)
+        if isinstance(data_concepts_resource, ConditionTemplate):
+            return self.condition_templates.register(data_concepts_resource)
 
 
 class DatasetCollection(Collection[Dataset]):

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -1,7 +1,26 @@
 from uuid import UUID, uuid4
 import pytest
+from taurus.entity.bounds.integer_bounds import IntegerBounds
+from taurus.entity.object import MeasurementRun
+from taurus.entity.template.material_template import MaterialTemplate
+from taurus.entity.template.parameter_template import ParameterTemplate
 
+from citrine.resources.condition_template import ConditionTemplateCollection, ConditionTemplate
 from citrine.resources.dataset import DatasetCollection
+from citrine.resources.ingredient_run import IngredientRun, IngredientRunCollection
+from citrine.resources.ingredient_spec import IngredientSpec, IngredientSpecCollection
+from citrine.resources.material_run import MaterialRunCollection, MaterialRun
+from citrine.resources.material_spec import MaterialSpecCollection, MaterialSpec
+from citrine.resources.material_template import MaterialTemplateCollection
+from citrine.resources.measurement_run import MeasurementRunCollection
+from citrine.resources.measurement_spec import MeasurementSpec, MeasurementSpecCollection
+from citrine.resources.measurement_template import MeasurementTemplate, \
+    MeasurementTemplateCollection
+from citrine.resources.parameter_template import ParameterTemplateCollection
+from citrine.resources.process_run import ProcessRunCollection, ProcessRun
+from citrine.resources.process_spec import ProcessSpecCollection, ProcessSpec
+from citrine.resources.process_template import ProcessTemplateCollection, ProcessTemplate
+from citrine.resources.property_template import PropertyTemplateCollection, PropertyTemplate
 from tests.utils.factories import DatasetDataFactory, DatasetFactory
 from tests.utils.session import FakeSession, FakePaginatedSession, FakeCall
 
@@ -32,11 +51,12 @@ def paginated_collection(paginated_session) -> DatasetCollection:
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def dataset():
     dataset = DatasetFactory(name='Test Dataset')
     dataset.project_id = UUID('6b608f78-e341-422c-8076-35adc8828545')
-    dataset.session = None
+    dataset.uid = UUID("503d7bf6-8e2d-4d29-88af-257af0d4fe4a")
+    dataset.session = FakeSession()
 
     return dataset
 
@@ -186,3 +206,28 @@ def test_ingredient_specs_get_project_id(dataset):
 
 def test_files_get_project_id(dataset):
     assert dataset.project_id == dataset.files.project_id
+
+
+def test_register_data_concepts(dataset):
+    """Check that register routes to the correct collections"""
+    from os.path import basename
+    expected_pairs = [
+        (MaterialTemplateCollection, MaterialTemplate("foo")),
+        (MaterialSpecCollection, MaterialSpec("foo")),
+        (MaterialRunCollection, MaterialRun("foo")),
+        (ProcessTemplateCollection, ProcessTemplate("foo")),
+        (ProcessSpecCollection, ProcessSpec("foo")),
+        (ProcessRunCollection, ProcessRun("foo")),
+        (MeasurementTemplateCollection, MeasurementTemplate("foo")),
+        (MeasurementSpecCollection, MeasurementSpec("foo")),
+        (MeasurementRunCollection, MeasurementRun("foo")),
+        (IngredientSpecCollection, IngredientSpec("foo")),
+        (IngredientRunCollection, IngredientRun("foo")),
+        (PropertyTemplateCollection, PropertyTemplate("bar", bounds=IntegerBounds(0, 1))),
+        (ParameterTemplateCollection, ParameterTemplate("bar", bounds=IntegerBounds(0, 1))),
+        (ConditionTemplateCollection, ConditionTemplate("bar", bounds=IntegerBounds(0, 1))),
+    ]
+
+    for collection, obj in expected_pairs:
+        dataset.register(obj)
+        assert basename(dataset.session.calls[-1].path) == basename(collection._path_template)

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -211,23 +211,23 @@ def test_files_get_project_id(dataset):
 def test_register_data_concepts(dataset):
     """Check that register routes to the correct collections"""
     from os.path import basename
-    expected_pairs = [
-        (MaterialTemplateCollection, MaterialTemplate("foo")),
-        (MaterialSpecCollection, MaterialSpec("foo")),
-        (MaterialRunCollection, MaterialRun("foo")),
-        (ProcessTemplateCollection, ProcessTemplate("foo")),
-        (ProcessSpecCollection, ProcessSpec("foo")),
-        (ProcessRunCollection, ProcessRun("foo")),
-        (MeasurementTemplateCollection, MeasurementTemplate("foo")),
-        (MeasurementSpecCollection, MeasurementSpec("foo")),
-        (MeasurementRunCollection, MeasurementRun("foo")),
-        (IngredientSpecCollection, IngredientSpec("foo")),
-        (IngredientRunCollection, IngredientRun("foo")),
-        (PropertyTemplateCollection, PropertyTemplate("bar", bounds=IntegerBounds(0, 1))),
-        (ParameterTemplateCollection, ParameterTemplate("bar", bounds=IntegerBounds(0, 1))),
-        (ConditionTemplateCollection, ConditionTemplate("bar", bounds=IntegerBounds(0, 1))),
-    ]
+    expected = {
+        MaterialTemplateCollection: MaterialTemplate("foo"),
+        MaterialSpecCollection: MaterialSpec("foo"),
+        MaterialRunCollection: MaterialRun("foo"),
+        ProcessTemplateCollection: ProcessTemplate("foo"),
+        ProcessSpecCollection: ProcessSpec("foo"),
+        ProcessRunCollection: ProcessRun("foo"),
+        MeasurementTemplateCollection: MeasurementTemplate("foo"),
+        MeasurementSpecCollection: MeasurementSpec("foo"),
+        MeasurementRunCollection: MeasurementRun("foo"),
+        IngredientSpecCollection: IngredientSpec("foo"),
+        IngredientRunCollection: IngredientRun("foo"),
+        PropertyTemplateCollection: PropertyTemplate("bar", bounds=IntegerBounds(0, 1)),
+        ParameterTemplateCollection: ParameterTemplate("bar", bounds=IntegerBounds(0, 1)),
+        ConditionTemplateCollection: ConditionTemplate("bar", bounds=IntegerBounds(0, 1))
+    }
 
-    for collection, obj in expected_pairs:
+    for collection, obj in expected.items():
         dataset.register(obj)
         assert basename(dataset.session.calls[-1].path) == basename(collection._path_template)


### PR DESCRIPTION
This makes registering lists of mixed types of objects much
easier.  The logic is simple, but getting test coverage
was a bit of a chore.