### PR TITLE
Pla 3297/warning on empty names

### DIFF
--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -161,7 +161,7 @@ class AraDefinition(Resource["AraDefinition"]):
         if not process.allowed_names:
             raise RuntimeError(
                 "Cannot add ingredients for process template \'{}\' because it has no defined "
-                "ingredients (allowed_names is an empty list).".format(process.name))
+                "ingredients (allowed_names is not defined).".format(process.name))
 
         new_variables = []
         new_columns = []

--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -158,6 +158,11 @@ class AraDefinition(Resource["AraDefinition"]):
         }
         process: ProcessTemplate = project.process_templates.get(
             uid=process_template.id, scope=process_template.scope)
+        if len(process.allowed_names) == 0:
+            raise RuntimeError(
+                "Cannot add ingredients for process template \'{}\' because it has no defined "
+                "ingredients (allowed_names is an empty list).".format(process.name))
+
         new_variables = []
         new_columns = []
         for name in process.allowed_names:

--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -158,7 +158,7 @@ class AraDefinition(Resource["AraDefinition"]):
         }
         process: ProcessTemplate = project.process_templates.get(
             uid=process_template.id, scope=process_template.scope)
-        if len(process.allowed_names) == 0:
+        if not process.allowed_names:
             raise RuntimeError(
                 "Cannot add ingredients for process template \'{}\' because it has no defined "
                 "ingredients (allowed_names is an empty list).".format(process.name))

--- a/tests/resources/test_ara_definition.py
+++ b/tests/resources/test_ara_definition.py
@@ -225,6 +225,14 @@ def test_add_all_ingredients(session, project):
         def2.add_all_ingredients(process_template=process_link, project=project,
                                  quantity_dimension=IngredientQuantityDimension.VOLUME)
 
+    # If the process template has an empty allowed_names list then an error should be raised
+    session.set_response(
+        ProcessTemplate(process_name, uids={'id': process_id}, allowed_names=[]).dump()
+    )
+    with pytest.raises(RuntimeError):
+        empty_defn().add_all_ingredients(process_template=process_link, project=project,
+                                         quantity_dimension=IngredientQuantityDimension.VOLUME)
+
 
 def test_register_new(collection, session):
     """Test the behavior of AraDefinitionCollection.register() on an unregistered AraDefinition"""

--- a/tests/resources/test_ara_definition.py
+++ b/tests/resources/test_ara_definition.py
@@ -227,7 +227,7 @@ def test_add_all_ingredients(session, project):
 
     # If the process template has an empty allowed_names list then an error should be raised
     session.set_response(
-        ProcessTemplate(process_name, uids={'id': process_id}, allowed_names=[]).dump()
+        ProcessTemplate(process_name, uids={'id': process_id}).dump()
     )
     with pytest.raises(RuntimeError):
         empty_defn().add_all_ingredients(process_template=process_link, project=project,

--- a/tests/resources/test_data_concepts.py
+++ b/tests/resources/test_data_concepts.py
@@ -1,7 +1,6 @@
 import pytest
 from uuid import uuid4
 
-from citrine._serialization.serializable import Serializable
 from citrine.resources.audit_info import AuditInfo
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.process_run import ProcessRun

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 import pytest
 from citrine._session import Session
-from citrine.resources.material_run import MaterialRunCollection, MaterialRun
+from citrine.resources.material_run import MaterialRunCollection
 from taurus.entity.object.material_run import MaterialRun as TaurusRun
 from taurus.entity.bounds.integer_bounds import IntegerBounds
 


### PR DESCRIPTION
# Citrine Python PR

## Description 
Throw an exception if the user calls add_all_ingredients using a process template that does not have `allowed_names` defined.

With masterflow do we need to do a version bump for each PR?

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
