### PR TITLE
Add output to job status

### DIFF
--- a/src/citrine/resources/ara_job.py
+++ b/src/citrine/resources/ara_job.py
@@ -1,10 +1,9 @@
-from typing import List, Optional, Set, Mapping, Dict
+from typing import List, Optional, Set, Dict
 from uuid import UUID
 
 from citrine._serialization.properties import Set as PropertySet, String, Object
 from citrine._rest.resource import Resource
 from citrine._serialization import properties
-from taurus.entity.dict_serializable import DictSerializable
 
 
 class JobSubmissionResponse(Resource['AraJobStatus']):
@@ -66,7 +65,7 @@ class TaskNode(Resource['TaskNode']):
         self.failure_reason = failure_reason
 
 
-class JobStatusResponse(Resource['JobStatusResponse'], DictSerializable):
+class JobStatusResponse(Resource['JobStatusResponse']):
     """[ALPHA] a response to a job status check.
 
     The JobStatusResponse summarizes the status for the entire job.
@@ -79,20 +78,22 @@ class JobStatusResponse(Resource['JobStatusResponse'], DictSerializable):
         the actual status of the job
     tasks: List[TaskNode]
         all of the constituent task required to complete this job
+    output: Optional[Map[String,String]]
+        job output properties and results
 
     """
 
     job_type = properties.String("job_type")
     status = properties.String("status")
     tasks = properties.List(Object(TaskNode), "tasks")
-    output = properties.Mapping(String('scope'), String('id'), 'output')
+    output = properties.Optional(properties.Mapping(String, String), 'output')
 
     def __init__(
             self,
             job_type: str,
             status: str,
             tasks: List[TaskNode],
-            output: Optional[Dict[str, str]] = None
+            output: Optional[Dict[str, str]]
     ):
         self.job_type = job_type
         self.status = status

--- a/src/citrine/resources/ara_job.py
+++ b/src/citrine/resources/ara_job.py
@@ -1,9 +1,10 @@
-from typing import List, Optional, Set
+from typing import List, Optional, Set, Mapping, Dict
 from uuid import UUID
 
 from citrine._serialization.properties import Set as PropertySet, String, Object
 from citrine._rest.resource import Resource
 from citrine._serialization import properties
+from taurus.entity.dict_serializable import DictSerializable
 
 
 class JobSubmissionResponse(Resource['AraJobStatus']):
@@ -65,7 +66,7 @@ class TaskNode(Resource['TaskNode']):
         self.failure_reason = failure_reason
 
 
-class JobStatusResponse(Resource['JobStatusResponse']):
+class JobStatusResponse(Resource['JobStatusResponse'], DictSerializable):
     """[ALPHA] a response to a job status check.
 
     The JobStatusResponse summarizes the status for the entire job.
@@ -84,13 +85,16 @@ class JobStatusResponse(Resource['JobStatusResponse']):
     job_type = properties.String("job_type")
     status = properties.String("status")
     tasks = properties.List(Object(TaskNode), "tasks")
+    output = properties.Mapping(String('scope'), String('id'), 'output')
 
     def __init__(
             self,
             job_type: str,
             status: str,
-            tasks: List[TaskNode]
+            tasks: List[TaskNode],
+            output: Optional[Dict[str, str]] = None
     ):
         self.job_type = job_type
         self.status = status
         self.tasks = tasks
+        self.output = output

--- a/tests/resources/test_job_client.py
+++ b/tests/resources/test_job_client.py
@@ -120,5 +120,10 @@ def test_job_status(collection: AraDefinitionCollection):
     status['output'] = None
     assert status == resp.dump()
 
-js = JobStatusResponse.build(job_status_with_output())
-print(str(js))
+
+def test_job_status_with_output(collection: AraDefinitionCollection):
+    status = job_status_with_output()
+    collection.session.set_response(status)
+    resp = collection.get_job_status(job_id='12345678-1234-1234-1234-123456789ccc')
+    status['tasks'][0]['failure_reason'] = None
+    assert status == resp.dump()

--- a/tests/resources/test_job_client.py
+++ b/tests/resources/test_job_client.py
@@ -25,6 +25,15 @@ def job_status() -> dict:
     return js
 
 
+def job_status_with_output() -> dict:
+    js = {'job_type': "dave_job_type",
+          'status': "david_job_status",
+          "tasks": [task_node_1(), task_node_2()],
+          "output": {"key1": "val1", "key2": "val2"}
+          }
+    return js
+
+
 @pytest.fixture
 def session() -> FakeSession:
     return FakeSession()
@@ -74,10 +83,26 @@ def test_js_serde():
     js = JobStatusResponse.build(job_status())
     expected = job_status()
     expected['tasks'][0]['failure_reason'] = None
+    expected['output'] = None
     expected_js = JobStatusResponse(
         job_type=expected['job_type'],
         status=expected['status'],
-        tasks=[TaskNode.build(i) for i in expected['tasks']])
+        tasks=[TaskNode.build(i) for i in expected['tasks']],
+        output=expected['output']
+    )
+    assert js.dump() == expected_js.dump()
+
+
+def test_js_serde_with_output():
+    js = JobStatusResponse.build(job_status_with_output())
+    expected = job_status_with_output()
+    expected['tasks'][0]['failure_reason'] = None
+    expected_js = JobStatusResponse(
+        job_type=expected['job_type'],
+        status=expected['status'],
+        tasks=[TaskNode.build(i) for i in expected['tasks']],
+        output={"key1": "val1", "key2": "val2"}
+    )
     assert js.dump() == expected_js.dump()
 
 
@@ -92,4 +117,8 @@ def test_job_status(collection: AraDefinitionCollection):
     collection.session.set_response(status)
     resp = collection.get_job_status(job_id='12345678-1234-1234-1234-123456789ccc')
     status['tasks'][0]['failure_reason'] = None
+    status['output'] = None
     assert status == resp.dump()
+
+js = JobStatusResponse.build(job_status_with_output())
+print(str(js))


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR adds the output field to JobStatusResponse (if available)
https://github.com/CitrineInformatics/platform-backend/blob/0024483df8a7603d63aeb2c0aa711da02d55e95c/code/faraday/dc-jobs/src/main/scala/io/citrine/faraday/jobs/JobStatusResponse.scala#L13

Jira Ticket: https://citrine.atlassian.net/browse/PLA-2568
### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [X] I have communicated the downstream consequences of the PR to others.
