### PR TITLE
Pla 3324/component quantity columns

### DIFF
--- a/docs/source/data_extraction.rst
+++ b/docs/source/data_extraction.rst
@@ -181,9 +181,9 @@ There are several ways to define columns, depending on the type of the attribute
 * Composition and chemical formula attribute values, like :class:`~taurus.entity.composition_value.CompositionValue`
 
  * :class:`~citrine.ara.columns.FlatCompositionColumn`: for flattening the composition into a chemical-formula-like string
- * :class:`~citrine.ara.columns.ComponentQuantityColumn`: for getting the quantity of a specific component, by name
+ * :class:`~citrine.ara.columns.ComponentQuantityColumn`: for getting the (optionally normalized) quantity of a specific component, by name
  * :class:`~citrine.ara.columns.NthBiggestComponentNameColumn`: for getting the name of the n-th biggest component (by quantity)
- * :class:`~citrine.ara.columns.NthBiggestComponentQuantityColumn`: for getting the quantity of the n-th biggest component (by quantity)
+ * :class:`~citrine.ara.columns.NthBiggestComponentQuantityColumn`: for getting the (optionally normalized) quantity of the n-th biggest component (by quantity)
 
 * String and boolean valued fields, like identifiers and non-attribute fields
 

--- a/src/citrine/ara/columns.py
+++ b/src/citrine/ara/columns.py
@@ -250,21 +250,26 @@ class ComponentQuantityColumn(Serializable["ComponentQuantityColumn"], Column):
         name of the variable to use when populating the column
     component_name: str
         name of the component from which to extract the quantity
+    normalize: Optional[str]
+        whether to normalize the quantity by the total quantity of all components. Default is false
 
     """
 
     data_source = properties.String('data_source')
     component_name = properties.String("component_name")
+    normalize = properties.Optional(properties.Boolean, "normalize")
     typ = properties.String('type', default="component_quantity_column", deserializable=False)
 
     def _attrs(self) -> List[str]:
-        return ["data_source", "component_name", "typ"]
+        return ["data_source", "component_name", "normalize", "typ"]
 
     def __init__(self, *,
                  data_source: str,
-                 component_name: str):
+                 component_name: str,
+                 normalize: Optional[bool] = False):
         self.data_source = data_source
         self.component_name = component_name
+        self.normalize = normalize
 
 
 class NthBiggestComponentNameColumn(Serializable["NthBiggestComponentNameColumn"], Column):
@@ -306,22 +311,27 @@ class NthBiggestComponentQuantityColumn(Serializable["NthBiggestComponentQuantit
         name of the variable to use when populating the column
     n: int
         index of the component quantity to extract, starting with 1 for the biggest
+    normalize: Optional[str]
+        whether to normalize the quantity by the total quantity of all components. Default is false
 
     """
 
     data_source = properties.String('data_source')
     n = properties.Integer("n")
+    normalize = properties.Optional(properties.Boolean, "normalize")
     typ = properties.String('type',
                             default="biggest_component_quantity_column", deserializable=False)
 
     def _attrs(self) -> List[str]:
-        return ["data_source", "n", "typ"]
+        return ["data_source", "n", "normalize", "typ"]
 
     def __init__(self, *,
                  data_source: str,
-                 n: int):
+                 n: int,
+                 normalize: Optional[bool] = False):
         self.data_source = data_source
         self.n = n
+        self.normalize = normalize
 
 
 class IdentityColumn(Serializable['IdentityColumn'], Column):

--- a/src/citrine/ara/columns.py
+++ b/src/citrine/ara/columns.py
@@ -251,7 +251,7 @@ class ComponentQuantityColumn(Serializable["ComponentQuantityColumn"], Column):
     component_name: str
         name of the component from which to extract the quantity
     normalize: Optional[str]
-        whether to normalize the quantity by the total quantity of all components. Default is false
+        whether to normalize the quantity by the sum of all component amounts. Default is false
 
     """
 
@@ -312,7 +312,7 @@ class NthBiggestComponentQuantityColumn(Serializable["NthBiggestComponentQuantit
     n: int
         index of the component quantity to extract, starting with 1 for the biggest
     normalize: Optional[str]
-        whether to normalize the quantity by the total quantity of all components. Default is false
+        whether to normalize the quantity by the sum of all component amounts. Default is false
 
     """
 

--- a/tests/ara/test_columns.py
+++ b/tests/ara/test_columns.py
@@ -16,7 +16,7 @@ from citrine.ara.columns import MeanColumn, IdentityColumn, Column, StdDevColumn
     MostLikelyCategoryColumn(data_source="color"),
     MostLikelyProbabilityColumn(data_source="color"),
     FlatCompositionColumn(data_source="formula", sort_order=CompositionSortOrder.QUANTITY),
-    ComponentQuantityColumn(data_source="formula", component_name="Si"),
+    ComponentQuantityColumn(data_source="formula", component_name="Si", normalize=True),
     NthBiggestComponentNameColumn(data_source="formula", n=1),
     NthBiggestComponentQuantityColumn(data_source="formula", n=2),
 ])


### PR DESCRIPTION
# Citrine Python PR

## Description 
Add  `normalize` option to `ComponentQuantityColumn` and `NthBiggestComponentQuantityColumn`, using False as the default.

I tested the change by registering an Ara Definition to develop and making sure that there was no error and that the result contained the expected values for the normalize field.

We still need a complete end-to-end test that builds a table using the relevant rows and columns, but I couldn't find anything to build off of (the tests in nextgen-devkit just test registering and updating, and I couldn't find an Ara demo in nextgen-devkit). Creating such an end-to-end test seems like an important task but it's out of scope and should be carded separately.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
