### PR TITLE
Pla 3366/embedded predictors in graph

### DIFF
--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -378,8 +378,8 @@ class Union(Property[typing.Any, typing.Any]):
                          serializable,
                          deserializable,
                          default)
-        if not isinstance(element_types, list):
-            raise ValueError("element types must be a list: {}".format(element_types))
+        if not isinstance(element_types, typing.Iterable):
+            raise ValueError("element types must be iterable: {}".format(element_types))
         self.element_types: typing.List[Property, ...] = \
             [el if isinstance(el, Property) else el() for el in element_types]
 

--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -362,7 +362,11 @@ class Set(Property[set, typing.Iterable]):
 
 
 class Union(Property[typing.Any, typing.Any]):
-    """One of several possible property types."""
+    """
+    One of several possible property types.
+
+    Attempted de/serialization is done in the order in which types are provided in the constructor.
+    """
 
     def __init__(self,
                  element_types: typing.Sequence[typing.Union[Property, typing.Type[Property]]],
@@ -382,14 +386,14 @@ class Union(Property[typing.Any, typing.Any]):
     @property
     def underlying_types(self):
         all_underlying_types = [prop.underlying_types for prop in self.element_types]
-        return tuple(chain(*[typ if isinstance(typ, tuple)
-                             else (typ,) for typ in all_underlying_types]))
+        return tuple(set(chain(*[typ if isinstance(typ, tuple)
+                                 else (typ,) for typ in all_underlying_types])))
 
     @property
     def serialized_types(self):
         all_serialized_types = [prop.serialized_types for prop in self.element_types]
-        return tuple(chain(*[typ if isinstance(typ, tuple)
-                             else (typ,) for typ in all_serialized_types]))
+        return tuple(set(chain(*[typ if isinstance(typ, tuple)
+                                 else (typ,) for typ in all_serialized_types])))
 
     def _serialize(self, value: typing.Any) -> typing.Any:
         for prop in self.element_types:

--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -411,7 +411,7 @@ class Union(Property[typing.Any, typing.Any]):
             except ValueError:
                 pass
         raise RuntimeError("An unexpected error occurred while trying to deserialize {} to one "
-                           "of the following types: {}.".format(value, self.serialized_types))
+                           "of the following types: {}.".format(value, self.underlying_types))
 
 
 class SpecifiedMixedList(Property[list, list]):

--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -408,8 +408,7 @@ class Union(Property[typing.Any, typing.Any]):
         for prop in self.element_types:
             try:
                 return prop.deserialize(value)
-            except ValueError as e:
-                print(e)
+            except ValueError:
                 pass
         raise RuntimeError("An unexpected error occurred while trying to deserialize {} to one "
                            "of the following types: {}.".format(value, self.underlying_types))

--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -408,7 +408,8 @@ class Union(Property[typing.Any, typing.Any]):
         for prop in self.element_types:
             try:
                 return prop.deserialize(value)
-            except ValueError:
+            except ValueError as e:
+                print(e)
                 pass
         raise RuntimeError("An unexpected error occurred while trying to deserialize {} to one "
                            "of the following types: {}.".format(value, self.underlying_types))

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -452,7 +452,9 @@ class AttributeInOutput(
     process_templates = properties.List(properties.Object(LinkByUID), 'process_templates')
     attribute_constraints = properties.Optional(
         properties.List(
-            properties.SpecifiedMixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
+            properties.SpecifiedMixedList(
+                [properties.Object(LinkByUID), properties.Object(BaseBounds)]
+            )
         ), 'attribute_constraints')
     typ = properties.String('type', default="attribute_in_trunk", deserializable=False)
 

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -116,7 +116,7 @@ class AttributeByTemplate(Serializable['AttributeByTemplate'], Variable):
     template = properties.Object(LinkByUID, 'template')
     attribute_constraints = properties.Optional(
         properties.List(
-            properties.MixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
+            properties.SpecifiedMixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
         ), 'attribute_constraints')
     typ = properties.String('type', default="attribute_by_template", deserializable=False)
 
@@ -161,7 +161,7 @@ class AttributeByTemplateAfterProcessTemplate(
     process_template = properties.Object(LinkByUID, 'process_template')
     attribute_constraints = properties.Optional(
         properties.List(
-            properties.MixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
+            properties.SpecifiedMixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
         ), 'attribute_constraints')
     typ = properties.String('type', default="attribute_after_process", deserializable=False)
 
@@ -213,7 +213,7 @@ class AttributeByTemplateAndObjectTemplate(
     object_template = properties.Object(LinkByUID, 'object_template')
     attribute_constraints = properties.Optional(
         properties.List(
-            properties.MixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
+            properties.SpecifiedMixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
         ), 'attribute_constraints')
     typ = properties.String('type', default="attribute_by_object", deserializable=False)
 

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -452,7 +452,7 @@ class AttributeInOutput(
     process_templates = properties.List(properties.Object(LinkByUID), 'process_templates')
     attribute_constraints = properties.Optional(
         properties.List(
-            properties.MixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
+            properties.SpecifiedMixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
         ), 'attribute_constraints')
     typ = properties.String('type', default="attribute_in_trunk", deserializable=False)
 

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -116,7 +116,9 @@ class AttributeByTemplate(Serializable['AttributeByTemplate'], Variable):
     template = properties.Object(LinkByUID, 'template')
     attribute_constraints = properties.Optional(
         properties.List(
-            properties.SpecifiedMixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
+            properties.SpecifiedMixedList(
+                [properties.Object(LinkByUID), properties.Object(BaseBounds)]
+            )
         ), 'attribute_constraints')
     typ = properties.String('type', default="attribute_by_template", deserializable=False)
 
@@ -161,7 +163,9 @@ class AttributeByTemplateAfterProcessTemplate(
     process_template = properties.Object(LinkByUID, 'process_template')
     attribute_constraints = properties.Optional(
         properties.List(
-            properties.SpecifiedMixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
+            properties.SpecifiedMixedList(
+                [properties.Object(LinkByUID), properties.Object(BaseBounds)]
+            )
         ), 'attribute_constraints')
     typ = properties.String('type', default="attribute_after_process", deserializable=False)
 
@@ -213,7 +217,9 @@ class AttributeByTemplateAndObjectTemplate(
     object_template = properties.Object(LinkByUID, 'object_template')
     attribute_constraints = properties.Optional(
         properties.List(
-            properties.SpecifiedMixedList([properties.Object(LinkByUID), properties.Object(BaseBounds)])
+            properties.SpecifiedMixedList(
+                [properties.Object(LinkByUID), properties.Object(BaseBounds)]
+            )
         ), 'attribute_constraints')
     typ = properties.String('type', default="attribute_by_object", deserializable=False)
 

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -176,6 +176,23 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
     def _post_dump(self, data: dict) -> dict:
         data['display_name'] = data['config']['name']
         return data
+    
+    @classmethod
+    def _pre_build(cls, data: dict) -> dict:
+        for i, predictor in enumerate(data['config']['predictors']):
+            if isinstance(predictor, dict):
+                data['config']['predictors'][i] = GraphPredictor.stuff_predictor_into_envelope(predictor)
+        return data
+
+    @staticmethod
+    def stuff_predictor_into_envelope(predictor: dict) -> dict:
+        """Insert a serialized embedded predictor into a module envelope, to facilitate deser."""
+        return dict(
+            module_type='PREDICTOR',
+            config=predictor,
+            status='EMBEDDED',
+            active=False
+        )
 
     def __str__(self):
         return '<GraphPredictor {!r}>'.format(self.name)

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -180,12 +180,13 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
                 # embedded predictors are not modules, so only serialize their config
                 data['config']['predictors'][i] = predictor['config']
         return data
-    
+
     @classmethod
     def _pre_build(cls, data: dict) -> dict:
         for i, predictor in enumerate(data['config']['predictors']):
             if isinstance(predictor, dict):
-                data['config']['predictors'][i] = GraphPredictor.stuff_predictor_into_envelope(predictor)
+                data['config']['predictors'][i] = \
+                    GraphPredictor.stuff_predictor_into_envelope(predictor)
         return data
 
     @staticmethod

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -174,6 +174,10 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
 
     def _post_dump(self, data: dict) -> dict:
         data['display_name'] = data['config']['name']
+        for i, predictor in enumerate(data['config']['predictors']):
+            if isinstance(predictor, dict):
+                # embedded predictors are not modules, so only serialize their config
+                data['config']['predictors'][i] = predictor['config']
         return data
     
     @classmethod

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -175,7 +175,28 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
 
     def _post_dump(self, data: dict) -> dict:
         data['display_name'] = data['config']['name']
+        for i, predictor in enumerate(data['config']['predictors']):
+            if isinstance(predictor, dict):
+                # embedded predictors are not modules, so only serialize their config
+                data['config']['predictors'][i] = predictor['config']
         return data
+    
+    @classmethod
+    def _pre_build(cls, data: dict) -> dict:
+        for i, predictor in enumerate(data['config']['predictors']):
+            if isinstance(predictor, dict):
+                data['config']['predictors'][i] = GraphPredictor.stuff_predictor_into_envelope(predictor)
+        return data
+    
+    @staticmethod
+    def stuff_predictor_into_envelope(predictor: dict) -> dict:
+        """Insert a serialized embedded predictor into a module envelope, to facilitate deser."""
+        return dict(
+            module_type='PREDICTOR',
+            config=predictor,
+            status='EMBEDDED',
+            active=False
+        )
 
     def __str__(self):
         return '<GraphPredictor {!r}>'.format(self.name)

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -195,8 +195,6 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
         return dict(
             module_type='PREDICTOR',
             config=predictor,
-            status='EMBEDDED',
-            status_info=[],
             active=False,
             schema_id='43c61ad4-7e33-45d0-a3de-504acb4e0737'  # TODO: what should this be?
         )

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -175,28 +175,7 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
 
     def _post_dump(self, data: dict) -> dict:
         data['display_name'] = data['config']['name']
-        for i, predictor in enumerate(data['config']['predictors']):
-            if isinstance(predictor, dict):
-                # embedded predictors are not modules, so only serialize their config
-                data['config']['predictors'][i] = predictor['config']
         return data
-    
-    @classmethod
-    def _pre_build(cls, data: dict) -> dict:
-        for i, predictor in enumerate(data['config']['predictors']):
-            if isinstance(predictor, dict):
-                data['config']['predictors'][i] = GraphPredictor.stuff_predictor_into_envelope(predictor)
-        return data
-    
-    @staticmethod
-    def stuff_predictor_into_envelope(predictor: dict) -> dict:
-        """Insert a serialized embedded predictor into a module envelope, to facilitate deser."""
-        return dict(
-            module_type='PREDICTOR',
-            config=predictor,
-            status='EMBEDDED',
-            active=False
-        )
 
     def __str__(self):
         return '<GraphPredictor {!r}>'.format(self.name)

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -142,7 +142,8 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
     uid = properties.Optional(properties.UUID, 'id', serializable=False)
     name = properties.String('config.name')
     description = properties.String('config.description')
-    predictors = properties.List(properties.Object(Predictor), 'config.predictors')
+    predictors = properties.List(properties.Union(
+        [properties.UUID, properties.Object(Predictor)]), 'config.predictors')
     typ = properties.String('config.type', default='Graph', deserializable=False)
     # Graph predictors may not be embedded in other predictors, hence while status is optional
     # for deserializing most predictors, it is required for deserializing a graph

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -142,8 +142,7 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
     uid = properties.Optional(properties.UUID, 'id', serializable=False)
     name = properties.String('config.name')
     description = properties.String('config.description')
-    predictors = properties.List(properties.Union(
-        [properties.UUID, properties.Object(Predictor)]), 'config.predictors')
+    predictors = properties.List(properties.Object(Predictor), 'config.predictors')
     typ = properties.String('config.type', default='Graph', deserializable=False)
     # Graph predictors may not be embedded in other predictors, hence while status is optional
     # for deserializing most predictors, it is required for deserializing a graph

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -134,8 +134,8 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
         name of the configuration
     description: str
         the description of the predictor
-    predictors: list[UUID]
-        the list of existing predictor UUIDs to graph together
+    predictors: list[UUID, Predictor]
+        the list of predictors to use in the grpah, either UUIDs or serialized predictors
 
     """
 
@@ -191,6 +191,7 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
             module_type='PREDICTOR',
             config=predictor,
             status='EMBEDDED',
+            status_info=[],
             active=False
         )
 

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -191,7 +191,8 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
             config=predictor,
             status='EMBEDDED',
             status_info=[],
-            active=False
+            active=False,
+            schema_id='43c61ad4-7e33-45d0-a3de-504acb4e0737'  # TODO: what should this be?
         )
 
     def __str__(self):

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Optional, Union, Sequence, Type
 from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
-from citrine._serialization.properties import String, Mapping, Object, MixedList, LinkOrElse
+from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, LinkOrElse
 from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
 from citrine.resources.property_template import PropertyTemplate
@@ -50,7 +50,7 @@ class MaterialTemplate(DataConcepts, Resource['MaterialTemplate'], TaurusMateria
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
     properties = PropertyOptional(PropertyList(
-        MixedList([LinkOrElse, Object(BaseBounds)])), 'properties')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'properties')
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -4,7 +4,8 @@ from typing import List, Dict, Optional, Union, Sequence, Type
 from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
-from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, LinkOrElse
+from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, \
+    LinkOrElse
 from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
 from citrine.resources.property_template import PropertyTemplate

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -2,7 +2,7 @@
 from typing import List, Dict, Optional, Union, Sequence, Type
 
 from citrine._rest.resource import Resource
-from citrine._serialization.properties import String, Mapping, Object, MixedList, LinkOrElse
+from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, LinkOrElse
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid
@@ -64,11 +64,11 @@ class MeasurementTemplate(DataConcepts,
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
     properties = PropertyOptional(PropertyList(
-        MixedList([LinkOrElse, Object(BaseBounds)])), 'properties')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'properties')
     conditions = PropertyOptional(PropertyList(
-        MixedList([LinkOrElse, Object(BaseBounds)])), 'conditions')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'conditions')
     parameters = PropertyOptional(PropertyList(
-        MixedList([LinkOrElse, Object(BaseBounds)])), 'parameters')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'parameters')
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -2,7 +2,8 @@
 from typing import List, Dict, Optional, Union, Sequence, Type
 
 from citrine._rest.resource import Resource
-from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, LinkOrElse
+from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, \
+    LinkOrElse
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -2,7 +2,8 @@
 from typing import List, Dict, Optional, Union, Sequence, Type
 
 from citrine._rest.resource import Resource
-from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, LinkOrElse
+from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, \
+    LinkOrElse
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -2,7 +2,7 @@
 from typing import List, Dict, Optional, Union, Sequence, Type
 
 from citrine._rest.resource import Resource
-from citrine._serialization.properties import String, Mapping, Object, MixedList, LinkOrElse
+from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, LinkOrElse
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid
@@ -56,9 +56,9 @@ class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTe
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
     conditions = PropertyOptional(PropertyList(
-        MixedList([LinkOrElse, Object(BaseBounds)])), 'conditions')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'conditions')
     parameters = PropertyOptional(PropertyList(
-        MixedList([LinkOrElse, Object(BaseBounds)])), 'parameters')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'parameters')
     allowed_labels = PropertyOptional(PropertyList(String()), 'allowed_labels')
     allowed_names = PropertyOptional(PropertyList(String()), 'allowed_names')
     typ = String('type')

--- a/tests/_serialization/test_container_properties.py
+++ b/tests/_serialization/test_container_properties.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 from citrine._serialization import properties

--- a/tests/_serialization/test_simple_properties.py
+++ b/tests/_serialization/test_simple_properties.py
@@ -3,6 +3,7 @@ import arrow
 import uuid
 from taurus.enumeration.base_enumeration import BaseEnumeration
 
+
 from citrine.resources.dataset import Dataset
 from citrine._serialization.properties import (
     Datetime,
@@ -11,7 +12,7 @@ from citrine._serialization.properties import (
     Integer,
     LinkByUID,
     LinkOrElse,
-    MixedList,
+    SpecifiedMixedList,
     Object,
     Optional,
     String,
@@ -138,17 +139,17 @@ def test_datetime_cannot_deserialize_float():
 
 def test_mixed_list_requires_property_list():
     with pytest.raises(ValueError):
-        MixedList(Integer)
+        SpecifiedMixedList(Integer)
 
 
 def test_deserialize_mixed_list():
-    ml = MixedList([Integer, String])
+    ml = SpecifiedMixedList([Integer, String])
     assert [1, '2'] == ml.deserialize([1, '2'])
     assert [1, None] == ml.deserialize([1])
 
 
 def test_mixed_list_cannot_deserialize_larger_lists():
-    ml = MixedList([Integer])
+    ml = SpecifiedMixedList([Integer])
     with pytest.raises(ValueError):
         ml.deserialize([1, '2'])
     with pytest.raises(ValueError):
@@ -156,7 +157,7 @@ def test_mixed_list_cannot_deserialize_larger_lists():
 
 
 def test_mixed_list_cannot_serialize_larger_lists():
-    ml = MixedList([Integer])
+    ml = SpecifiedMixedList([Integer])
     with pytest.raises(ValueError):
         ml.serialize([1, '2'])
     with pytest.raises(ValueError):
@@ -164,7 +165,7 @@ def test_mixed_list_cannot_serialize_larger_lists():
 
 
 def test_mixed_list_with_defaults():
-    ml = MixedList([Integer, Integer, Integer(default=100)])
+    ml = SpecifiedMixedList([Integer, Integer, Integer(default=100)])
     assert [1, 2, 100] == ml.serialize([1, 2])
 
 

--- a/tests/_serialization/test_simple_properties.py
+++ b/tests/_serialization/test_simple_properties.py
@@ -182,6 +182,11 @@ def test_union():
         union_type.deserialize(1.7)
 
 
+def test_untion_requires_property_iterable():
+    with pytest.raises(ValueError):
+        Union(Integer)
+
+
 class EnumerationExample(BaseEnumeration):
     FOO = "foo"
     BAR = "bar"

--- a/tests/_serialization/test_simple_properties.py
+++ b/tests/_serialization/test_simple_properties.py
@@ -16,6 +16,7 @@ from citrine._serialization.properties import (
     Object,
     Optional,
     String,
+    Union,
     UUID,
 )
 from ._data import (
@@ -167,6 +168,18 @@ def test_mixed_list_cannot_serialize_larger_lists():
 def test_mixed_list_with_defaults():
     ml = SpecifiedMixedList([Integer, Integer, Integer(default=100)])
     assert [1, 2, 100] == ml.serialize([1, 2])
+
+
+def test_union():
+    # Attempt to de/serialize first with Integer, then LinkOrElse, then String
+    union_type = Union([Integer, LinkOrElse, String])
+    assert 3 == union_type.deserialize(3)
+    assert 3 == union_type.serialize(3)
+    # Since "3" can be deserialized with Integer, this deserializes as an int
+    assert 3 == union_type.deserialize("3")
+    assert "3" == union_type.serialize("3")
+    with pytest.raises(ValueError):
+        union_type.deserialize(1.7)
 
 
 class EnumerationExample(BaseEnumeration):

--- a/tests/_serialization/test_simple_properties.py
+++ b/tests/_serialization/test_simple_properties.py
@@ -187,6 +187,25 @@ class EnumerationExample(BaseEnumeration):
     BAR = "bar"
 
 
+def test_union_runtime_errors():
+    """
+    De/serialization of Union ignores value errors.
+    They indicate that a specific property is not the one that should be used for de/ser.
+
+    If a different type of value error occurs then it can result in a difficult-to-diagnose
+    error state and a runtime error is thrown.
+    This test illustrates how that can happen for both serialization and deserialization.
+
+    """
+    # The underlying type is correct (BaseEnumeration) but FOO is not part of that enumeration
+    with pytest.raises(RuntimeError):
+        Union([Enumeration(BaseEnumeration)]).serialize(EnumerationExample.FOO)
+    # The serialized type is correct (dict) but it is missing fields
+    incomplete_dataset_dict = {'name': 'name'}
+    with pytest.raises(RuntimeError):
+        Union([Object(Dataset)]).deserialize(incomplete_dataset_dict)
+
+
 def test_enumeration_ser():
     assert Enumeration(EnumerationExample).serialize(EnumerationExample.FOO) == "foo"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ def valid_simple_ml_predictor_data():
 
 
 @pytest.fixture
-def valid_graph_predictor_data(valid_expression_predictor_data):
+def valid_graph_predictor_data():
     """Produce valid data used for tests."""
     from citrine.informatics.descriptors import RealDescriptor
     return dict(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,7 @@ def valid_graph_predictor_data(valid_expression_predictor_data):
         config=dict(
             type='Graph',
             name='Graph predictor',
-            description='description of graph',
+            description='description',
             predictors=[
                 dict(
                     type='Expression',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,7 @@ def valid_graph_predictor_data(valid_expression_predictor_data):
         config=dict(
             type='Graph',
             name='Graph predictor',
-            description='description',
+            description='description of graph',
             predictors=[
                 dict(
                     type='Expression',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,7 @@ def valid_graph_predictor_data(valid_expression_predictor_data):
             name='Graph predictor',
             description='description',
             predictors=[
+                str(uuid.uuid4()),
                 dict(
                     type='Expression',
                     name='Expression predictor',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,23 +131,17 @@ def valid_graph_predictor_data(valid_expression_predictor_data):
             predictors=[
                 str(uuid.uuid4()),
                 dict(
-                    module_type='PREDICTOR',
-                    active=True,
-                    display_name='Expression predictor',
-                    schema_id='866e72a6-0a01-4c5f-8c35-146eb2540166',
-                    config=dict(
-                        type='Expression',
-                        name='Expression predictor',
-                        description='mean of 2 outputs',
-                        expression='(X + Y)/2',
-                        output=RealDescriptor(
-                            'Property~Some metric', lower_bound=0, upper_bound=1000, units='W'
-                        ).dump(),
-                        aliases={
-                            "Property~X": "X",
-                            "Property~Y": "Y"
-                        }
-                    )
+                    type='Expression',
+                    name='Expression predictor',
+                    description='mean of 2 outputs',
+                    expression='(X + Y)/2',
+                    output=RealDescriptor(
+                        'Property~Some metric', lower_bound=0, upper_bound=1000, units='W'
+                    ).dump(),
+                    aliases={
+                        "Property~X": "X",
+                        "Property~Y": "Y"
+                    }
                 )
             ]
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,7 +129,6 @@ def valid_graph_predictor_data(valid_expression_predictor_data):
             name='Graph predictor',
             description='description',
             predictors=[
-                str(uuid.uuid4()),
                 dict(
                     type='Expression',
                     name='Expression predictor',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,8 +113,9 @@ def valid_simple_ml_predictor_data():
 
 
 @pytest.fixture
-def valid_graph_predictor_data():
+def valid_graph_predictor_data(valid_expression_predictor_data):
     """Produce valid data used for tests."""
+    from citrine.informatics.descriptors import RealDescriptor
     return dict(
         module_type='PREDICTOR',
         status='VALID',
@@ -127,7 +128,28 @@ def valid_graph_predictor_data():
             type='Graph',
             name='Graph predictor',
             description='description',
-            predictors=[str(uuid.uuid4()), str(uuid.uuid4())]
+            predictors=[
+                str(uuid.uuid4()),
+                dict(
+                    module_type='PREDICTOR',
+                    active=True,
+                    display_name='Expression predictor',
+                    schema_id='866e72a6-0a01-4c5f-8c35-146eb2540166',
+                    config=dict(
+                        type='Expression',
+                        name='Expression predictor',
+                        description='mean of 2 outputs',
+                        expression='(X + Y)/2',
+                        output=RealDescriptor(
+                            'Property~Some metric', lower_bound=0, upper_bound=1000, units='W'
+                        ).dump(),
+                        aliases={
+                            "Property~X": "X",
+                            "Property~Y": "Y"
+                        }
+                    )
+                )
+            ]
         )
     )
 

--- a/tests/resources/test_ara_definition.py
+++ b/tests/resources/test_ara_definition.py
@@ -132,7 +132,6 @@ def test_dump_example():
             OriginalUnitsColumn(data_source=density.name),
         ]
     )
-    print(json.dumps(ara_definition.dump(), indent=2))
 
 
 def test_preview(collection, session):

--- a/tests/resources/test_predictor.py
+++ b/tests/resources/test_predictor.py
@@ -2,6 +2,7 @@
 import mock
 import pytest
 import uuid
+from copy import deepcopy
 
 from citrine.exceptions import ModuleRegistrationFailedException, NotFound
 from citrine.informatics.predictors import GraphPredictor, SimpleMLPredictor
@@ -51,8 +52,9 @@ def test_register(valid_simple_ml_predictor_data):
 
 
 def test_graph_register(valid_graph_predictor_data):
+    copy_graph_data = deepcopy(valid_graph_predictor_data)
     session = mock.Mock()
-    session.post_resource.return_value = valid_graph_predictor_data
+    session.post_resource.return_value = copy_graph_data
     session.get_resource.return_value = {
         'id': str(uuid.uuid4()),
         'status': 'VALID',

--- a/tests/serialization/test_predictors.py
+++ b/tests/serialization/test_predictors.py
@@ -1,6 +1,7 @@
 """Tests for citrine.informatics.predictors serialization."""
 import pytest
 from uuid import UUID
+from uuid import uuid4
 
 from citrine.informatics.predictors import ExpressionPredictor, GraphPredictor, Predictor, SimpleMLPredictor
 from citrine.informatics.descriptors import RealDescriptor

--- a/tests/serialization/test_predictors.py
+++ b/tests/serialization/test_predictors.py
@@ -1,13 +1,13 @@
 """Tests for citrine.informatics.predictors serialization."""
 import pytest
 from uuid import UUID
-from uuid import uuid4
 
 from citrine.informatics.predictors import ExpressionPredictor, GraphPredictor, Predictor, SimpleMLPredictor
 from citrine.informatics.descriptors import RealDescriptor
 
 
 def valid_serialization_output(data):
+    """Remove fields that are not preserved by serialization."""
     return {x: y for x, y in data.items() if x not in {'status', 'status_info'}}
 
 

--- a/tests/serialization/test_predictors.py
+++ b/tests/serialization/test_predictors.py
@@ -52,6 +52,7 @@ def test_graph_serialization(valid_graph_predictor_data):
     predictor = GraphPredictor.build(valid_graph_predictor_data)
     serialized = predictor.dump()
     serialized['id'] = valid_graph_predictor_data['id']
+    assert serialized['config']['predictors'] == valid_graph_predictor_data['config']['predictors']
     assert serialized == valid_serialization_output(valid_graph_predictor_data)
 
 

--- a/tests/serialization/test_predictors.py
+++ b/tests/serialization/test_predictors.py
@@ -1,6 +1,7 @@
 """Tests for citrine.informatics.predictors serialization."""
 import pytest
 from uuid import UUID
+from copy import deepcopy
 
 from citrine.informatics.predictors import ExpressionPredictor, GraphPredictor, Predictor, SimpleMLPredictor
 from citrine.informatics.descriptors import RealDescriptor
@@ -49,11 +50,12 @@ def test_legacy_serialization(valid_simple_ml_predictor_data):
 
 def test_graph_serialization(valid_graph_predictor_data):
     """Ensure that a serialized GraphPredictor looks sane."""
+    graph_data_copy = deepcopy(valid_graph_predictor_data)
     predictor = GraphPredictor.build(valid_graph_predictor_data)
     serialized = predictor.dump()
-    serialized['id'] = valid_graph_predictor_data['id']
-    assert serialized['config']['predictors'] == valid_graph_predictor_data['config']['predictors']
-    assert serialized == valid_serialization_output(valid_graph_predictor_data)
+    serialized['id'] = graph_data_copy['id']
+    assert serialized['config']['predictors'] == graph_data_copy['config']['predictors']
+    assert serialized == valid_serialization_output(graph_data_copy)
 
 
 def test_expression_serialization(valid_expression_predictor_data):


### PR DESCRIPTION
# Citrine Python PR

## Description 
Allows for embedded predictors in graph.
* GraphPredictor `predictors` field now accepts a list of UUIDs, other predictors, or a mixture of the 2
* Created `Union` Property to allow for this "UUID or predictor" logic
* Renamed `MixedList` Property to `SpecifiedMixedList` to clarify that each entry has a specified type ("MixedList" sounds like its List[Union[...]], which it isn't)
* Update GraphPredictor serde test to include an embedded expression predictor.

Follow-on PR in orion-documentation will reflect these changes

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [X] I have communicated the downstream consequences of the PR to others.
