### PR TITLE
Bug/pla 3008 notebook connection reset error

### DIFF
--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -82,7 +82,7 @@ class Session(requests.Session):
         try:
             response = super().request(method, uri, **kwargs)
         except (ConnectionError, ConnectionResetError):
-            logger.debug('Connection Reset, creating a new session')
+            logger.debug('Connection Error, creating a new session')
             super().__init__()
             response = super().request(method, uri, **kwargs)
 

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -81,7 +81,7 @@ class Session(requests.Session):
 
         try:
             response = super().request(method, uri, **kwargs)
-        except ConnectionResetError:
+        except (ConnectionError, ConnectionResetError):
             logger.debug('Connection Reset, creating a new session')
             super().__init__()
             response = super().request(method, uri, **kwargs)

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -79,7 +79,12 @@ class Session(requests.Session):
             logger.debug('\t{}: {}'.format(k, v))
         logger.debug('END request details.')
 
-        response = super().request(method, uri, **kwargs)
+        try:
+            response = super().request(method, uri, **kwargs)
+        except ConnectionResetError:
+            logger.debug('Connection Reset, creating a new session')
+            super().__init__()
+            response = super().request(method, uri, **kwargs)
 
         try:
             if response.status_code == 401 and response.json().get("reason") == "invalid-token":

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -200,7 +200,7 @@ def test_cursor_paged_resource():
 def test_connection_reset_error_starts_new_session(session: Session):
     call_count = 0
 
-    # This function is used to raise a ConnectionResetError on the first call and otherwise True.  This execises
+    # This function is used to raise a ConnectionResetError on the first call and otherwise True.  This exercises
     # the code that recreates the session and retries the request.
     def error_on_first_call(_):
         nonlocal call_count


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR is a proposed bugfix for https://citrine.atlassian.net/browse/PLA-3008.  If a ConnectionResetError or ConnectionError exception is raised while running a request, this will reinitialize the session and try the request again.  This does not use recursion.

I view this as a low risk PR as there is no substantial change to the logic.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
