### PR TITLE
Deploy sphinx docs on tags rather than the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ deploy:
     keep_history: true
     local_dir: ./docs/_build/html/
     on:
-      branch: master
+      tags: true
   - provider: pypi
     user: "CitrineInformatics"
     password: "$PYPI_PASSWORD"


### PR DESCRIPTION
This makes it consistent with the deployment to pypi, such
that the most recent version on pypi is the version that's documented
on the gh-pages site.