### PR TITLE
Add retry logic with basic backoff to request logic

### DIFF
--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -87,8 +87,9 @@ class Session(requests.Session):
 
             try:
                 response = super().request(method, uri, **kwargs)
+                msg = 'Received server error from citrine, trying again. {}'.format(try_msg)
                 if response.status_code >= 500:
-                    logger.warn('Received server error from citrine, trying again. {}'.format(try_msg))
+                    logger.warn(msg)
                 else:
                     break
             except (ConnectionError, ConnectionResetError) as e:

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -15,6 +15,7 @@ from citrine.exceptions import (
 
 import jwt
 import requests
+import time
 
 # Choose a 5 second buffer so that there's no chance of the access token
 # expiring during the check for expiration
@@ -95,6 +96,8 @@ class Session(requests.Session):
                     logger.debug('Connection reset by server, trying again. ')
                 else:
                     raise e
+
+            time.sleep(tries)
 
         try:
             if response.status_code == 401 and response.json().get("reason") == "invalid-token":


### PR DESCRIPTION
Adds a backoff retry loop to the request making logic. Should add wiggle room for connection related issues.

Test coverage is at 90% in the session class with this PR, but it was at that same point before this PR as well, so this does not decrease test coverage.
