### PR TITLE
Handle non-json responses to REST calls without erroring

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -226,3 +226,18 @@ def test_connection_reset_error_starts_new_session(session: Session):
             session.get_resource('/foo')
 
     assert call_count is 3
+
+
+def test_bad_json_response(session: Session):
+    with requests_mock.Mocker() as m:
+        m.delete('http://citrine-testing.fake/api/v1/bar/something', status_code=200)
+        response_json = session.delete_resource('/bar/something')
+        assert response_json == {}
+
+
+def test_good_json_response(session: Session):
+    with requests_mock.Mocker() as m:
+        json_to_validate = {"bar": "something"}
+        m.put('http://citrine-testing.fake/api/v1/bar/something', status_code=200, json=json_to_validate)
+        response_json = session.put_resource('bar/something', {"ignored": "true"})
+        assert response_json == json_to_validate


### PR DESCRIPTION
# Citrine Python PR

## Description 
Handle non-json or invalid json responses from the backend without erroring, e.g. status code only with no payload

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
