### PR TITLE
Refactoring the retry logic to use a urllib3 Retry and HTTPAdapter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sphinxcontrib-apidoc==0.3.0
 boto3==1.9.226
 botocore==1.12.226
 deprecation==2.0.7
+urllib3==1.25.7

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,8 @@ setup(name='citrine',
           "taurus-citrine>=0.6.0,<0.7",
           "boto3>=1.9.226,<2",
           "botocore>=1.12.226,<2",
-          "deprecation>=2.0.7,<3"
+          "deprecation>=2.0.7,<3",
+          "urllib3>=1.25.7,<2"
       ],
       cmdclass={
           'install': PostInstallCommand,


### PR DESCRIPTION
This gives us fine grained control over the retry logic and backoff params.
We also control which HTTP status codes trigger a retry, including CloudFlare
specific codes.  This also switches from using super().request() to self.request()
for simplicity.

# Citrine Python PR

## Description 

The goal of this PR is to use a standard approach to HTTP retries that is simple and robust.  This approach uses the one suggested by the Request docs.  This is the approach used by the Pip package management tool which handles timeouts and other errors gracefully.

I'm happy to discuss and modify the HTTP codes we wish to retry on, the number of retries and the backoff params.  I picked arbitrary parameters based on other examples I saw.  This should cover just about everything we are likely to encounter.

This will work for all relevant requests made using the Citrine-python Session class (get/put/post/etc).

I removed a couple unit tests since the retry logic is now outside of citrine-python.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
