### PR TITLE
Clarify that every PR to master requires a version bump, and catch up…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,13 +190,12 @@ For additional (non-binding) inspiration, check out the [Google Python Style Gui
 
 ## PR Submission<a name="pr"></a>
 Features should be developed in a branch with a descriptive name and the pull request (PR) submitted into the `master` branch.
+Every PR to `master` should increment the version number following [semantic versioning](https://semver.org/). 
 In order to be merged, a PR must be approved by one authorized user and the build must pass.
 A passing build requires the following:
 * All tests pass
 * The linter finds no violations of PEP8 style
 * Every line of code is executed by a test (100% coverage)
-
-
 
 ## Documentation<a name="documentation"></a>
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.8.0',
+      version='0.9.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',


### PR DESCRIPTION
This is consistent with our updated https://citrine.atlassian.net/wiki/spaces/PLA/pages/91947433/Citrine-python+deployment+plan

#263 added the "dry_run" option, which is a new feature, so minor bump.