### PR TITLE
Add multilayered inheritance structure to DataConcepts[Collection]

### DIFF
--- a/src/citrine/resources/attribute_templates.py
+++ b/src/citrine/resources/attribute_templates.py
@@ -1,13 +1,11 @@
 """Top-level class for all attribute template objects and collections thereof."""
-from abc import abstractmethod
-from typing import Type
+from abc import ABC
 
-from citrine._serialization.serializable import Serializable
 from citrine.resources.data_concepts import ResourceType
 from citrine.resources.templates import Template, TemplateCollection
 
 
-class AttributeTemplate(Template):
+class AttributeTemplate(Template, ABC):
     """
     An abstract attribute template object.
 
@@ -17,8 +15,3 @@ class AttributeTemplate(Template):
 
 class AttributeTemplateCollection(TemplateCollection[ResourceType]):
     """A collection of one kind of attribute template object."""
-
-    @classmethod
-    @abstractmethod
-    def get_type(cls) -> Type[Serializable]:
-        """Return the resource type in the collection."""

--- a/src/citrine/resources/attribute_templates.py
+++ b/src/citrine/resources/attribute_templates.py
@@ -1,0 +1,24 @@
+"""Top-level class for all attribute template objects and collections thereof."""
+from abc import abstractmethod
+from typing import Type
+
+from citrine._serialization.serializable import Serializable
+from citrine.resources.data_concepts import ResourceType
+from citrine.resources.templates import Template, TemplateCollection
+
+
+class AttributeTemplate(Template):
+    """
+    An abstract attribute template object.
+
+    AttributeTemplate must be extended along with `Resource`
+    """
+
+
+class AttributeTemplateCollection(TemplateCollection[ResourceType]):
+    """A collection of one kind of attribute template object."""
+
+    @classmethod
+    @abstractmethod
+    def get_type(cls) -> Type[Serializable]:
+        """Return the resource type in the collection."""

--- a/src/citrine/resources/condition_template.py
+++ b/src/citrine/resources/condition_template.py
@@ -2,16 +2,17 @@
 from typing import List, Dict, Optional, Type
 
 from citrine._rest.resource import Resource
-from citrine._serialization.properties import String, Mapping, Object
-from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
+from citrine._serialization.properties import Optional as PropertyOptional
+from citrine._serialization.properties import String, Mapping, Object
 from citrine._utils.functions import set_default_uid
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
-from taurus.entity.template.condition_template import ConditionTemplate as TaurusConditionTemplate
+from citrine.resources.attribute_templates import AttributeTemplate, AttributeTemplateCollection
+from citrine.resources.data_concepts import DataConcepts
 from taurus.entity.bounds.base_bounds import BaseBounds
+from taurus.entity.template.condition_template import ConditionTemplate as TaurusConditionTemplate
 
 
-class ConditionTemplate(DataConcepts, Resource['ConditionTemplate'], TaurusConditionTemplate):
+class ConditionTemplate(AttributeTemplate, Resource['ConditionTemplate'], TaurusConditionTemplate):
     """
     A condition template.
 
@@ -58,7 +59,7 @@ class ConditionTemplate(DataConcepts, Resource['ConditionTemplate'], TaurusCondi
         return '<Condition template {!r}>'.format(self.name)
 
 
-class ConditionTemplateCollection(DataConceptsCollection[ConditionTemplate]):
+class ConditionTemplateCollection(AttributeTemplateCollection[ConditionTemplate]):
     """A collection of condition templates."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/condition-templates'

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -1,7 +1,7 @@
 """Top-level class for all data concepts objects and collections thereof."""
 from uuid import UUID
 from typing import TypeVar, Type, List, Dict, Union, Optional, Iterator
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 
 from citrine._session import Session
 from citrine._rest.collection import Collection
@@ -18,7 +18,7 @@ from taurus.entity.template.attribute_template import AttributeTemplate
 from citrine.resources.response import Response
 
 
-class DataConcepts(PolymorphicSerializable['DataConcepts'], DictSerializable):
+class DataConcepts(PolymorphicSerializable['DataConcepts'], DictSerializable, ABC):
     """
     An abstract data concepts object.
 
@@ -193,7 +193,7 @@ class DataConcepts(PolymorphicSerializable['DataConcepts'], DictSerializable):
 ResourceType = TypeVar('ResourceType', bound='DataConcepts')
 
 
-class DataConceptsCollection(Collection[ResourceType]):
+class DataConceptsCollection(Collection[ResourceType], ABC):
     """
     A collection of one kind of data concepts object.
 

--- a/src/citrine/resources/data_objects.py
+++ b/src/citrine/resources/data_objects.py
@@ -1,12 +1,10 @@
 """Top-level class for all data object (i.e. spec and run) objects and collections thereof."""
-from abc import abstractmethod
-from typing import Type
+from abc import ABC
 
-from citrine._serialization.serializable import Serializable
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection, ResourceType
 
 
-class DataObject(DataConcepts):
+class DataObject(DataConcepts, ABC):
     """
     An abstract data object object.
 
@@ -14,10 +12,5 @@ class DataObject(DataConcepts):
     """
 
 
-class DataObjectCollection(DataConceptsCollection[ResourceType]):
+class DataObjectCollection(DataConceptsCollection[ResourceType], ABC):
     """A collection of one kind of data object object."""
-
-    @classmethod
-    @abstractmethod
-    def get_type(cls) -> Type[Serializable]:
-        """Return the resource type in the collection."""

--- a/src/citrine/resources/data_objects.py
+++ b/src/citrine/resources/data_objects.py
@@ -1,0 +1,23 @@
+"""Top-level class for all data object (i.e. spec and run) objects and collections thereof."""
+from abc import abstractmethod
+from typing import Type
+
+from citrine._serialization.serializable import Serializable
+from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection, ResourceType
+
+
+class DataObject(DataConcepts):
+    """
+    An abstract data object object.
+
+    DataObject must be extended along with `Resource`
+    """
+
+
+class DataObjectCollection(DataConceptsCollection[ResourceType]):
+    """A collection of one kind of data object object."""
+
+    @classmethod
+    @abstractmethod
+    def get_type(cls) -> Type[Serializable]:
+        """Return the resource type in the collection."""

--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -1,12 +1,13 @@
 """Resources that represent ingredient run data objects."""
 from typing import List, Dict, Optional, Type
 
-from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
-from citrine.resources.data_concepts import DataConceptsCollection, DataConcepts
-from citrine._serialization.properties import Mapping, String, LinkOrElse, Object
 from citrine._serialization.properties import List as PropertyList
+from citrine._serialization.properties import Mapping, String, LinkOrElse, Object
 from citrine._serialization.properties import Optional as PropertyOptional
+from citrine._utils.functions import set_default_uid
+from citrine.resources.data_concepts import DataConcepts
+from citrine.resources.object_runs import ObjectRun, ObjectRunCollection
 from taurus.entity.file_link import FileLink
 from taurus.entity.object.ingredient_run import IngredientRun as TaurusIngredientRun
 from taurus.entity.object.ingredient_spec import IngredientSpec as TaurusIngredientSpec
@@ -15,7 +16,7 @@ from taurus.entity.object.process_run import ProcessRun as TaurusProcessRun
 from taurus.entity.value.continuous_value import ContinuousValue
 
 
-class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun):
+class IngredientRun(ObjectRun, Resource['IngredientRun'], TaurusIngredientRun):
     """
     An ingredient run.
 
@@ -106,7 +107,7 @@ class IngredientRun(DataConcepts, Resource['IngredientRun'], TaurusIngredientRun
         return '<Ingredient run {!r}>'.format(self.name)
 
 
-class IngredientRunCollection(DataConceptsCollection[IngredientRun]):
+class IngredientRunCollection(ObjectRunCollection[IngredientRun]):
     """Represents the collection of all ingredient runs associated with a dataset."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/ingredient-runs'

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -1,20 +1,21 @@
 """Resources that represent ingredient spec data objects."""
 from typing import List, Dict, Optional, Type
 
-from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
-from citrine.resources.data_concepts import DataConceptsCollection, DataConcepts
-from citrine._serialization.properties import Mapping, String, LinkOrElse, Object
 from citrine._serialization.properties import List as PropertyList
+from citrine._serialization.properties import Mapping, String, LinkOrElse, Object
 from citrine._serialization.properties import Optional as PropertyOptional
+from citrine._utils.functions import set_default_uid
+from citrine.resources.data_concepts import DataConcepts
+from citrine.resources.object_specs import ObjectSpec, ObjectSpecCollection
 from taurus.entity.file_link import FileLink
 from taurus.entity.object.ingredient_spec import IngredientSpec as TaurusIngredientSpec
-from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 from taurus.entity.object.material_spec import MaterialSpec as TaurusMaterialSpec
+from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 from taurus.entity.value.continuous_value import ContinuousValue
 
 
-class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientSpec):
+class IngredientSpec(ObjectSpec, Resource['IngredientSpec'], TaurusIngredientSpec):
     """
     An ingredient specification.
 
@@ -99,7 +100,7 @@ class IngredientSpec(DataConcepts, Resource['IngredientSpec'], TaurusIngredientS
         return '<Ingredient spec {!r}>'.format(self.name)
 
 
-class IngredientSpecCollection(DataConceptsCollection[IngredientSpec]):
+class IngredientSpecCollection(ObjectSpecCollection[IngredientSpec]):
     """Represents the collection of all ingredient specs associated with a dataset."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/ingredient-specs'

--- a/src/citrine/resources/material_run.py
+++ b/src/citrine/resources/material_run.py
@@ -8,18 +8,19 @@ from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, LinkOrElse, Mapping, Object
 from citrine._utils.functions import set_default_uid
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.material_spec import MaterialSpecCollection
+from citrine.resources.object_runs import ObjectRun, ObjectRunCollection
 from taurus.entity.file_link import FileLink
 from taurus.entity.link_by_uid import LinkByUID
 from taurus.entity.object.material_run import MaterialRun as TaurusMaterialRun
 from taurus.entity.object.material_spec import MaterialSpec as TaurusMaterialSpec
 from taurus.entity.object.process_run import ProcessRun as TaurusProcessRun
-from taurus.util import writable_sort_order
 from taurus.json import TaurusEncoder
+from taurus.util import writable_sort_order
 
 
-class MaterialRun(DataConcepts, Resource['MaterialRun'], TaurusMaterialRun):
+class MaterialRun(ObjectRun, Resource['MaterialRun'], TaurusMaterialRun):
     """
     A material run.
 
@@ -86,7 +87,7 @@ class MaterialRun(DataConcepts, Resource['MaterialRun'], TaurusMaterialRun):
         return '<Material run {!r}>'.format(self.name)
 
 
-class MaterialRunCollection(DataConceptsCollection[MaterialRun]):
+class MaterialRunCollection(ObjectRunCollection[MaterialRun]):
     """Represents the collection of all material runs associated with a dataset."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/material-runs'

--- a/src/citrine/resources/material_spec.py
+++ b/src/citrine/resources/material_spec.py
@@ -6,8 +6,9 @@ from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, LinkOrElse, Mapping, Object
 from citrine._utils.functions import set_default_uid
-from citrine.resources.data_concepts import DataConceptsCollection, DataConcepts
+from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.material_template import MaterialTemplateCollection
+from citrine.resources.object_specs import ObjectSpec, ObjectSpecCollection
 from taurus.entity.attribute.property_and_conditions import PropertyAndConditions
 from taurus.entity.file_link import FileLink
 from taurus.entity.object.material_spec import MaterialSpec as TaurusMaterialSpec
@@ -15,7 +16,7 @@ from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 from taurus.entity.template.material_template import MaterialTemplate as TaurusMaterialTemplate
 
 
-class MaterialSpec(DataConcepts, Resource['MaterialSpec'], TaurusMaterialSpec):
+class MaterialSpec(ObjectSpec, Resource['MaterialSpec'], TaurusMaterialSpec):
     """
     A material specification.
 
@@ -75,7 +76,7 @@ class MaterialSpec(DataConcepts, Resource['MaterialSpec'], TaurusMaterialSpec):
         return '<Material spec {!r}>'.format(self.name)
 
 
-class MaterialSpecCollection(DataConceptsCollection[MaterialSpec]):
+class MaterialSpecCollection(ObjectSpecCollection[MaterialSpec]):
     """Represents the collection of all material specs associated with a dataset."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/material-specs'

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -7,14 +7,15 @@ from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, \
     LinkOrElse
 from citrine._utils.functions import set_default_uid
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.data_concepts import DataConcepts
+from citrine.resources.object_templates import ObjectTemplateCollection, ObjectTemplate
 from citrine.resources.property_template import PropertyTemplate
 from taurus.entity.bounds.base_bounds import BaseBounds
 from taurus.entity.link_by_uid import LinkByUID
 from taurus.entity.template.material_template import MaterialTemplate as TaurusMaterialTemplate
 
 
-class MaterialTemplate(DataConcepts, Resource['MaterialTemplate'], TaurusMaterialTemplate):
+class MaterialTemplate(ObjectTemplate, Resource['MaterialTemplate'], TaurusMaterialTemplate):
     """
     A material template.
 
@@ -76,7 +77,7 @@ class MaterialTemplate(DataConcepts, Resource['MaterialTemplate'], TaurusMateria
         return '<Material template {!r}>'.format(self.name)
 
 
-class MaterialTemplateCollection(DataConceptsCollection[MaterialTemplate]):
+class MaterialTemplateCollection(ObjectTemplateCollection[MaterialTemplate]):
     """A collection of material templates."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/material-templates'

--- a/src/citrine/resources/measurement_run.py
+++ b/src/citrine/resources/measurement_run.py
@@ -1,12 +1,13 @@
 """Resources that represent measurement run data objects."""
 from typing import List, Dict, Optional, Type
 
-from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
-from citrine._serialization.properties import String, Object, Mapping, LinkOrElse
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine._serialization.properties import String, Object, Mapping, LinkOrElse
+from citrine._utils.functions import set_default_uid
+from citrine.resources.data_concepts import DataConcepts
+from citrine.resources.object_runs import ObjectRun, ObjectRunCollection
 from taurus.entity.attribute.condition import Condition
 from taurus.entity.attribute.parameter import Parameter
 from taurus.entity.attribute.property import Property
@@ -17,7 +18,7 @@ from taurus.entity.object.measurement_spec import MeasurementSpec as TaurusMeasu
 from taurus.entity.source.performed_source import PerformedSource
 
 
-class MeasurementRun(DataConcepts, Resource['MeasurementRun'], TaurusMeasurementRun):
+class MeasurementRun(ObjectRun, Resource['MeasurementRun'], TaurusMeasurementRun):
     """
     A measurement run.
 
@@ -92,7 +93,7 @@ class MeasurementRun(DataConcepts, Resource['MeasurementRun'], TaurusMeasurement
         return '<Measurement run {!r}>'.format(self.name)
 
 
-class MeasurementRunCollection(DataConceptsCollection[MeasurementRun]):
+class MeasurementRunCollection(ObjectRunCollection[MeasurementRun]):
     """Represents the collection of all measurement runs associated with a dataset."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/measurement-runs'

--- a/src/citrine/resources/measurement_spec.py
+++ b/src/citrine/resources/measurement_spec.py
@@ -1,12 +1,13 @@
 """Resources that represent measurement spec data objects."""
 from typing import List, Dict, Optional, Type
 
-from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
-from citrine._serialization.properties import String, Object, Mapping, LinkOrElse
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
-from citrine.resources.data_concepts import DataConceptsCollection, DataConcepts
+from citrine._serialization.properties import String, Object, Mapping, LinkOrElse
+from citrine._utils.functions import set_default_uid
+from citrine.resources.data_concepts import DataConcepts
+from citrine.resources.object_specs import ObjectSpec, ObjectSpecCollection
 from taurus.entity.attribute.condition import Condition
 from taurus.entity.attribute.parameter import Parameter
 from taurus.entity.file_link import FileLink
@@ -15,7 +16,7 @@ from taurus.entity.template.measurement_template import \
     MeasurementTemplate as TaurusMeasurementTemplate
 
 
-class MeasurementSpec(DataConcepts, Resource['MeasurementSpec'], TaurusMeasurementSpec):
+class MeasurementSpec(ObjectSpec, Resource['MeasurementSpec'], TaurusMeasurementSpec):
     """
     A measurement specification.
 
@@ -75,7 +76,7 @@ class MeasurementSpec(DataConcepts, Resource['MeasurementSpec'], TaurusMeasureme
         return '<Measurement spec {!r}>'.format(self.name)
 
 
-class MeasurementSpecCollection(DataConceptsCollection[MeasurementSpec]):
+class MeasurementSpecCollection(ObjectSpecCollection[MeasurementSpec]):
     """Represents the collection of all measurement specs associated with a dataset."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/measurement-specs'

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -2,22 +2,23 @@
 from typing import List, Dict, Optional, Union, Sequence, Type
 
 from citrine._rest.resource import Resource
+from citrine._serialization.properties import List as PropertyList
+from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, \
     LinkOrElse
-from citrine._serialization.properties import Optional as PropertyOptional
-from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
-from citrine.resources.property_template import PropertyTemplate
-from citrine.resources.parameter_template import ParameterTemplate
 from citrine.resources.condition_template import ConditionTemplate
-from taurus.entity.template.measurement_template \
-    import MeasurementTemplate as TaurusMeasurementTemplate
+from citrine.resources.data_concepts import DataConcepts
+from citrine.resources.object_templates import ObjectTemplate, ObjectTemplateCollection
+from citrine.resources.parameter_template import ParameterTemplate
+from citrine.resources.property_template import PropertyTemplate
 from taurus.entity.bounds.base_bounds import BaseBounds
 from taurus.entity.link_by_uid import LinkByUID
+from taurus.entity.template.measurement_template \
+    import MeasurementTemplate as TaurusMeasurementTemplate
 
 
-class MeasurementTemplate(DataConcepts,
+class MeasurementTemplate(ObjectTemplate,
                           Resource['MeasurementTemplate'], TaurusMeasurementTemplate):
     """
     A measurement template.
@@ -101,7 +102,7 @@ class MeasurementTemplate(DataConcepts,
         return '<Measurement template {!r}>'.format(self.name)
 
 
-class MeasurementTemplateCollection(DataConceptsCollection[MeasurementTemplate]):
+class MeasurementTemplateCollection(ObjectTemplateCollection[MeasurementTemplate]):
     """A collection of measurement templates."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/measurement-templates'

--- a/src/citrine/resources/object_runs.py
+++ b/src/citrine/resources/object_runs.py
@@ -1,13 +1,11 @@
 """Top-level class for all object run objects and collections thereof."""
-from abc import abstractmethod
-from typing import Type
+from abc import ABC
 
-from citrine._serialization.serializable import Serializable
 from citrine.resources.data_concepts import ResourceType
 from citrine.resources.data_objects import DataObject, DataObjectCollection
 
 
-class ObjectRun(DataObject):
+class ObjectRun(DataObject, ABC):
     """
     An abstract object run object.
 
@@ -15,10 +13,5 @@ class ObjectRun(DataObject):
     """
 
 
-class ObjectRunCollection(DataObjectCollection[ResourceType]):
+class ObjectRunCollection(DataObjectCollection[ResourceType], ABC):
     """A collection of one kind of object run object."""
-
-    @classmethod
-    @abstractmethod
-    def get_type(cls) -> Type[Serializable]:
-        """Return the resource type in the collection."""

--- a/src/citrine/resources/object_runs.py
+++ b/src/citrine/resources/object_runs.py
@@ -1,0 +1,24 @@
+"""Top-level class for all object run objects and collections thereof."""
+from abc import abstractmethod
+from typing import Type
+
+from citrine._serialization.serializable import Serializable
+from citrine.resources.data_concepts import ResourceType
+from citrine.resources.data_objects import DataObject, DataObjectCollection
+
+
+class ObjectRun(DataObject):
+    """
+    An abstract object run object.
+
+    ObjectRun must be extended along with `Resource`
+    """
+
+
+class ObjectRunCollection(DataObjectCollection[ResourceType]):
+    """A collection of one kind of object run object."""
+
+    @classmethod
+    @abstractmethod
+    def get_type(cls) -> Type[Serializable]:
+        """Return the resource type in the collection."""

--- a/src/citrine/resources/object_specs.py
+++ b/src/citrine/resources/object_specs.py
@@ -1,0 +1,24 @@
+"""Top-level class for all object spec objects and collections thereof."""
+from abc import abstractmethod
+from typing import Type
+
+from citrine._serialization.serializable import Serializable
+from citrine.resources.data_concepts import ResourceType
+from citrine.resources.data_objects import DataObject, DataObjectCollection
+
+
+class ObjectSpec(DataObject):
+    """
+    An abstract object spec object.
+
+    ObjectSpec must be extended along with `Resource`
+    """
+
+
+class ObjectSpecCollection(DataObjectCollection[ResourceType]):
+    """A collection of one kind of object spec object."""
+
+    @classmethod
+    @abstractmethod
+    def get_type(cls) -> Type[Serializable]:
+        """Return the resource type in the collection."""

--- a/src/citrine/resources/object_specs.py
+++ b/src/citrine/resources/object_specs.py
@@ -1,13 +1,11 @@
 """Top-level class for all object spec objects and collections thereof."""
-from abc import abstractmethod
-from typing import Type
+from abc import ABC
 
-from citrine._serialization.serializable import Serializable
 from citrine.resources.data_concepts import ResourceType
 from citrine.resources.data_objects import DataObject, DataObjectCollection
 
 
-class ObjectSpec(DataObject):
+class ObjectSpec(DataObject, ABC):
     """
     An abstract object spec object.
 
@@ -15,10 +13,5 @@ class ObjectSpec(DataObject):
     """
 
 
-class ObjectSpecCollection(DataObjectCollection[ResourceType]):
+class ObjectSpecCollection(DataObjectCollection[ResourceType], ABC):
     """A collection of one kind of object spec object."""
-
-    @classmethod
-    @abstractmethod
-    def get_type(cls) -> Type[Serializable]:
-        """Return the resource type in the collection."""

--- a/src/citrine/resources/object_templates.py
+++ b/src/citrine/resources/object_templates.py
@@ -1,13 +1,11 @@
 """Top-level class for all object template objects and collections thereof."""
-from abc import abstractmethod
-from typing import Type
+from abc import ABC
 
-from citrine._serialization.serializable import Serializable
 from citrine.resources.data_concepts import ResourceType
 from citrine.resources.templates import Template, TemplateCollection
 
 
-class ObjectTemplate(Template):
+class ObjectTemplate(Template, ABC):
     """
     An abstract object template object.
 
@@ -15,10 +13,5 @@ class ObjectTemplate(Template):
     """
 
 
-class ObjectTemplateCollection(TemplateCollection[ResourceType]):
+class ObjectTemplateCollection(TemplateCollection[ResourceType], ABC):
     """A collection of one kind of object template object."""
-
-    @classmethod
-    @abstractmethod
-    def get_type(cls) -> Type[Serializable]:
-        """Return the resource type in the collection."""

--- a/src/citrine/resources/object_templates.py
+++ b/src/citrine/resources/object_templates.py
@@ -1,0 +1,24 @@
+"""Top-level class for all object template objects and collections thereof."""
+from abc import abstractmethod
+from typing import Type
+
+from citrine._serialization.serializable import Serializable
+from citrine.resources.data_concepts import ResourceType
+from citrine.resources.templates import Template, TemplateCollection
+
+
+class ObjectTemplate(Template):
+    """
+    An abstract object template object.
+
+    ObjectTemplate must be extended along with `Resource`
+    """
+
+
+class ObjectTemplateCollection(TemplateCollection[ResourceType]):
+    """A collection of one kind of object template object."""
+
+    @classmethod
+    @abstractmethod
+    def get_type(cls) -> Type[Serializable]:
+        """Return the resource type in the collection."""

--- a/src/citrine/resources/parameter_template.py
+++ b/src/citrine/resources/parameter_template.py
@@ -2,16 +2,17 @@
 from typing import List, Dict, Optional, Type
 
 from citrine._rest.resource import Resource
-from citrine._serialization.properties import String, Mapping, Object
-from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
+from citrine._serialization.properties import Optional as PropertyOptional
+from citrine._serialization.properties import String, Mapping, Object
 from citrine._utils.functions import set_default_uid
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
-from taurus.entity.template.parameter_template import ParameterTemplate as TaurusParameterTemplate
+from citrine.resources.attribute_templates import AttributeTemplate, AttributeTemplateCollection
+from citrine.resources.data_concepts import DataConcepts
 from taurus.entity.bounds.base_bounds import BaseBounds
+from taurus.entity.template.parameter_template import ParameterTemplate as TaurusParameterTemplate
 
 
-class ParameterTemplate(DataConcepts, Resource['ParameterTemplate'], TaurusParameterTemplate):
+class ParameterTemplate(AttributeTemplate, Resource['ParameterTemplate'], TaurusParameterTemplate):
     """
     A parameter template.
 
@@ -57,7 +58,7 @@ class ParameterTemplate(DataConcepts, Resource['ParameterTemplate'], TaurusParam
         return '<Parameter template {!r}>'.format(self.name)
 
 
-class ParameterTemplateCollection(DataConceptsCollection[ParameterTemplate]):
+class ParameterTemplateCollection(AttributeTemplateCollection[ParameterTemplate]):
     """A collection of parameter templates."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/parameter-templates'

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -1,12 +1,13 @@
 """Resources that represent process run data objects."""
 from typing import List, Dict, Optional, Type
 
-from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
-from citrine._serialization.properties import String, Mapping, Object, LinkOrElse
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
-from citrine.resources.data_concepts import DataConceptsCollection, DataConcepts
+from citrine._serialization.properties import String, Mapping, Object, LinkOrElse
+from citrine._utils.functions import set_default_uid
+from citrine.resources.data_concepts import DataConcepts
+from citrine.resources.object_runs import ObjectRun, ObjectRunCollection
 from taurus.entity.attribute.condition import Condition
 from taurus.entity.attribute.parameter import Parameter
 from taurus.entity.file_link import FileLink
@@ -15,7 +16,7 @@ from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 from taurus.entity.source.performed_source import PerformedSource
 
 
-class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
+class ProcessRun(ObjectRun, Resource['ProcessRun'], TaurusProcessRun):
     """
     A process run.
 
@@ -90,7 +91,7 @@ class ProcessRun(DataConcepts, Resource['ProcessRun'], TaurusProcessRun):
         return '<Process run {!r}>'.format(self.name)
 
 
-class ProcessRunCollection(DataConceptsCollection[ProcessRun]):
+class ProcessRunCollection(ObjectRunCollection[ProcessRun]):
     """Represents the collection of all process runs associated with a dataset."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/process-runs'

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -1,12 +1,13 @@
 """Resources that represent process spec objects."""
 from typing import Optional, Dict, List, Type
 
-from citrine._utils.functions import set_default_uid
 from citrine._rest.resource import Resource
-from citrine._serialization.properties import String, Mapping, Object, LinkOrElse
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
-from citrine.resources.data_concepts import DataConceptsCollection, DataConcepts
+from citrine._serialization.properties import String, Mapping, Object, LinkOrElse
+from citrine._utils.functions import set_default_uid
+from citrine.resources.data_concepts import DataConcepts
+from citrine.resources.object_specs import ObjectSpec, ObjectSpecCollection
 from taurus.entity.attribute.condition import Condition
 from taurus.entity.attribute.parameter import Parameter
 from taurus.entity.file_link import FileLink
@@ -14,7 +15,7 @@ from taurus.entity.object.process_spec import ProcessSpec as TaurusProcessSpec
 from taurus.entity.template.process_template import ProcessTemplate as TaurusProcessTemplate
 
 
-class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
+class ProcessSpec(ObjectSpec, Resource['ProcessSpec'], TaurusProcessSpec):
     """
     A process specification.
 
@@ -86,7 +87,7 @@ class ProcessSpec(DataConcepts, Resource['ProcessSpec'], TaurusProcessSpec):
         return '<Process spec {!r}>'.format(self.name)
 
 
-class ProcessSpecCollection(DataConceptsCollection[ProcessSpec]):
+class ProcessSpecCollection(ObjectSpecCollection[ProcessSpec]):
     """Represents the collection of all process specs associated with a dataset."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/process-specs'

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -2,20 +2,21 @@
 from typing import List, Dict, Optional, Union, Sequence, Type
 
 from citrine._rest.resource import Resource
+from citrine._serialization.properties import List as PropertyList
+from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, \
     LinkOrElse
-from citrine._serialization.properties import Optional as PropertyOptional
-from citrine._serialization.properties import List as PropertyList
 from citrine._utils.functions import set_default_uid
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
-from citrine.resources.parameter_template import ParameterTemplate
 from citrine.resources.condition_template import ConditionTemplate
-from taurus.entity.template.process_template import ProcessTemplate as TaurusProcessTemplate
+from citrine.resources.data_concepts import DataConcepts
+from citrine.resources.object_templates import ObjectTemplate, ObjectTemplateCollection
+from citrine.resources.parameter_template import ParameterTemplate
 from taurus.entity.bounds.base_bounds import BaseBounds
 from taurus.entity.link_by_uid import LinkByUID
+from taurus.entity.template.process_template import ProcessTemplate as TaurusProcessTemplate
 
 
-class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTemplate):
+class ProcessTemplate(ObjectTemplate, Resource['ProcessTemplate'], TaurusProcessTemplate):
     """
     A process template.
 
@@ -91,7 +92,7 @@ class ProcessTemplate(DataConcepts, Resource['ProcessTemplate'], TaurusProcessTe
         return '<Process template {!r}>'.format(self.name)
 
 
-class ProcessTemplateCollection(DataConceptsCollection[ProcessTemplate]):
+class ProcessTemplateCollection(ObjectTemplateCollection[ProcessTemplate]):
     """A collection of process templates."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/process-templates'

--- a/src/citrine/resources/property_template.py
+++ b/src/citrine/resources/property_template.py
@@ -2,16 +2,17 @@
 from typing import List, Dict, Optional, Type
 
 from citrine._rest.resource import Resource
-from citrine._serialization.properties import String, Mapping, Object
-from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import List as PropertyList
+from citrine._serialization.properties import Optional as PropertyOptional
+from citrine._serialization.properties import String, Mapping, Object
 from citrine._utils.functions import set_default_uid
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
-from taurus.entity.template.property_template import PropertyTemplate as TaurusPropertyTemplate
+from citrine.resources.attribute_templates import AttributeTemplate, AttributeTemplateCollection
+from citrine.resources.data_concepts import DataConcepts
 from taurus.entity.bounds.base_bounds import BaseBounds
+from taurus.entity.template.property_template import PropertyTemplate as TaurusPropertyTemplate
 
 
-class PropertyTemplate(DataConcepts, Resource['PropertyTemplate'], TaurusPropertyTemplate):
+class PropertyTemplate(AttributeTemplate, Resource['PropertyTemplate'], TaurusPropertyTemplate):
     """
     A property template.
 
@@ -57,7 +58,7 @@ class PropertyTemplate(DataConcepts, Resource['PropertyTemplate'], TaurusPropert
         return '<Property template {!r}>'.format(self.name)
 
 
-class PropertyTemplateCollection(DataConceptsCollection[PropertyTemplate]):
+class PropertyTemplateCollection(AttributeTemplateCollection[PropertyTemplate]):
     """A collection of property templates."""
 
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/property-templates'

--- a/src/citrine/resources/templates.py
+++ b/src/citrine/resources/templates.py
@@ -1,0 +1,23 @@
+"""Top-level class for all template objects and collections thereof."""
+from abc import abstractmethod
+from typing import Type
+
+from citrine._serialization.serializable import Serializable
+from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection, ResourceType
+
+
+class Template(DataConcepts):
+    """
+    An abstract template object.
+
+    Template must be extended along with `Resource`
+    """
+
+
+class TemplateCollection(DataConceptsCollection[ResourceType]):
+    """A collection of one kind of template object."""
+
+    @classmethod
+    @abstractmethod
+    def get_type(cls) -> Type[Serializable]:
+        """Return the resource type in the collection."""

--- a/src/citrine/resources/templates.py
+++ b/src/citrine/resources/templates.py
@@ -1,12 +1,10 @@
 """Top-level class for all template objects and collections thereof."""
-from abc import abstractmethod
-from typing import Type
+from abc import ABC
 
-from citrine._serialization.serializable import Serializable
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection, ResourceType
 
 
-class Template(DataConcepts):
+class Template(DataConcepts, ABC):
     """
     An abstract template object.
 
@@ -14,10 +12,5 @@ class Template(DataConcepts):
     """
 
 
-class TemplateCollection(DataConceptsCollection[ResourceType]):
+class TemplateCollection(DataConceptsCollection[ResourceType], ABC):
     """A collection of one kind of template object."""
-
-    @classmethod
-    @abstractmethod
-    def get_type(cls) -> Type[Serializable]:
-        """Return the resource type in the collection."""


### PR DESCRIPTION
# Citrine Python PR

## Description 
Add multilayered inheritance structure to DataConcepts[Collection]. Allows for more fine-grained control of which classes have access to shared methods/values

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
