### PR TITLE
Bugfix/no template method filtering by attribute bounds

### DIFF
--- a/src/citrine/resources/attribute_templates.py
+++ b/src/citrine/resources/attribute_templates.py
@@ -1,7 +1,7 @@
 """Top-level class for all attribute template objects and collections thereof."""
 from abc import ABC
+from typing import TypeVar
 
-from citrine.resources.data_concepts import ResourceType
 from citrine.resources.templates import Template, TemplateCollection
 
 
@@ -13,5 +13,8 @@ class AttributeTemplate(Template, ABC):
     """
 
 
-class AttributeTemplateCollection(TemplateCollection[ResourceType]):
+AttributeTemplateResourceType = TypeVar("AttributeTemplateResourceType", bound="AttributeTemplate")
+
+
+class AttributeTemplateCollection(TemplateCollection[AttributeTemplateResourceType]):
     """A collection of one kind of attribute template object."""

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -1,21 +1,18 @@
 """Top-level class for all data concepts objects and collections thereof."""
-from uuid import UUID
-from typing import TypeVar, Type, List, Dict, Union, Optional, Iterator
 from abc import abstractmethod, ABC
+from typing import TypeVar, Type, List, Union, Optional, Iterator
+from uuid import UUID
 
-from citrine._session import Session
 from citrine._rest.collection import Collection
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
 from citrine._serialization.serializable import Serializable
-from citrine._utils.functions import scrub_none, replace_objects_with_links, get_object_id
+from citrine._session import Session
+from citrine._utils.functions import scrub_none, replace_objects_with_links
 from citrine.resources.audit_info import AuditInfo
-from taurus.json import TaurusJson
-from taurus.entity.link_by_uid import LinkByUID
-from taurus.entity.dict_serializable import DictSerializable
-from taurus.entity.bounds.base_bounds import BaseBounds
-from taurus.entity.template.attribute_template import AttributeTemplate
-
 from citrine.resources.response import Response
+from taurus.entity.dict_serializable import DictSerializable
+from taurus.entity.link_by_uid import LinkByUID
+from taurus.json import TaurusJson
 
 
 class DataConcepts(PolymorphicSerializable['DataConcepts'], DictSerializable, ABC):
@@ -395,54 +392,6 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
             params=params)
         return [self.build(content) for content in response["contents"]]
 
-    def filter_by_attribute_bounds(
-            self,
-            attribute_bounds: Dict[Union[AttributeTemplate, LinkByUID], BaseBounds],
-            page: Optional[int] = None, per_page: Optional[int] = None):
-        """
-        Get all objects in the collection with attributes within certain bounds.
-
-        Currently only one attribute and one bounds on that attribute is supported.
-
-        Parameters
-        ----------
-        attribute_bounds: Dict[Union[AttributeTemplate, \
-        :py:class:`LinkByUID <taurus.entity.link_by_uid.LinkByUID>`], \
-        :py:class:`BaseBounds <taurus.entity.bounds.base_bounds.BaseBounds>`]
-            A dictionary from attributes to the bounds on that attribute.
-            Currently only real and integer bounds are supported.
-            Each attribute may be represented as an AttributeTemplate (PropertyTemplate,
-            ParameterTemplate, or ConditionTemplate) or as a LinkByUID,
-            but in either case there must be a uid and it must correspond to an
-            AttributeTemplate that exists in the database.
-            Only the uid is passed, so if you would like to update an attribute template you
-            must register that change to the database before you can use it to filter.
-        page: Optional[int]
-            The page of results to list, 1-indexed (i.e. the first page is page=1)
-        per_page: Optional[int]
-            The number of results to list per page
-
-        Returns
-        -------
-        List[DataConcepts]
-            List of all objects in this collection that both have the specified attribute
-            and have values within the specified bounds.
-
-        """
-        body = self._get_attribute_bounds_search_body(attribute_bounds)
-        params = {}
-        if self.dataset_id is not None:
-            params['dataset_id'] = str(self.dataset_id)
-        if page is not None:
-            params['page'] = page
-        if per_page is not None:
-            params['per_page'] = per_page
-
-        response = self.session.post_resource(
-            self._get_path(ignore_dataset=True) + "/filter-by-attribute-bounds",
-            json=body, params=params)
-        return [self.build(content) for content in response["contents"]]
-
     def filter_by_name(self, name: str, exact: bool = False,
                        page: Optional[int] = None, per_page: Optional[int] = None):
         """
@@ -511,58 +460,6 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
             self.session.get_resource,
             # "Ignoring" dataset because it is in the query params (and required)
             self._get_path(ignore_dataset=True) + "/filter-by-name",
-            forward=forward,
-            per_page=per_page,
-            params=params)
-        return (self.build(raw) for raw in raw_objects)
-
-    def list_by_attribute_bounds(
-            self,
-            attribute_bounds: Dict[Union[AttributeTemplate, LinkByUID], BaseBounds],
-            forward: bool = True, per_page: int = 100) -> Iterator[DataConcepts]:
-        """
-        Get all objects in the collection with attributes within certain bounds.
-
-        Results are ordered first by dataset, then by attribute value.
-
-        Currently only one attribute and one bounds on that attribute is supported, and
-        attribute type must be numeric.
-
-        Parameters
-        ----------
-        attribute_bounds: Dict[Union[AttributeTemplate, \
-        :py:class:`LinkByUID <taurus.entity.link_by_uid.LinkByUID>`], \
-        :py:class:`BaseBounds <taurus.entity.bounds.base_bounds.BaseBounds>`]
-            A dictionary from attributes to the bounds on that attribute.
-            Currently only real and integer bounds are supported.
-            Each attribute may be represented as an AttributeTemplate (PropertyTemplate,
-            ParameterTemplate, or ConditionTemplate) or as a LinkByUID,
-            but in either case there must be a uid and it must correspond to an
-            AttributeTemplate that exists in the database.
-            Only the uid is passed, so if you would like to update an attribute template you
-            must register that change to the database before you can use it to filter.
-        forward: bool
-            Set to False to reverse the order of results (i.e. return in descending order).
-        per_page: int
-            Controls the number of results fetched with each http request to the backend.
-            Typically, this is set to a sensible default and should not be modified. Consider
-            modifying this value only if you find this method is unacceptably latent.
-
-        Returns
-        -------
-        Iterator[DataConcepts]
-            List of every object in this collection whose `name` matches the search term.
-
-        """
-        body = self._get_attribute_bounds_search_body(attribute_bounds)
-        params = {}
-        if self.dataset_id is not None:
-            params['dataset_id'] = str(self.dataset_id)
-        raw_objects = self.session.cursor_paged_resource(
-            self.session.post_resource,
-            # "Ignoring" dataset because it is in the query params (and required)
-            self._get_path(ignore_dataset=True) + "/filter-by-attribute-bounds",
-            json=body,
             forward=forward,
             per_page=per_page,
             params=params)
@@ -656,19 +553,3 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         params = {'dry_run': dry_run}
         self.session.delete_resource(path, params=params)
         return Response(status_code=200)  # delete succeeded
-
-    @staticmethod
-    def _get_attribute_bounds_search_body(attribute_bounds):
-        if not isinstance(attribute_bounds, dict):
-            raise TypeError('attribute_bounds must be a dict mapping template to bounds; '
-                            'got {}'.format(attribute_bounds))
-        if len(attribute_bounds) != 1:
-            raise NotImplementedError('Currently, only searches with exactly one template '
-                                      'to bounds mapping are supported; got {}'
-                                      .format(attribute_bounds))
-        return {
-            'attribute_bounds': {
-                get_object_id(templ): bounds.as_dict()
-                for templ, bounds in attribute_bounds.items()
-            }
-        }

--- a/src/citrine/resources/data_objects.py
+++ b/src/citrine/resources/data_objects.py
@@ -1,7 +1,12 @@
 """Top-level class for all data object (i.e. spec and run) objects and collections thereof."""
 from abc import ABC
+from typing import Dict, Union, Optional, Iterator, List, TypeVar
 
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection, ResourceType
+from citrine._utils.functions import get_object_id
+from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from taurus.entity.bounds.base_bounds import BaseBounds
+from taurus.entity.link_by_uid import LinkByUID
+from taurus.entity.template.attribute_template import AttributeTemplate
 
 
 class DataObject(DataConcepts, ABC):
@@ -12,5 +17,124 @@ class DataObject(DataConcepts, ABC):
     """
 
 
-class DataObjectCollection(DataConceptsCollection[ResourceType], ABC):
+DataObjectResourceType = TypeVar("DataObjectResourceType", bound="DataObject")
+
+
+class DataObjectCollection(DataConceptsCollection[DataObjectResourceType], ABC):
     """A collection of one kind of data object object."""
+
+    def filter_by_attribute_bounds(
+            self,
+            attribute_bounds: Dict[Union[AttributeTemplate, LinkByUID], BaseBounds],
+            page: Optional[int] = None, per_page: Optional[int] = None) -> List[DataObject]:
+        """
+        Get all objects in the collection with attributes within certain bounds.
+
+        Currently only one attribute and one bounds on that attribute is supported.
+
+        Parameters
+        ----------
+        attribute_bounds: Dict[Union[AttributeTemplate, \
+        :py:class:`LinkByUID <taurus.entity.link_by_uid.LinkByUID>`], \
+        :py:class:`BaseBounds <taurus.entity.bounds.base_bounds.BaseBounds>`]
+            A dictionary from attributes to the bounds on that attribute.
+            Currently only real and integer bounds are supported.
+            Each attribute may be represented as an AttributeTemplate (PropertyTemplate,
+            ParameterTemplate, or ConditionTemplate) or as a LinkByUID,
+            but in either case there must be a uid and it must correspond to an
+            AttributeTemplate that exists in the database.
+            Only the uid is passed, so if you would like to update an attribute template you
+            must register that change to the database before you can use it to filter.
+        page: Optional[int]
+            The page of results to list, 1-indexed (i.e. the first page is page=1)
+        per_page: Optional[int]
+            The number of results to list per page
+
+        Returns
+        -------
+        List[DataObject]
+            List of all objects in this collection that both have the specified attribute
+            and have values within the specified bounds.
+
+        """
+        body = self._get_attribute_bounds_search_body(attribute_bounds)
+        params = {}
+        if self.dataset_id is not None:
+            params['dataset_id'] = str(self.dataset_id)
+        if page is not None:
+            params['page'] = page
+        if per_page is not None:
+            params['per_page'] = per_page
+
+        response = self.session.post_resource(
+            self._get_path(ignore_dataset=True) + "/filter-by-attribute-bounds",
+            json=body, params=params)
+        return [self.build(content) for content in response["contents"]]
+
+    def list_by_attribute_bounds(
+            self,
+            attribute_bounds: Dict[Union[AttributeTemplate, LinkByUID], BaseBounds],
+            forward: bool = True, per_page: int = 100) -> Iterator[DataObject]:
+        """
+        Get all objects in the collection with attributes within certain bounds.
+
+        Results are ordered first by dataset, then by attribute value.
+
+        Currently only one attribute and one bounds on that attribute is supported, and
+        attribute type must be numeric.
+
+        Parameters
+        ----------
+        attribute_bounds: Dict[Union[AttributeTemplate, \
+        :py:class:`LinkByUID <taurus.entity.link_by_uid.LinkByUID>`], \
+        :py:class:`BaseBounds <taurus.entity.bounds.base_bounds.BaseBounds>`]
+            A dictionary from attributes to the bounds on that attribute.
+            Currently only real and integer bounds are supported.
+            Each attribute may be represented as an AttributeTemplate (PropertyTemplate,
+            ParameterTemplate, or ConditionTemplate) or as a LinkByUID,
+            but in either case there must be a uid and it must correspond to an
+            AttributeTemplate that exists in the database.
+            Only the uid is passed, so if you would like to update an attribute template you
+            must register that change to the database before you can use it to filter.
+        forward: bool
+            Set to False to reverse the order of results (i.e. return in descending order).
+        per_page: int
+            Controls the number of results fetched with each http request to the backend.
+            Typically, this is set to a sensible default and should not be modified. Consider
+            modifying this value only if you find this method is unacceptably latent.
+
+        Returns
+        -------
+        Iterator[DataObject]
+            List of every object in this collection whose `name` matches the search term.
+
+        """
+        body = self._get_attribute_bounds_search_body(attribute_bounds)
+        params = {}
+        if self.dataset_id is not None:
+            params['dataset_id'] = str(self.dataset_id)
+        raw_objects = self.session.cursor_paged_resource(
+            self.session.post_resource,
+            # "Ignoring" dataset because it is in the query params (and required)
+            self._get_path(ignore_dataset=True) + "/filter-by-attribute-bounds",
+            json=body,
+            forward=forward,
+            per_page=per_page,
+            params=params)
+        return (self.build(raw) for raw in raw_objects)
+
+    @staticmethod
+    def _get_attribute_bounds_search_body(attribute_bounds):
+        if not isinstance(attribute_bounds, dict):
+            raise TypeError('attribute_bounds must be a dict mapping template to bounds; '
+                            'got {}'.format(attribute_bounds))
+        if len(attribute_bounds) != 1:
+            raise NotImplementedError('Currently, only searches with exactly one template '
+                                      'to bounds mapping are supported; got {}'
+                                      .format(attribute_bounds))
+        return {
+            'attribute_bounds': {
+                get_object_id(templ): bounds.as_dict()
+                for templ, bounds in attribute_bounds.items()
+            }
+        }

--- a/src/citrine/resources/object_runs.py
+++ b/src/citrine/resources/object_runs.py
@@ -1,7 +1,7 @@
 """Top-level class for all object run objects and collections thereof."""
 from abc import ABC
+from typing import TypeVar
 
-from citrine.resources.data_concepts import ResourceType
 from citrine.resources.data_objects import DataObject, DataObjectCollection
 
 
@@ -13,5 +13,8 @@ class ObjectRun(DataObject, ABC):
     """
 
 
-class ObjectRunCollection(DataObjectCollection[ResourceType], ABC):
+ObjectRunResourceType = TypeVar("ObjectRunResourceType", bound="ObjectRun")
+
+
+class ObjectRunCollection(DataObjectCollection[ObjectRunResourceType], ABC):
     """A collection of one kind of object run object."""

--- a/src/citrine/resources/object_specs.py
+++ b/src/citrine/resources/object_specs.py
@@ -1,7 +1,7 @@
 """Top-level class for all object spec objects and collections thereof."""
 from abc import ABC
+from typing import TypeVar
 
-from citrine.resources.data_concepts import ResourceType
 from citrine.resources.data_objects import DataObject, DataObjectCollection
 
 
@@ -13,5 +13,8 @@ class ObjectSpec(DataObject, ABC):
     """
 
 
-class ObjectSpecCollection(DataObjectCollection[ResourceType], ABC):
+ObjectSpecResourceType = TypeVar("ObjectSpecResourceType", bound="ObjectSpec")
+
+
+class ObjectSpecCollection(DataObjectCollection[ObjectSpecResourceType], ABC):
     """A collection of one kind of object spec object."""

--- a/src/citrine/resources/object_templates.py
+++ b/src/citrine/resources/object_templates.py
@@ -1,7 +1,7 @@
 """Top-level class for all object template objects and collections thereof."""
 from abc import ABC
+from typing import TypeVar
 
-from citrine.resources.data_concepts import ResourceType
 from citrine.resources.templates import Template, TemplateCollection
 
 
@@ -13,5 +13,8 @@ class ObjectTemplate(Template, ABC):
     """
 
 
-class ObjectTemplateCollection(TemplateCollection[ResourceType], ABC):
+ObjectTemplateResourceType = TypeVar("ObjectTemplateResourceType", bound="ObjectTemplate")
+
+
+class ObjectTemplateCollection(TemplateCollection[ObjectTemplateResourceType], ABC):
     """A collection of one kind of object template object."""

--- a/src/citrine/resources/templates.py
+++ b/src/citrine/resources/templates.py
@@ -1,7 +1,8 @@
 """Top-level class for all template objects and collections thereof."""
 from abc import ABC
+from typing import TypeVar
 
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection, ResourceType
+from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
 
 
 class Template(DataConcepts, ABC):
@@ -12,5 +13,8 @@ class Template(DataConcepts, ABC):
     """
 
 
-class TemplateCollection(DataConceptsCollection[ResourceType], ABC):
+TemplateResourceType = TypeVar("TemplateResourceType", bound="Template")
+
+
+class TemplateCollection(DataConceptsCollection[TemplateResourceType], ABC):
     """A collection of one kind of template object."""


### PR DESCRIPTION
# Citrine Python PR

## Description 
On the backend, filtering/listing by attribute bounds is not available for object templates, so moving the methods that hit the backend to reflect that. Also fixing types

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
