### PR TITLE
Add dataset to data concepts classes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.11.0',
+      version='0.12.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from citrine._rest.collection import Collection
 from citrine._serialization import properties
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
-from citrine._serialization.properties import Property
+from citrine._serialization.properties import Property as SerializableProperty
 from citrine._serialization.serializable import Serializable
 from citrine._session import Session
 from citrine._utils.functions import scrub_none, replace_objects_with_links
@@ -103,7 +103,7 @@ class DataConcepts(PolymorphicSerializable['DataConcepts'], DictSerializable, AB
                     raise TypeError(
                         "{} must be a dictionary or None but was {}".format(field, value))
                 deserialized = clazz.build(value)
-            elif issubclass(clazz, Property):
+            elif issubclass(clazz, SerializableProperty):
                 # deserialize handles type checking already
                 deserialized = clazz(clazz).deserialize(value)
             else:

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -97,13 +97,13 @@ class DataConcepts(PolymorphicSerializable['DataConcepts'], DictSerializable, AB
             if value is None:
                 deserialized = None
             elif issubclass(clazz, DictSerializable):
-                deserialized = clazz.build(value)
                 if not isinstance(value, dict):
                     raise TypeError("{} must be a dictionary or None but was {}".format(field, value))
+                deserialized = clazz.build(value)
             elif clazz == UUID:
-                deserialized = UUID(value)
                 if not isinstance(value, str):
                     raise TypeError("{} must be a string or None but was {}".format(field, value))
+                deserialized = UUID(value)
             else:
                 raise NotImplementedError("No deserialization strategy reported for client "
                                           "field type {} for field.".format(clazz, field))

--- a/tests/serialization/test_data_concepts.py
+++ b/tests/serialization/test_data_concepts.py
@@ -1,0 +1,16 @@
+import pytest
+
+from citrine._rest.resource import Resource
+from taurus.entity.object.process_spec import ProcessSpec
+
+from citrine.resources.object_specs import ObjectSpec
+
+
+def test_invalid_client_field():
+    """Ensure we get a NotImplementedError as a result of defining a class with unsupported client fields."""
+    class BadProcessSpec(ObjectSpec, Resource['ProcessSpec'], ProcessSpec):
+        client_specific_fields = {
+            'foo': int,
+        }
+    with pytest.raises(NotImplementedError):
+        BadProcessSpec.from_dict({'name': 'Mr. Foo', 'typ': 'process_spec', 'foo': 1})

--- a/tests/serialization/test_measurement_run.py
+++ b/tests/serialization/test_measurement_run.py
@@ -1,6 +1,6 @@
 """Tests of the Measurement Run schema"""
 import pytest
-from uuid import uuid4
+from uuid import uuid4, UUID
 
 from taurus.entity.attribute.property import Property
 from taurus.entity.value.nominal_integer import NominalInteger
@@ -39,7 +39,8 @@ def valid_data():
             'audit_info': {
                 'created_by': str(uuid4()), 'created_at': 1559933807392,
                 'updated_by': str(uuid4()), 'updated_at': 1560033807392
-            }
+            },
+            'dataset': str(uuid4()),
         },
         spec=None,
         file_links=[],
@@ -49,7 +50,8 @@ def valid_data():
             "performed_by": "Marie Curie",
             "performed_date": "1898-07-01"
         },
-        audit_info={'created_by': str(uuid4()), 'created_at': 1560133807392}
+        audit_info={'created_by': str(uuid4()), 'created_at': 1560133807392},
+        dataset=str(uuid4()),
     )
 
 
@@ -72,9 +74,11 @@ def test_simple_deserialization(valid_data):
                                                    uids={'id': valid_data['material']['uids']['id']},
                                                    sample_type='experimental')
     assert measurement_run.material.audit_info == AuditInfo(**valid_data['material']['audit_info'])
+    assert measurement_run.material.dataset == UUID(valid_data['material']['dataset'])
     assert measurement_run.spec is None
     assert measurement_run.typ == 'measurement_run'
     assert measurement_run.audit_info == AuditInfo(**valid_data['audit_info'])
+    assert measurement_run.dataset == UUID(valid_data['dataset'])
 
 
 def test_serialization(valid_data):
@@ -82,7 +86,9 @@ def test_serialization(valid_data):
     measurement_run: MeasurementRun = MeasurementRun.build(valid_data)
     serialized = measurement_run.dump()
     valid_data['material'].pop('audit_info')
+    valid_data['material'].pop('dataset')
     valid_data.pop('audit_info')
+    valid_data.pop('dataset')
     assert serialized == valid_data
 
 


### PR DESCRIPTION
# Citrine Python PR

## Description 
Readies client for new `dataset` field which will appear on all data concepts classes, if they were created from the backend's response.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
