### PR TITLE
Add seeding utility for sorting templating from data objects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.14.0',
+      version='0.15.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/src/citrine/seeding/sort_gems.py
+++ b/src/citrine/seeding/sort_gems.py
@@ -2,7 +2,7 @@ from taurus.entity.template.attribute_template import AttributeTemplate
 from taurus.entity.template.base_template import BaseTemplate
 
 
-def sort_templates_from_objects(gems):
+def split_templates_from_objects(gems):
     """
     Sort the provided gems into two lists.
 
@@ -11,6 +11,9 @@ def sort_templates_from_objects(gems):
 
     Useful when the procedure for seeding templates needs to be distinct from the procedure for
     seeding data objects.
+
+    Note that each list is unsorted and it is expected that subsequent registration code will
+    handle sorting the gems provided.
     """
     templates = []
     data_objects = []

--- a/src/citrine/seeding/sort_gems.py
+++ b/src/citrine/seeding/sort_gems.py
@@ -1,0 +1,22 @@
+from taurus.entity.template.attribute_template import AttributeTemplate
+from taurus.entity.template.base_template import BaseTemplate
+
+
+def sort_templates_from_objects(gems):
+    """
+    Sort the provided gems into two lists.
+
+    The first list contains only templates (both ObjectTemplate and AttributeTemplate).
+    The second list contains only data objects (specs and runs).
+
+    Useful when the procedure for seeding templates needs to be distinct from the procedure for
+    seeding data objects.
+    """
+    templates = []
+    data_objects = []
+    for gem in gems:
+        if isinstance(gem, AttributeTemplate) or isinstance(gem, BaseTemplate):
+            templates.append(gem)
+        else:
+            data_objects.append(gem)
+    return templates, data_objects

--- a/tests/seeding/test_sort_gems.py
+++ b/tests/seeding/test_sort_gems.py
@@ -2,19 +2,19 @@ from citrine.resources.condition_template import ConditionTemplate
 from citrine.resources.measurement_spec import MeasurementSpec
 from citrine.resources.process_spec import ProcessSpec
 from citrine.resources.property_template import PropertyTemplate
-from citrine.seeding.sort_gems import sort_templates_from_objects
+from citrine.seeding.sort_gems import split_templates_from_objects
 from taurus.entity.bounds.categorical_bounds import CategoricalBounds
 
 
 def test_no_templates():
     objs = [ProcessSpec("ps"), MeasurementSpec("ms")]
-    templates, data_objects = sort_templates_from_objects(objs)
+    templates, data_objects = split_templates_from_objects(objs)
     assert len(templates) == 0
     assert len(data_objects) == 2
 
 def test_no_data_objects():
     objs = [PropertyTemplate("pt", CategoricalBounds()), ConditionTemplate("ct", CategoricalBounds())]
-    templates, data_objects = sort_templates_from_objects(objs)
+    templates, data_objects = split_templates_from_objects(objs)
     assert len(templates) == 2
     assert len(data_objects) == 0
 
@@ -23,6 +23,6 @@ def test_both_present():
             PropertyTemplate("pt", CategoricalBounds()),
             MeasurementSpec("ms"),
             ConditionTemplate("ct", CategoricalBounds())]
-    templates, data_objects = sort_templates_from_objects(objs)
+    templates, data_objects = split_templates_from_objects(objs)
     assert len(templates) == 2
     assert len(data_objects) == 2

--- a/tests/seeding/test_sort_gems.py
+++ b/tests/seeding/test_sort_gems.py
@@ -1,0 +1,28 @@
+from citrine.resources.condition_template import ConditionTemplate
+from citrine.resources.measurement_spec import MeasurementSpec
+from citrine.resources.process_spec import ProcessSpec
+from citrine.resources.property_template import PropertyTemplate
+from citrine.seeding.sort_gems import sort_templates_from_objects
+from taurus.entity.bounds.categorical_bounds import CategoricalBounds
+
+
+def test_no_templates():
+    objs = [ProcessSpec("ps"), MeasurementSpec("ms")]
+    templates, data_objects = sort_templates_from_objects(objs)
+    assert len(templates) == 0
+    assert len(data_objects) == 2
+
+def test_no_data_objects():
+    objs = [PropertyTemplate("pt", CategoricalBounds()), ConditionTemplate("ct", CategoricalBounds())]
+    templates, data_objects = sort_templates_from_objects(objs)
+    assert len(templates) == 2
+    assert len(data_objects) == 0
+
+def test_both_present():
+    objs = [ProcessSpec("ps"),
+            PropertyTemplate("pt", CategoricalBounds()),
+            MeasurementSpec("ms"),
+            ConditionTemplate("ct", CategoricalBounds())]
+    templates, data_objects = sort_templates_from_objects(objs)
+    assert len(templates) == 2
+    assert len(data_objects) == 2


### PR DESCRIPTION
# Citrine Python PR

## Description 
Add seeding utility for sorting templating from data objects. Useful when seeding needs to be different for templates vs data objects

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
