### PR TITLE
Pla 3725/rename inorganic chemical descriptor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.15.4',
+      version='0.15.5',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.16.0',
+      version='0.15.4',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.15.1',
+      version='0.16.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -21,7 +21,7 @@ class Descriptor(PolymorphicSerializable['Descriptor']):
         return {
             "Real": RealDescriptor,
             "Inorganic": ChemicalFormulaDescriptor,
-            "Categorical": CategoricalDescriptor
+            "Categorical": CategoricalDescriptor,
             "Organic": MolecularStructureDescriptor,
         }[data["type"]]
 
@@ -96,7 +96,7 @@ class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descr
 
 
 def InorganicDescriptor(key: str, threshold: Optional[float] = 1.0):
-    """[DEPRECATED] Use ChemicalFormulaDescriptor instead"""
+    """[DEPRECATED] Use ChemicalFormulaDescriptor instead."""
     logger.warning("InorganicDescriptor is deprecated and will soon be removed. "
                    "Use ChemicalFormulaDescriptor instead.")
     return ChemicalFormulaDescriptor(key)

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -1,12 +1,9 @@
 """Tools for working with Descriptors."""
 from typing import Type, Optional, List  # noqa: F401
-from logging import getLogger
 
 from citrine._serialization.serializable import Serializable
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
 from citrine._serialization import properties
-
-logger = getLogger(__name__)
 
 
 class Descriptor(PolymorphicSerializable['Descriptor']):
@@ -97,8 +94,9 @@ class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descr
 
 def InorganicDescriptor(key: str, threshold: Optional[float] = 1.0):
     """[DEPRECATED] Use ChemicalFormulaDescriptor instead."""
-    logger.warning("InorganicDescriptor is deprecated and will soon be removed. "
-                   "Use ChemicalFormulaDescriptor instead.")
+    from warnings import warn
+    warn("InorganicDescriptor is deprecated and will soon be removed. "
+         "Use ChemicalFormulaDescriptor instead.", DeprecationWarning)
     return ChemicalFormulaDescriptor(key)
 
 

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -75,7 +75,7 @@ class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descr
 
     key = properties.String('descriptor_key')
     # `threshold` exists in the backend but is not configurable through this client. It is fixed
-    # to 1.0 which means that chemical formula string parsing is strict with respect to typos.
+    # to 1.0 which means that chemical formula string parsing is strict with regards to typos.
     threshold = properties.Float('threshold', deserializable=False, default=1.0)
     typ = properties.String('type', default='Inorganic', deserializable=False)
 

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -18,7 +18,7 @@ class Descriptor(PolymorphicSerializable['Descriptor']):
         """Return the subtype."""
         return {
             "Real": RealDescriptor,
-            "Inorganic": InorganicDescriptor,
+            "Inorganic": ChemicalFormulaDescriptor,
             "Categorical": CategoricalDescriptor
         }[data["type"]]
 
@@ -63,7 +63,7 @@ class RealDescriptor(Serializable['RealDescriptor'], Descriptor):
         self.units: Optional[str] = units
 
 
-class InorganicDescriptor(Serializable['InorganicDescriptor'], Descriptor):
+class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descriptor):
     """[ALPHA] Captures domain-specific context about the chemical formula for an inorganic compound.
 
     Parameters

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -1,9 +1,12 @@
 """Tools for working with Descriptors."""
 from typing import Type, Optional, List  # noqa: F401
+from logging import getLogger
 
 from citrine._serialization.serializable import Serializable
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
 from citrine._serialization import properties
+
+logger = getLogger(__name__)
 
 
 class Descriptor(PolymorphicSerializable['Descriptor']):
@@ -90,6 +93,13 @@ class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descr
 
     def __init__(self, key: str):
         self.key: str = key
+
+
+def InorganicDescriptor(key: str, threshold: Optional[float] = 1.0):
+    """[DEPRECATED] Use ChemicalFormulaDescriptor instead"""
+    logger.warning("InorganicDescriptor is deprecated and will soon be removed. "
+                   "Use ChemicalFormulaDescriptor instead.")
+    return ChemicalFormulaDescriptor(key)
 
 
 class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -64,20 +64,16 @@ class RealDescriptor(Serializable['RealDescriptor'], Descriptor):
 
 
 class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descriptor):
-    """[ALPHA] Captures domain-specific context about the chemical formula for an inorganic compound.
+    """[ALPHA] Captures domain-specific context about a stoichiometric chemical formula.
 
     Parameters
     ----------
     key: str
         the key corresponding to a descriptor
-    threshold: float
-        the threshold for valid chemical formulae. Users can think of this as a level of tolerance
-        for typos and/or loss in interpreting a string input as a parseable chemical formula.
 
     """
 
     key = properties.String('descriptor_key')
-    threshold = properties.Float('threshold')
     typ = properties.String('type', default='Inorganic', deserializable=False)
 
     def __eq__(self, other):
@@ -89,9 +85,8 @@ class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descr
         except Exception:
             return False
 
-    def __init__(self, key: str, threshold: float = 1.0):
+    def __init__(self, key: str):
         self.key: str = key
-        self.threshold = threshold
 
 
 class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -74,6 +74,9 @@ class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descr
     """
 
     key = properties.String('descriptor_key')
+    # `threshold` exists in the backend but is not configurable through this client. It is fixed
+    # to 1.0 which means that chemical formula string parsing is strict with respect to typos.
+    threshold = properties.Float('threshold', deserializable=False, default=1.0)
     typ = properties.String('type', default='Inorganic', deserializable=False)
 
     def __eq__(self, other):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,11 +73,16 @@ def valid_enumerated_design_space_data():
                     type='Categorical',
                     descriptor_key='color',
                     descriptor_values=['red', 'green', 'blue'],
+                ),
+                dict(
+                    type='Inorganic',
+                    descriptor_key='formula',
+                    threshold=1.0
                 )
             ],
             data=[
-                dict(x=1, color='red'),
-                dict(x=2.0, color='green')
+                dict(x=1, color='red', formula='C44H54Si2'),
+                dict(x=2.0, color='green', formula='V2O3')
             ]
         )
     )

--- a/tests/informatics/test_descriptors.py
+++ b/tests/informatics/test_descriptors.py
@@ -1,12 +1,12 @@
 """Tests for citrine.informatics.descriptors."""
 import pytest
 
-from citrine.informatics.descriptors import RealDescriptor, Descriptor, InorganicDescriptor, CategoricalDescriptor
+from citrine.informatics.descriptors import RealDescriptor, Descriptor, ChemicalFormulaDescriptor, CategoricalDescriptor
 
 
 @pytest.fixture(params=[
     RealDescriptor('alpha', 0, 100),
-    InorganicDescriptor('formula'),
+    ChemicalFormulaDescriptor('formula'),
     CategoricalDescriptor("my categorical", ["a", "b"]),
     CategoricalDescriptor("categorical", ["*"])
 ])

--- a/tests/informatics/test_descriptors.py
+++ b/tests/informatics/test_descriptors.py
@@ -2,6 +2,7 @@
 import pytest
 
 from citrine.informatics.descriptors import RealDescriptor, Descriptor, ChemicalFormulaDescriptor, CategoricalDescriptor
+from citrine.informatics.descriptors import InorganicDescriptor
 
 
 @pytest.fixture(params=[
@@ -24,3 +25,8 @@ def test_deser_from_parent(descriptor):
 def test_invalid_eq(descriptor):
     other = None
     assert not descriptor == other
+
+
+def test_inorganic_deprecated():
+    old_descriptor = InorganicDescriptor("formula")
+    assert isinstance(old_descriptor, ChemicalFormulaDescriptor)

--- a/tests/serialization/test_design_spaces.py
+++ b/tests/serialization/test_design_spaces.py
@@ -1,5 +1,5 @@
 """Tests for citrine.informatics.design_spaces serialization."""
-from citrine.informatics.descriptors import CategoricalDescriptor, RealDescriptor
+from citrine.informatics.descriptors import CategoricalDescriptor, RealDescriptor, ChemicalFormulaDescriptor
 from citrine.informatics.design_spaces import DesignSpace, ProductDesignSpace, EnumeratedDesignSpace
 from citrine.informatics.dimensions import ContinuousDimension, EnumeratedDimension
 
@@ -39,53 +39,35 @@ def test_product_serialization(valid_product_design_space_data):
 
 
 def test_simple_enumerated_deserialization(valid_enumerated_design_space_data):
-    """Ensure that a deserialized EnumeratedDesignSpace looks sane."""
-    design_space: EnumeratedDesignSpace = EnumeratedDesignSpace.build(valid_enumerated_design_space_data)
-    assert design_space.name == 'my enumerated design space'
-    assert design_space.description == 'enumerates some things'
+    """Ensure that a deserialized EnumeratedDesignSpace looks sane.
+    Deserialization is done both directly (using EnumeratedDesignSpace)
+    and polymorphically (using DesignSpace)
+    """
+    for clazz in [DesignSpace, EnumeratedDesignSpace]:
+        design_space: EnumeratedDesignSpace = clazz.build(valid_enumerated_design_space_data)
+        assert design_space.name == 'my enumerated design space'
+        assert design_space.description == 'enumerates some things'
 
-    assert len(design_space.descriptors) == 2
+        assert len(design_space.descriptors) == 3
 
-    real, categorical = design_space.descriptors
+        real, categorical, formula = design_space.descriptors
 
-    assert type(real) == RealDescriptor
-    assert real.key == 'x'
-    assert real.units == ''
-    assert real.lower_bound == 1.0
-    assert real.upper_bound == 2.0
+        assert type(real) == RealDescriptor
+        assert real.key == 'x'
+        assert real.units == ''
+        assert real.lower_bound == 1.0
+        assert real.upper_bound == 2.0
 
-    assert type(categorical) == CategoricalDescriptor
-    assert categorical.key == 'color'
-    assert categorical.categories == ['red', 'green', 'blue']
+        assert type(categorical) == CategoricalDescriptor
+        assert categorical.key == 'color'
+        assert categorical.categories == ['red', 'green', 'blue']
 
-    assert len(design_space.data) == 2
-    assert design_space.data[0] == {'x': 1.0, 'color': 'red'}
-    assert design_space.data[1] == {'x': 2.0, 'color': 'green'}
+        assert type(formula) == ChemicalFormulaDescriptor
+        assert formula.key == 'formula'
 
-
-def test_polymorphic_enumerated_deserialization(valid_enumerated_design_space_data):
-    """Ensure that a polymorphically deserialized EnumeratedDesignSpace looks sane."""
-    design_space: EnumeratedDesignSpace = DesignSpace.build(valid_enumerated_design_space_data)
-    assert design_space.name == 'my enumerated design space'
-    assert design_space.description == 'enumerates some things'
-
-    assert len(design_space.descriptors) == 2
-
-    real, categorical = design_space.descriptors
-
-    assert type(real) == RealDescriptor
-    assert real.key == 'x'
-    assert real.units == ''
-    assert real.lower_bound == 1.0
-    assert real.upper_bound == 2.0
-
-    assert type(categorical) == CategoricalDescriptor
-    assert categorical.key == 'color'
-    assert categorical.categories == ['red', 'green', 'blue']
-
-    assert len(design_space.data) == 2
-    assert design_space.data[0] == {'x': 1.0, 'color': 'red'}
-    assert design_space.data[1] == {'x': 2.0, 'color': 'green'}
+        assert len(design_space.data) == 2
+        assert design_space.data[0] == {'x': 1.0, 'color': 'red', 'formula': 'C44H54Si2'}
+        assert design_space.data[1] == {'x': 2.0, 'color': 'green', 'formula': 'V2O3'}
 
 
 def test_enumerated_serialization(valid_enumerated_design_space_data):

--- a/tests/serialization/test_design_spaces.py
+++ b/tests/serialization/test_design_spaces.py
@@ -43,8 +43,8 @@ def test_simple_enumerated_deserialization(valid_enumerated_design_space_data):
     Deserialization is done both directly (using EnumeratedDesignSpace)
     and polymorphically (using DesignSpace)
     """
-    for clazz in [DesignSpace, EnumeratedDesignSpace]:
-        design_space: EnumeratedDesignSpace = clazz.build(valid_enumerated_design_space_data)
+    for designSpaceClass in [DesignSpace, EnumeratedDesignSpace]:
+        design_space: EnumeratedDesignSpace = designSpaceClass.build(valid_enumerated_design_space_data)
         assert design_space.name == 'my enumerated design space'
         assert design_space.description == 'enumerates some things'
 


### PR DESCRIPTION
# Citrine Python PR

## Description 
Renames InorganicDescriptor to ChemicalFormulaDescriptor and removes the `threshold` argument from the constructor. The backend implementation still has a threshold parameter so we need to take it into account during serde, but it's less exposed to the user now.

If a user tries to create an `InorganicDescriptor` they will instead get a `ChemicalFormulaDescriptor` and they will see a deprecation warning.

Corresponding changes to nextgen-devkit (merged): https://github.com/CitrineInformatics/nextgen-devkit/pull/414/files#diff-b9e1cad38f41a2a025680df6f77d2aacR6-R9

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [X] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
