### PR TITLE
Feature/pla 3702 list tables for ara defn version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.15.2',
+      version='0.15.3',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
-from typing import Optional, Union, Generic, TypeVar, Iterable, Callable, Dict, Any
+from typing import Optional, Union, Generic, TypeVar, Iterable, Dict
 from uuid import UUID
-import warnings
 
 from citrine._rest.paginator import Paginator
 from citrine.exceptions import ModuleRegistrationFailedException, NonRetryableException

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -3,9 +3,9 @@ from typing import Optional, Union, Generic, TypeVar, Iterable, Callable, Dict, 
 from uuid import UUID
 import warnings
 
+from citrine._rest.paginator import Paginator
 from citrine.exceptions import ModuleRegistrationFailedException, NonRetryableException
 from citrine.resources.response import Response
-
 
 ResourceType = TypeVar('ResourceType', bound='Resource')
 
@@ -54,6 +54,46 @@ class Collection(Generic[ResourceType]):
         except NonRetryableException as e:
             raise ModuleRegistrationFailedException(model.__class__.__name__, e)
 
+    def list(self,
+             page: Optional[int] = None,
+             per_page: int = 100) -> Iterable[ResourceType]:
+        """
+        Paginate over the elements of the collection.
+
+        Leaving page and per_page as default values will yield all elements in the
+        collection, paginating over all available pages.
+
+        Parameters
+        ---------
+        page: int, optional
+            The "page" of results to list. Default is to read all pages and yield
+            all results.  This option is deprecated.
+        per_page: int, optional
+            Max number of results to return per page. Default is 100.  This parameter
+            is used when making requests to the backend service.  If the page parameter
+            is specified it limits the maximum number of elements in the response.
+
+        Returns
+        -------
+        Iterable[ResourceType]
+            Resources in this collection.
+        """
+
+        return Paginator().paginate(self._fetch_page, page, per_page)
+
+    def update(self, model: CreationType) -> CreationType:
+        """Update a particular element of the collection."""
+        url = self._get_path(model.uid)
+        updated = self.session.put_resource(url, model.dump())
+        data = updated[self._individual_key] if self._individual_key else updated
+        return self.build(data)
+
+    def delete(self, uid: Union[UUID, str]) -> Response:
+        """Delete a particular element of the collection."""
+        url = self._get_path(uid)
+        data = self.session.delete_resource(url)
+        return Response(body=data)
+
     def _fetch_page(self,
                     page: Optional[int] = None,
                     per_page: Optional[int] = None) -> Iterable[ResourceType]:
@@ -79,11 +119,7 @@ class Collection(Generic[ResourceType]):
         """
         path = self._get_path()
 
-        params = {}
-        if page is not None:
-            params["page"] = page
-        if per_page is not None:
-            params["per_page"] = per_page
+        params = self._page_params(page, per_page)
 
         data = self.session.get_resource(path, params=params)
         # A 'None' collection key implies response has a top-level array
@@ -103,126 +139,10 @@ class Collection(Generic[ResourceType]):
                 # properly, so we are filtering client-side.
                 pass
 
-    def list(self,
-             page: Optional[int] = None,
-             per_page: int = 100) -> Iterable[ResourceType]:
-        """
-        List all visible elements in the collection.
-
-        Leaving page and per_page as default values will yield all elements in the
-        collection, paginating over all available pages.
-
-        Parameters
-        ---------
-        page: int, optional
-            The "page" of results to list. Default is to read all pages and yield
-            all results.  This option is deprecated.
-        per_page: int, optional
-            Max number of results to return per page. Default is 100.  This parameter
-            is used when making requests to the backend service.  If the page parameter
-            is specified it limits the maximum number of elements in the response.
-
-        Returns
-        -------
-        Iterable[ResourceType]
-            Resources in this collection.
-
-        """
-
-        return self._paginate(self._fetch_page, page, per_page)
-
-    def _paginate(self,
-                  page_fetcher: Callable[[Optional[int], int], Iterable[ResourceType]],
-                  page: Optional[int] = None,
-                  per_page: int = 100) -> Iterable[ResourceType]:
-        """
-        Paginate generically over the resource type of this collection, parameterized
-        by the callable passed in. This allows us to paginate over different data suppliers.
-
-        Leaving page and per_page as default values will yield all elements in the
-        collection, paginating over all available pages.
-
-        Parameters
-        ---------
-        page: int, optional
-            The "page" of results to list. Default is to read all pages and yield
-            all results.  This option is deprecated.
-        per_page: int, optional
-            Max number of results to return per page. Default is 100.  This parameter
-            is used when making requests to the backend service.  If the page parameter
-            is specified it limits the maximum number of elements in the response.
-
-        Returns
-        -------
-        Iterable[ResourceType]
-            Resources in this collection.
-        """
-
-        if page is not None:
-            warnings.warn("The page parameter is deprecated, default is automatic pagination",
-                          DeprecationWarning)
-
-        first_unique_identifiers = None
-        page_idx = page
-
-        while True:
-            subset = page_fetcher(page_idx, per_page)
-
-            count = 0
-            for idx, element in enumerate(subset):
-
-                # escaping from infinite loops where page/per_page are not
-                # honored and are returning the same results regardless of page:
-                unique_identifiers = self._extract_unique_identifiers(element)
-                if first_unique_identifiers is not None and first_unique_identifiers == unique_identifiers:
-                    # TODO: raise an exception once the APIs that ignore pagination are fixed
-                    break
-
-                yield element
-
-                if idx == 0:
-                    first_unique_identifiers = unique_identifiers
-
-                count += 1
-
-            # If the page number is specified we exit to disable auto-paginating
-            if page is not None:
-                break
-
-            # Handle the case where we get an unexpected number of results (e.g. last page)
-            if count == 0 or count < per_page:
-                break
-
-            if page_idx is None:
-                page_idx = 2
-            else:
-                page_idx += 1
-
-    def _page_params(self, page: Optional[int], per_page: int) -> Dict[str, int]:
+    def _page_params(self, page: Optional[int], per_page: Optional[int]) -> Dict[str, int]:
         params = {}
         if page is not None:
             params["page"] = page
         if per_page is not None:
             params["per_page"] = per_page
         return params
-
-    def _extract_unique_identifiers(self, entity: ResourceType) -> Any:
-        """
-        Extract the uniquely identifying attributes from the resource type into an object we can
-        compare for equality.
-        """
-        return getattr(entity, 'uid', None)
-
-
-    def update(self, model: CreationType) -> CreationType:
-        """Update a particular element of the collection."""
-        url = self._get_path(model.uid)
-        updated = self.session.put_resource(url, model.dump())
-        data = updated[self._individual_key] if self._individual_key else updated
-        return self.build(data)
-
-    def delete(self, uid: Union[UUID, str]) -> Response:
-        """Delete a particular element of the collection."""
-        url = self._get_path(uid)
-        data = self.session.delete_resource(url)
-        return Response(body=data)

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -76,8 +76,8 @@ class Collection(Generic[ResourceType]):
         -------
         Iterable[ResourceType]
             Resources in this collection.
-        """
 
+        """
         return Paginator().paginate(self._fetch_page, page, per_page)
 
     def update(self, model: CreationType) -> CreationType:

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -22,6 +22,7 @@ class Collection(Generic[ResourceType]):
     _individual_key: str = NotImplemented
     _resource: ResourceType = NotImplemented
     _collection_key: str = 'entries'
+    _paginator: Paginator = Paginator()
 
     def _get_path(self, uid: Optional[Union[UUID, str]] = None,
                   ignore_dataset: Optional[bool] = False) -> str:
@@ -78,7 +79,7 @@ class Collection(Generic[ResourceType]):
             Resources in this collection.
 
         """
-        return Paginator().paginate(self._fetch_page, page, per_page)
+        return self._paginator.paginate(self._fetch_page, page, per_page)
 
     def update(self, model: CreationType) -> CreationType:
         """Update a particular element of the collection."""

--- a/src/citrine/_rest/paginator.py
+++ b/src/citrine/_rest/paginator.py
@@ -5,14 +5,19 @@ ResourceType = TypeVar('ResourceType')
 
 
 class Paginator(Generic[ResourceType]):
+    """
+    This generically pages over a resource, given a page_fetcher callable.
+
+    One can override this class to fine-tune the components of the objects
+    that will be extracted for comparison purposes (to avoid looping on the same items).
+    """
 
     def paginate(self,
                  page_fetcher: Callable[[Optional[int], int], Iterable[ResourceType]],
                  page: Optional[int] = None,
                  per_page: int = 100) -> Iterable[ResourceType]:
         """
-        Paginate generically over the items returned by the page fetcher, parameterized
-        by the callable passed in. This allows us to paginate over different data suppliers.
+        A generic support class to paginate requests into an iterable of a built object.
 
         Leaving page and per_page as default values will yield all elements in the
         collection, paginating over all available pages.
@@ -34,8 +39,8 @@ class Paginator(Generic[ResourceType]):
         -------
         Iterable[ResourceType]
             Resources in this collection.
-        """
 
+        """
         if page is not None:
             warnings.warn("The page parameter is deprecated, default is automatic pagination",
                           DeprecationWarning)
@@ -79,8 +84,7 @@ class Paginator(Generic[ResourceType]):
 
     def _extract_unique_identifiers(self, entity: ResourceType) -> Any:
         """
-        Extract the uniquely identifying attributes from the resource type into an object we can
-        compare for equality.
+        Extract the uniquely identifying attributes for equality comparison.
 
         If the 'uid' here isn't found, default to comparing the entire entity.
         """

--- a/src/citrine/_rest/paginator.py
+++ b/src/citrine/_rest/paginator.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import TypeVar, Generic, Callable, Optional, Iterable, Dict, Any
+from typing import TypeVar, Generic, Callable, Optional, Iterable, Any
 
 ResourceType = TypeVar('ResourceType')
 
@@ -52,7 +52,8 @@ class Paginator(Generic[ResourceType]):
                 # escaping from infinite loops where page/per_page are not
                 # honored and are returning the same results regardless of page:
                 unique_identifiers = self._extract_unique_identifiers(element)
-                if first_unique_identifiers is not None and first_unique_identifiers == unique_identifiers:
+                if first_unique_identifiers is not None and \
+                        first_unique_identifiers == unique_identifiers:
                     # TODO: raise an exception once the APIs that ignore pagination are fixed
                     break
 

--- a/src/citrine/_rest/paginator.py
+++ b/src/citrine/_rest/paginator.py
@@ -1,0 +1,86 @@
+import warnings
+from typing import TypeVar, Generic, Callable, Optional, Iterable, Dict, Any
+
+ResourceType = TypeVar('ResourceType')
+
+
+class Paginator(Generic[ResourceType]):
+
+    def paginate(self,
+                 page_fetcher: Callable[[Optional[int], int], Iterable[ResourceType]],
+                 page: Optional[int] = None,
+                 per_page: int = 100) -> Iterable[ResourceType]:
+        """
+        Paginate generically over the items returned by the page fetcher, parameterized
+        by the callable passed in. This allows us to paginate over different data suppliers.
+
+        Leaving page and per_page as default values will yield all elements in the
+        collection, paginating over all available pages.
+
+        The page fetcher returns an Iterable of subsequent items on every invocation,
+        returning an empty iterable when fetching is finished.
+
+        Parameters
+        ---------
+        page: int, optional
+            The "page" of results to list. Default is to read all pages and yield
+            all results.  This option is deprecated.
+        per_page: int, optional
+            Max number of results to return per page. Default is 100.  This parameter
+            is used when making requests to the backend service.  If the page parameter
+            is specified it limits the maximum number of elements in the response.
+
+        Returns
+        -------
+        Iterable[ResourceType]
+            Resources in this collection.
+        """
+
+        if page is not None:
+            warnings.warn("The page parameter is deprecated, default is automatic pagination",
+                          DeprecationWarning)
+
+        first_unique_identifiers = None
+        page_idx = page
+
+        while True:
+            subset = page_fetcher(page_idx, per_page)
+
+            count = 0
+            for idx, element in enumerate(subset):
+
+                # escaping from infinite loops where page/per_page are not
+                # honored and are returning the same results regardless of page:
+                unique_identifiers = self._extract_unique_identifiers(element)
+                if first_unique_identifiers is not None and first_unique_identifiers == unique_identifiers:
+                    # TODO: raise an exception once the APIs that ignore pagination are fixed
+                    break
+
+                yield element
+
+                if first_unique_identifiers is None:
+                    first_unique_identifiers = unique_identifiers
+
+                count += 1
+
+            # If the page number is specified we exit to disable auto-paginating
+            if page is not None:
+                break
+
+            # Handle the case where we get an unexpected number of results (e.g. last page)
+            if count == 0 or count < per_page:
+                break
+
+            if page_idx is None:
+                page_idx = 2
+            else:
+                page_idx += 1
+
+    def _extract_unique_identifiers(self, entity: ResourceType) -> Any:
+        """
+        Extract the uniquely identifying attributes from the resource type into an object we can
+        compare for equality.
+
+        If the 'uid' here isn't found, default to comparing the entire entity.
+        """
+        return getattr(entity, 'uid', entity)

--- a/src/citrine/_rest/paginator.py
+++ b/src/citrine/_rest/paginator.py
@@ -45,7 +45,7 @@ class Paginator(Generic[ResourceType]):
             warnings.warn("The page parameter is deprecated, default is automatic pagination",
                           DeprecationWarning)
 
-        first_unique_identifiers = None
+        first_entity = None
         page_idx = page
 
         while True:
@@ -56,16 +56,16 @@ class Paginator(Generic[ResourceType]):
 
                 # escaping from infinite loops where page/per_page are not
                 # honored and are returning the same results regardless of page:
-                unique_identifiers = self._extract_unique_identifiers(element)
-                if first_unique_identifiers is not None and \
-                        first_unique_identifiers == unique_identifiers:
+                current_entity = self._comparison_fields(element)
+                if first_entity is not None and \
+                        first_entity == current_entity:
                     # TODO: raise an exception once the APIs that ignore pagination are fixed
                     break
 
                 yield element
 
-                if first_unique_identifiers is None:
-                    first_unique_identifiers = unique_identifiers
+                if first_entity is None:
+                    first_entity = current_entity
 
                 count += 1
 
@@ -82,7 +82,7 @@ class Paginator(Generic[ResourceType]):
             else:
                 page_idx += 1
 
-    def _extract_unique_identifiers(self, entity: ResourceType) -> Any:
+    def _comparison_fields(self, entity: ResourceType) -> Any:
         """
         Extract the uniquely identifying attributes for equality comparison.
 

--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -243,7 +243,6 @@ class AraDefinitionCollection(Collection[AraDefinition]):
             the ara definition describing the new table
 
         """
-        # TODO: shouldn't this live on the AraDefinition object?
         job_id = uuid4()
         url_suffix: str = "/{ara_definition}/versions/{version_number}/build?job_id={job_id}"
         path: str = self._path_template.format(

--- a/src/citrine/resources/table.py
+++ b/src/citrine/resources/table.py
@@ -1,4 +1,4 @@
-from typing import Union, Iterable, Optional
+from typing import Union, Iterable, Optional, Any
 
 import requests
 
@@ -79,9 +79,13 @@ class TableCollection(Collection[Table]):
         def fetch_versions(page: Optional[int], per_page: int) -> Iterable[Table]:
             data = self.session.get_resource(self._get_path() + '/' + str(uid),
                                              params=self._page_params(page, per_page))
-            return [self.build(item) for item in data[self._collection_key]]
+            for item in data[self._collection_key]:
+                yield self.build(item)
 
         return self._paginate(fetch_versions, page, per_page)
+
+    def _extract_unique_identifiers(self, entity: Table) -> Any:
+        return (entity.uid, entity.version)
 
     def build(self, data: dict) -> Table:
         """Build an individual Table from a dictionary."""

--- a/src/citrine/resources/table.py
+++ b/src/citrine/resources/table.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Iterable, Optional
 
 import requests
 
@@ -70,6 +70,18 @@ class TableCollection(Collection[Table]):
         path = self._get_path(uid) + "/versions/{}".format(version)
         data = self.session.get_resource(path)
         return self.build(data)
+
+    def list_versions(self,
+                      uid: UUID,
+                      page: Optional[int] = None,
+                      per_page: int = 100) -> Iterable[Table]:
+
+        def fetch_versions(page: Optional[int], per_page: int) -> Iterable[Table]:
+            data = self.session.get_resource(self._get_path() + '/' + str(uid),
+                                             params=self._page_params(page, per_page))
+            return [self.build(item) for item in data[self._collection_key]]
+
+        return self._paginate(fetch_versions, page, per_page)
 
     def build(self, data: dict) -> Table:
         """Build an individual Table from a dictionary."""

--- a/src/citrine/resources/table.py
+++ b/src/citrine/resources/table.py
@@ -101,4 +101,3 @@ class TableCollection(Collection[Table]):
     def register(self, model: Table) -> Table:
         """Tables cannot be created at this time."""
         raise RuntimeError('Creating Tables is not supported at this time.')
-

--- a/src/citrine/resources/table.py
+++ b/src/citrine/resources/table.py
@@ -76,7 +76,17 @@ class TableCollection(Collection[Table]):
                       uid: UUID,
                       page: Optional[int] = None,
                       per_page: int = 100) -> Iterable[Table]:
+        """
+        List the versions of a table given a specific Table UID.
 
+        This is a paginated collection, similar to a .list() call.
+
+
+        :param uid: The Table UID.
+        :param page: The page number to display (eg: 1)
+        :param per_page: The number of items to fetch per-page.
+        :return: An iterable of the versions of the Tables (as Table objects).
+        """
         class TablePaginator(Paginator[Table]):
             def _extract_unique_identifiers(self, entity: Table) -> Any:
                 return (entity.uid, entity.version)

--- a/tests/resources/test_table.py
+++ b/tests/resources/test_table.py
@@ -5,7 +5,7 @@ import requests_mock
 from mock import patch, call
 
 from citrine.resources.table import TableCollection, Table
-from tests.utils.factories import TableDataFactory
+from tests.utils.factories import TableDataFactory, ListTableVersionsDataFactory
 from tests.utils.session import FakeSession, FakeCall
 
 
@@ -26,11 +26,12 @@ def collection(session) -> TableCollection:
 def table() -> Table:
     def _table(download_url: str):
         return Table.build(TableDataFactory(signed_download_url=download_url, version=2))
+
     return _table
 
 
 @patch("citrine.resources.table.write_file_locally")
-def test_read_table(mock_write_files_locally,  table):
+def test_read_table(mock_write_files_locally, table):
     # When
     with requests_mock.mock() as mock_get:
         remote_url = "http://otherhost:4572/anywhere"
@@ -48,6 +49,7 @@ def test_read_table(mock_write_files_locally,  table):
         assert mock_get.call_count == 1
         assert mock_write_files_locally.call_count == 2
         assert mock_write_files_locally.call_args == call(b'stuff', "table2.pdf")
+
 
 def test_get_table_metadata(collection, session):
     # Given
@@ -68,6 +70,33 @@ def test_get_table_metadata(collection, session):
     assert str(retrieved_table.uid) == table["id"]
     assert retrieved_table.version == table["version"]
     assert retrieved_table.download_url == table["signed_download_url"]
+
+
+def test_list_tables(collection, session):
+    # Given
+    tableVersions = ListTableVersionsDataFactory()
+    session.set_response(tableVersions)
+
+    # When
+    results = list(collection.list())
+
+    # Then
+    assert len(results) == 1
+    assert results[0].uid is not None
+
+
+def test_list_table_versions(collection, session):
+    # Given
+    tableVersions = ListTableVersionsDataFactory()
+    session.set_response(tableVersions)
+
+    # When
+    results = list(collection.list_versions(tableVersions['tables'][0]['id']))
+
+    # Then
+    assert len(results) == 1
+    assert results[0].uid is not None
+
 
 def test_init_table():
     table = Table()

--- a/tests/rest/test_paginator.py
+++ b/tests/rest/test_paginator.py
@@ -1,0 +1,45 @@
+"""Test the Paginator"""
+from mock import Mock
+
+from citrine._rest.paginator import Paginator
+
+
+def test_validate_mock_fetcher():
+    """Just ensure our mock fetcher method does the right thing for what the paginator expects"""
+    mock_fetcher = mocked_fetcher("a", "b")
+
+    # Make calls (and ignore arguments on the callable), and ensure we get back the above elements, each wrapped in a
+    # list, and the final call should be an empty list.
+    assert mock_fetcher("a", "b") == ["a"]
+    assert mock_fetcher() == ["b"]
+    assert mock_fetcher() == []
+
+
+def test_paginator_fetches_single_page():
+    # Return a single page with 2 elements
+    result = Paginator().paginate(mocked_fetcher(["a", "b"]), per_page=2)
+    assert list(result) == ["a", "b"]
+
+
+def test_pagination_across_two_pages():
+    result = Paginator().paginate(mocked_fetcher("a", "b"), per_page=1)
+    assert list(result) == ["a", "b"]
+
+
+def test_pagination_stops_when_initial_item_repeated():
+    result = Paginator().paginate(mocked_fetcher("a", "b", "a"), per_page=1)
+    assert list(result) == ["a", "b"]
+
+
+def mocked_fetcher(*args):
+    """
+    Take a list of arguments, and return them (wrapped in a list) in subsequent calls to this mock.
+    Finish with an empty list.
+
+    This lets us mock a fetcher easily.
+    """
+    mock_fetcher = Mock()
+    args_in_lists = [list(a) for a in args]
+    args_in_lists.append([])
+    mock_fetcher.side_effect = list(args_in_lists)
+    return mock_fetcher

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -39,6 +39,10 @@ class TableDataFactory(factory.DictFactory):
     signed_download_url = factory.Faker('uri')
 
 
+class ListTableVersionsDataFactory(factory.DictFactory):
+    tables = [TableDataFactory()]
+
+
 class AraDefinitionDataFactory(factory.DictFactory):
     name = factory.Faker("company")
     description = factory.Faker('bs')


### PR DESCRIPTION
# Citrine Python PR

This implements the tables.list_version(TABLE_UID) functionality.

Similar to resource.list(), this paginates transparently behind the scenes (and pulls out logic to do that on arbitrary resources easily).

This also adds some tests specific to this "Paginator" we pulled out, and fixes some issues with it (resetting the original item, pluggable strategy for uniqueness comparisons, etc).

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
