### PR TITLE
fix ScalarRangeConstraints docstring

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.15.6',
+      version='0.15.7',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/src/citrine/informatics/constraints.py
+++ b/src/citrine/informatics/constraints.py
@@ -34,9 +34,9 @@ class ScalarRangeConstraint(Serializable['ScalarRangeConstraint'], Constraint):
     ----------
     descriptor_key: str
         the key corresponding to a descriptor
-    min: int
+    min: float
         the minimum value in the range
-    max: int
+    max: float
         the maximum value in the range
     min_inclusive: bool
         if True, will include the min value in the range


### PR DESCRIPTION
Updated `min`/`max` arguments from `int` to `float` in ScalarRangeConstraint docstring.

# Citrine Python PR

## Description 
Please briefly explain the goal of the changes/this PR.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [x ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ x] I have bumped the version in setup.py
