### PR TITLE
Add ability to override s3 url for table read

### DIFF
--- a/docs/source/data_extraction.rst
+++ b/docs/source/data_extraction.rst
@@ -165,7 +165,7 @@ For example:
         table_version = status.output['display_table_version']
         # 4. Download the table
         table = project.tables.get(table_id, table_version)
-        table.read("./my_table.csv")
+        project.tables.read(table, "./my_table.csv")
 
 The return type of the ``build_ara_table`` method is a :class:`~citrine.resources.ara_job.JobSubmissionResponse` that contains a unique identifier for the submitted job.
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.15.9',
+      version='0.16.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.15.8',
+      version='0.15.9',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/src/citrine/_utils/functions.py
+++ b/src/citrine/_utils/functions.py
@@ -128,7 +128,7 @@ def object_to_link_by_uid(json: dict) -> dict:
         return json
 
 
-def rewrite_s3_links_locally(url: str) -> str:
+def rewrite_s3_links_locally(url: str, s3_endpoint_url: str = None) -> str:
     """
     Rewrites 'localstack' hosts to localhost for testing.
 
@@ -140,9 +140,16 @@ def rewrite_s3_links_locally(url: str) -> str:
     In order to access dockerized servers from outside of docker, the
     host:port space must be mapped onto localhost. For S3, this mapping is as follows:
     localstack:4572 => localhost:9572
+
+    Allows for an explicit override, useful for tests that are trying to access this endpoint
+    from within the docker context
     """
     parsed_url = urlparse(url)
-    if parsed_url.netloc != "localstack:4572":
+    if s3_endpoint_url is not None:
+        parsed_s3_endpoint = urlparse(s3_endpoint_url)
+        return parsed_url._replace(scheme=parsed_s3_endpoint.scheme,
+                                   netloc=parsed_s3_endpoint.netloc).geturl()
+    elif parsed_url.netloc != "localstack:4572":
         return url
     else:
         return parsed_url._replace(netloc="localhost:9572").geturl()

--- a/src/citrine/resources/table.py
+++ b/src/citrine/resources/table.py
@@ -46,7 +46,7 @@ class Table(Resource['Table']):
         # TODO: Change this to name once that's added to the table model
         return '<Table {!r}, version {}>'.format(self.uid, self.version)
 
-    @deprecation.deprecated(deprecated_in="0.15.9", details="Use TableCollection.read() instead")
+    @deprecation.deprecated(deprecated_in="0.16.0", details="Use TableCollection.read() instead")
     def read(self, local_path):
         """[DEPRECATED] Use TableCollection.read() instead."""  # noqa: D402
         data_location = self.download_url

--- a/src/citrine/resources/table.py
+++ b/src/citrine/resources/table.py
@@ -1,5 +1,6 @@
 from typing import Union, Iterable, Optional, Any
 
+import deprecation
 import requests
 
 from citrine._rest.collection import Collection
@@ -45,11 +46,9 @@ class Table(Resource['Table']):
         # TODO: Change this to name once that's added to the table model
         return '<Table {!r}, version {}>'.format(self.uid, self.version)
 
+    @deprecation.deprecated(deprecated_in="0.15.9", details="Use TableCollection.read() instead")
     def read(self, local_path):
-        """Read the Table file from S3."""
-        # NOTE: this uses the pre-signed S3 download url. If we need to download larger files,
-        # we have other options available (using multi-part downloads in parallel , for example).
-
+        """[DEPRECATED] Use TableCollection.read() instead."""  # noqa: D402
         data_location = self.download_url
         data_location = rewrite_s3_links_locally(data_location)
         response = requests.get(data_location)
@@ -118,3 +117,13 @@ class TableCollection(Collection[Table]):
     def register(self, model: Table) -> Table:
         """Tables cannot be created at this time."""
         raise RuntimeError('Creating Tables is not supported at this time.')
+
+    def read(self, table: Table, local_path: str):
+        """Read the Table file from S3."""
+        # NOTE: this uses the pre-signed S3 download url. If we need to download larger files,
+        # we have other options available (using multi-part downloads in parallel , for example).
+
+        data_location = table.download_url
+        data_location = rewrite_s3_links_locally(data_location, self.session.s3_endpoint_url)
+        response = requests.get(data_location)
+        write_file_locally(response.content, local_path)


### PR DESCRIPTION
# Citrine Python PR

## Description 
Add ability to override s3 url for table read. Useful for local testing inside of a docker container. Deprecates Table.read() in favor of TableCollection.read().

Fixes PLA-3806

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [x] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
