### PR TITLE
Prepare objects for store before trying to validate them

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.15.8',
+      version='0.15.9',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/src/citrine/resources/data_objects.py
+++ b/src/citrine/resources/data_objects.py
@@ -2,7 +2,7 @@
 from abc import ABC
 from typing import Dict, Union, Optional, Iterator, List, TypeVar
 
-from citrine._utils.functions import get_object_id
+from citrine._utils.functions import get_object_id, replace_objects_with_links, scrub_none
 from citrine.exceptions import BadRequest
 from citrine.resources.api_error import ValidationError
 from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
@@ -161,11 +161,14 @@ class DataObjectCollection(DataConceptsCollection[DataObjectResourceType], ABC):
         :return: List[ValidationError] of validation errors encountered. Empty if successful.
         """
         path = self._get_path(ignore_dataset=True) + "/validate-templates"
-        request_data = {"dataObject": model.dump()}
+        dumped_data = replace_objects_with_links(scrub_none(model.dump()))
+        request_data = {"dataObject": dumped_data}
         if object_template is not None:
-            request_data["objectTemplate"] = object_template.dump()
+            request_data["objectTemplate"] = \
+                replace_objects_with_links(scrub_none(object_template.dump()))
         if ingredient_process_template is not None:
-            request_data["ingredientProcessTemplate"] = ingredient_process_template.dump()
+            request_data["ingredientProcessTemplate"] = \
+                replace_objects_with_links(scrub_none(ingredient_process_template.dump()))
         try:
             self.session.put_resource(path, request_data)
             return []

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -2,6 +2,7 @@ from uuid import UUID
 
 import pytest
 from citrine._session import Session
+from citrine._utils.functions import scrub_none
 from citrine.exceptions import BadRequest
 from citrine.resources.api_error import ValidationError
 from citrine.resources.material_run import MaterialRunCollection
@@ -417,7 +418,7 @@ def test_validate_templates_successful_minimal_params(collection, session):
     expected_call = FakeCall(
         method="PUT",
         path="projects/{}/material-runs/validate-templates".format(project_id),
-        json={"dataObject":run.dump()})
+        json={"dataObject":scrub_none(run.dump())})
     assert session.last_call == expected_call
     assert errors == []
 
@@ -443,9 +444,9 @@ def test_validate_templates_successful_all_params(collection, session):
     expected_call = FakeCall(
         method="PUT",
         path="projects/{}/material-runs/validate-templates".format(project_id),
-        json={"dataObject": run.dump(),
-              "objectTemplate": template.dump(),
-              "ingredientProcessTemplate": unused_process_template.dump()})
+        json={"dataObject": scrub_none(run.dump()),
+              "objectTemplate": scrub_none(template.dump()),
+              "ingredientProcessTemplate": scrub_none(unused_process_template.dump())})
     assert session.last_call == expected_call
     assert errors == []
 
@@ -468,7 +469,7 @@ def test_validate_templates_errors(collection, session):
     expected_call = FakeCall(
         method="PUT",
         path="projects/{}/material-runs/validate-templates".format(project_id),
-        json={"dataObject":run.dump()})
+        json={"dataObject":scrub_none(run.dump())})
     assert session.last_call == expected_call
     assert errors == [validation_error]
 


### PR DESCRIPTION
# Citrine Python PR

## Description 
Prepare objects for store in the same way that register() does prior to running template validation on them. Prevents 500s on the backend which expects a specific format for incoming data

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
