### PR TITLE
PLA-3480 Ensure that validation raises 400s that aren't associated with validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.16.1',
+      version='0.16.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/src/citrine/resources/data_objects.py
+++ b/src/citrine/resources/data_objects.py
@@ -173,6 +173,6 @@ class DataObjectCollection(DataConceptsCollection[DataObjectResourceType], ABC):
             self.session.put_resource(path, request_data)
             return []
         except BadRequest as e:
-            if e.api_error is not None:
+            if e.api_error is not None and e.api_error.validation_errors:
                 return e.api_error.validation_errors
             raise e

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -485,3 +485,16 @@ def test_validate_templates_unrelated_400(collection, session):
     session.set_response(BadRequest("path", FakeRequestResponse(400)))
     with pytest.raises(BadRequest):
         collection.validate_templates(run)
+
+
+def test_validate_templates_unrelated_400_with_api_error(collection, session):
+    """
+    Test that DataObjectCollection.validate_templates() propagates an unrelated 400
+    """
+    # Given
+    run = MaterialRunFactory()
+
+    # When
+    session.set_response(BadRequest("path", FakeRequestResponseApiError(400, "I am not a validation error", [])))
+    with pytest.raises(BadRequest):
+        collection.validate_templates(run)


### PR DESCRIPTION
# Citrine Python PR

## Description 
Ensure that `.validate_templates()` raises 400s that have api errors but no validation errors

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [x] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
