### PR TITLE
Update Refresh Tokens Route to be the right one

### DIFF
--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -70,7 +70,7 @@ class Session(requests.Session):
         """Optionally refresh our access token (if the previous one is about to expire)."""
         data = {'refresh_token': self.refresh_token}
         response = self.request(
-            'POST', self._versioned_base_url() + 'tokens/refresh', json=data)
+            'POST', self._versioned_base_url() + 'tokens/refresh-tokens', json=data)
         if response.status_code != 200:
             raise UnauthorizedRefreshToken()
         self.access_token = response.json()['access_token']

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -49,7 +49,7 @@ def test_get_refreshes_token(session: Session):
     token_refresh_response = refresh_token(datetime(2019, 3, 14, tzinfo=pytz.utc))
 
     with requests_mock.Mocker() as m:
-        m.post('http://citrine-testing.fake/api/v1/tokens/refresh', json=token_refresh_response)
+        m.post('http://citrine-testing.fake/api/v1/tokens/refresh-tokens', json=token_refresh_response)
         m.get('http://citrine-testing.fake/api/v1/foo', json={'foo': 'bar'})
 
         resp = session.get_resource('/foo')
@@ -62,7 +62,7 @@ def test_get_refresh_token_failure(session: Session):
     session.access_token_expiration = datetime.utcnow() - timedelta(minutes=1)
 
     with requests_mock.Mocker() as m:
-        m.post('http://citrine-testing.fake/api/v1/tokens/refresh', status_code=401)
+        m.post('http://citrine-testing.fake/api/v1/tokens/refresh-tokens', status_code=401)
 
         with pytest.raises(UnauthorizedRefreshToken):
             session.get_resource('/foo')


### PR DESCRIPTION
# Citrine Python PR

## Description 
The platform api route to refresh tokens got updated to end with refresh-tokens as opposed to refresh.  Long running e2e tests (test_ara_integration.py) are now throwing  `WARNING:urllib3.connectionpool:Retrying (Retry(total=5, connect=0, read=5, redirect=None, status=5)) after connection broken by 'NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fed3649b2e8>: Failed to establish a new connection: [Errno 110] Connection timed out',)': /api/v1/tokens/refresh` as a result.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
