### PR TITLE
Mock versioning automation proposal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - '3.6'
 install:
 - git tag
+- echo $TRAVIS_COMMIT_MESSAGE
 - pip install -U -r requirements.txt
 - pip install -U -r test_requirements.txt
 - pip install --no-deps -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
 - '3.5'
 - '3.6'
 install:
-- git tag
-- echo $TRAVIS_COMMIT_MESSAGE
 - pip install -U -r requirements.txt
 - pip install -U -r test_requirements.txt
 - pip install --no-deps -e .
@@ -18,7 +16,24 @@ script:
 # following https://docs.travis-ci.com/user/environment-variables/#convenience-variables
 # the pull request isn't set to true if its a PR; its just set to false if its not.
 - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then bash ./scripts/validate-version-bump.sh; fi
-
+after_success:
+- |
+  # PSEUDO CODE
+  if branch == master
+      prev_tag = git tag -l | HEAD -1
+      msg = $TRAVIS_COMMIT_MESSAGE
+      if msg.startswith('patch')
+          bump = 0.0.1
+      elif msg.startswith('minor')
+          bump = 0.1.0
+      elif msg.startswith('major')
+          bump = 1.0.0
+      elif msg.startswith('pre')
+          bump = None
+      if bump
+          tag = prev_tag + bump
+          git tag $tag
+          git push --tags
 deploy:
   - provider: pages
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,16 @@ after_success:
   if branch == master
       prev_tag = git tag -l | HEAD -1
       msg = $TRAVIS_COMMIT_MESSAGE
-      if msg.startswith('patch')
+      if msg.startswith('[patch]')
           bump = 0.0.1
-      elif msg.startswith('minor')
+      elif msg.startswith('[minor]')
           bump = 0.1.0
-      elif msg.startswith('major')
+      elif msg.startswith('[major]')
           bump = 1.0.0
-      elif msg.startswith('pre')
+      elif msg.startswith('[pre]')
           bump = None
+      else
+          exit 1 "Invalid semver bump"
       if bump
           tag = prev_tag + bump
           git tag $tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '3.5'
 - '3.6'
 install:
+- git tag
 - pip install -U -r requirements.txt
 - pip install -U -r test_requirements.txt
 - pip install --no-deps -e .

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,14 @@ class PreBuildCommand(build_py):
         build_py.run(self)
 
 
+def get_git_tag():
+    # probably not valid subprocess usage, but you get the idea
+    import subprocess
+    return subprocess.run('git tag -l | HEAD -1').stdout
+
+
 setup(name='citrine',
-      version='0.16.4',
+      version=get_git_tag(),
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',


### PR DESCRIPTION
# Citrine Python PR

## Description 
Approached based upon the interface of https://github.com/semantic-release/semantic-release, which is designed for JS projects.

How it works:
* All version state is stored in git tags
* setup.py reads version from git at runtime
* Commit messages are prefixed with bump 'sizes' which are used to create a new git tag in Travis
* PyPi releases continue to be triggered from git tags

What this means
* We don't commit any information about version, so there aren't any merge conflicts around editing it
* Post-merge travis job cannot run concurrently safely — I think it’s possible our fast-forward-only setting makes this happen, but if not travis also lets you configure max parallelism, and 1 doesn’t seem too bad given how fast the pipeline is
* We no longer have to manually release to pypi, but we still have the ability to do it manually with a manual git tag and push
* The version bump type can be edited during PR review if needed
* We may accumulate a lot of bump type messages in our commit log when a PR has a lot of iterations and we don't use rebase.
