### PR TITLE
PLA-3905 Bump gemd version to include strehlow & cook changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gemd==0.6.2
+gemd==0.6.4
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.15.4

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.16.7',
+      version='0.16.8',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',
@@ -69,7 +69,7 @@ setup(name='citrine',
           "pyjwt>=1.7.1,<2",
           "arrow>=0.15.4,<0.16",
           "strip-hints>=0.1.8,<0.2",
-          "gemd>=0.6.2,<0.7",
+          "gemd>=0.6.4,<0.7",
           "boto3>=1.9.226,<2",
           "botocore>=1.12.226,<2",
           "deprecation>=2.0.7,<3",


### PR DESCRIPTION
# Citrine Python PR

## Description 
Bump gemd version from 0.6.2 to 0.6.4. This provides access to strehlow and cook demo dataset improvements, which are useful for seeding.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [x] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
