### PR TITLE
Alias filename to name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.17.0',
+      version='0.17.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -55,6 +55,11 @@ class FileLink(Resource['FileLink'], GEMDFileLink):
         GEMDFileLink.__init__(self, filename, url)
         self.typ = GEMDFileLink.typ
 
+    @property
+    def name(self):
+        """Attribute name is an alias for filename."""
+        return self.filename
+
     def __str__(self):
         return '<File link {!r}>'.format(self.filename)
 

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -40,6 +40,12 @@ def test_build_as_dict(collection, valid_data):
     assert collection.build(valid_data).dump() == FileLink.build(valid_data).as_dict()
 
 
+def test_name_alias(valid_data):
+    """Test that .name aliases to filename."""
+    file = FileLink.build(valid_data)
+    assert file.name == file.filename
+
+
 def test_string_representation(valid_data):
     """Test the string representation."""
     assert str(FileLink.build(valid_data)) == '<File link \'materials.txt\'>'


### PR DESCRIPTION
# Citrine Python PR

## Description 
Gives `FileLink` objects a `.name` field which is an alias to `.filename`.

Methods like this https://github.com/CitrineInformatics/citrine-python/blob/feature/filename-alias/src/citrine/seeding/find_or_create.py#L4 assume that all resources with uids also have a `.name` field. That's mostly true but not true for `FileLink`s.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
