### PR TITLE
Docs/expression restrictions

### DIFF
--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -104,7 +104,7 @@ If an alias isn't defined, the expression argument is expected to match the desc
 
 The syntax is described in the `mXparser documentation <http://mathparser.org/mxparser-math-collection>`_.
 Citrine-python currently supports the following operators and functions:
-- basic operators: addition `+`, subtraction `-`, multiplication `*`, division `/`, power `^`,
+- basic operators: addition `+`, subtraction `-`, multiplication `*`, division `/`, exponentiation `^`
 - built-in math functions:
   - trigonometric: `sin`, `cos`, `tan`, `asin`, `acos`, `atan`
   - hyperbolic: `sinh`, `cosh`, `tanh`

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -106,10 +106,10 @@ The syntax is described in the `mXparser documentation <http://mathparser.org/mx
 Citrine-python currently supports the following operators and functions:
 - basic operators: addition `+`, subtraction `-`, multiplication `*`, division `/`, power `^`,
 - built-in math functions:
-  - trigonometric `sin`, `cos`, `tan`, `asin`, `acos`, `atan`
-  - hyperbolic `sinh`, `cosh`, `tanh`
-  - logarithm `log10`, `ln`
-  - exponential `exp`
+  - trigonometric: `sin`, `cos`, `tan`, `asin`, `acos`, `atan`
+  - hyperbolic: `sinh`, `cosh`, `tanh`
+  - logarithm: `log10`, `ln`
+  - exponential: `exp`
 - constants: `pi`, `e`
 
 The following example demonstrates how to create an :class:`~citrine.informatics.predictors.ExpressionPredictor`.

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -93,19 +93,26 @@ The following example demonstrates how to use the python SDK to create a :class:
 Expression predictor
 --------------------
 
-The :class:`~citrine.informatics.predictors.ExpressionPredictor` defines an analytic (lossless) model that computes
-one real-valued output descriptor from one or more input descriptors. An ExpressionPredictor should be used when the
-relationship between inputs and outputs is known.
+The :class:`~citrine.informatics.predictors.ExpressionPredictor` defines an analytic (lossless) model that computes one real-valued output descriptor from one or more input descriptors.
+An ExpressionPredictor should be used when the relationship between inputs and outputs is known.
 
-Note, a string is used to define the expression, and the corresponding output is defined by a RealDescriptor.
-The aliases parameter defines a mapping from expression argument to descriptor key. Expression arguments with spaces
-are not supported, so an alias is created for each input. Aliases are not required for inputs that do not contain
-spaces (but may be useful to avoid typing out the verbose descriptors in the expression string). If an alias isn't
-defined, the expression argument is expected to match the descriptor key exactly.
+A string is used to define the expression, and the corresponding output is defined by a :class:`~citrine.informatics.descriptors.RealDescriptor`.
+The ``aliases`` parameter defines a mapping from expression arguments to descriptor keys.
+Expression arguments with spaces are not supported, so an alias must be created for each input that has a space in its name.
+Aliases are not required for inputs that do not contain spaces, but may be useful to avoid typing out the verbose descriptors in the expression string.
+If an alias isn't defined, the expression argument is expected to match the descriptor key exactly.
 
-For a full list of supported syntax see the `mXparser documentation <http://mathparser.org/mxparser-math-collection>`_.
+The syntax is described in the `mXparser documentation <http://mathparser.org/mxparser-math-collection>`_.
+Citrine-python currently supports the following operators and functions:
+- basic operators: addition `+`, subtraction `-`, multiplication `*`, division `/`, power `^`,
+- built-in math functions:
+  - trigonometric `sin`, `cos`, `tan`, `asin`, `acos`, `atan`
+  - hyperbolic `sinh`, `cosh`, `tanh`
+  - logarithm `log10`, `ln`
+  - exponential `exp`
+- constants: `pi`, `e`
 
-The following example demonstrates how to use the python SDK to create a :class:`~citrine.informatics.predictors.ExpressionPredictor`.
+The following example demonstrates how to create an :class:`~citrine.informatics.predictors.ExpressionPredictor`.
 
 .. code:: python
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.17.1',
+      version='0.17.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Andrew Millspaugh',


### PR DESCRIPTION
# Citrine Python PR

## Description 
The `ExpressionPredictor` documentation did not include a list of supported items.

This PR also updates it so that there is 1 sentence per line.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
