### PR TITLE
[PLA-3692] Added identifiers to csv data source.

### DIFF
--- a/docs/source/workflows/data_sources.rst
+++ b/docs/source/workflows/data_sources.rst
@@ -1,6 +1,3 @@
-Data Sources
-=============
-
 Data sources are used by modules to pull data from outside of the AI engine.
 For example, a :doc:`predictor <predictors>` may need to define external training data.
 
@@ -25,11 +22,11 @@ Assume that a file data.csv exists with the following contents:
 
 .. code::
 
-    Chemical Formula,Gap,Crystallinity
-    Bi2Te3,0.153,Single crystalline
-    Mg2Ge,0.567,Single crystalline
-    GeTe,0.7,Amorphous
-    Sb2Se3,1.15,Polycrystalline
+    Chemical Formula,Gap,Crystallinity,Sample ID
+    Bi2Te3,0.153,Single crystalline,0
+    Mg2Ge,0.567,Single crystalline,1
+    GeTe,0.7,Amorphous,2
+    Sb2Se3,1.15,Polycrystalline,3
 
 That file could be used as the training data for a predictor as:
 
@@ -51,9 +48,7 @@ That file could be used as the training data for a predictor as:
             "Crystallinity": CategoricalDescriptor("Crystallinity", categories=[
                 "Single crystalline", "Amorphous", "Polycrystalline"])
         },
-        # assuming no two row share the same chemical formula,
-        # we may wish to use the column as an identifier
-        identifiers = ["Chemical Formula"]
+        identifiers = ["Sample ID"]
     )
 
     predictor = SimpleMLPredictor(

--- a/docs/source/workflows/data_sources.rst
+++ b/docs/source/workflows/data_sources.rst
@@ -1,3 +1,6 @@
+Data Sources
+=============
+
 Data sources are used by modules to pull data from outside of the AI engine.
 For example, a :doc:`predictor <predictors>` may need to define external training data.
 

--- a/docs/source/workflows/data_sources.rst
+++ b/docs/source/workflows/data_sources.rst
@@ -15,6 +15,12 @@ Uploading a new file with the same name will produce a new version of the file w
 The columns in the CSV are extracted and parsed by a mapping of column header names to user-created descriptors.
 Columns in the CSV that are not mapped with a descriptor are ignored.
 
+An optional list of identifiers can be specified.
+Each identifier is a column header name.
+These may overlap with the keys defined in the mapping from column header names to descriptors if a column should be parsed as data and used as an identifier.
+Identifiers should be globally unique.
+No two rows should contain the same value.
+
 Assume that a file data.csv exists with the following contents:
 
 .. code::
@@ -44,7 +50,10 @@ That file could be used as the training data for a predictor as:
             "Gap": RealDescriptor("Band gap", lower_bound=0, upper_bound=20, units="eV"),
             "Crystallinity": CategoricalDescriptor("Crystallinity", categories=[
                 "Single crystalline", "Amorphous", "Polycrystalline"])
-        }
+        },
+        # assuming no two row share the same chemical formula,
+        # we may wish to use the column as an identifier
+        identifiers = ["Chemical Formula"]
     )
 
     predictor = SimpleMLPredictor(

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.17.4',
+      version='0.18.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/informatics/data_sources.py
+++ b/src/citrine/informatics/data_sources.py
@@ -54,9 +54,10 @@ class CSVDataSource(Serializable['CSVDataSource'], DataSource):
     column_definitions: Mapping[str, Descriptor]
         Map the column headers to the descriptors that will be used to interpret the cell contents
     identifiers: Optional[List[str]]
-        List of one or more column headers whose values uniquely identify a row. These may overlap with
-        ``column_definitions`` if a column should be used as data and as an identifier, but this is not necessary.
-        Identifiers should be globally unique. No two rows should contain the same value.
+        List of one or more column headers whose values uniquely identify a row. These may overlap
+        with ``column_definitions`` if a column should be used as data and as an identifier,
+        but this is not necessary. Identifiers should be globally unique. No two rows should
+        contain the same value.
 
     """
 

--- a/src/citrine/informatics/data_sources.py
+++ b/src/citrine/informatics/data_sources.py
@@ -1,6 +1,6 @@
 """Tools for working with Descriptors."""
 from abc import abstractmethod
-from typing import Type, List, Mapping, Union  # noqa: F401
+from typing import Type, List, Mapping, Optional, Union  # noqa: F401
 from uuid import UUID
 
 from citrine._serialization.serializable import Serializable
@@ -53,6 +53,10 @@ class CSVDataSource(Serializable['CSVDataSource'], DataSource):
         link to the CSV file to read the data from
     column_definitions: Mapping[str, Descriptor]
         Map the column headers to the descriptors that will be used to interpret the cell contents
+    identifiers: Optional[List[str]]
+        List of one or more column headers whose values uniquely identify a row. These may overlap with
+        ``column_definitions`` if a column should be used as data and as an identifier, but this is not necessary.
+        Identifiers should be globally unique. No two rows should contain the same value.
 
     """
 
@@ -60,15 +64,18 @@ class CSVDataSource(Serializable['CSVDataSource'], DataSource):
     file_link = properties.Object(FileLink, "file_link")
     column_definitions = properties.Mapping(
         properties.String, properties.Object(Descriptor), "column_definitions")
+    identifiers = properties.Optional(properties.List(properties.String), "identifiers")
 
     def _attrs(self) -> List[str]:
-        return ["file_link", "column_definitions", "typ"]
+        return ["file_link", "column_definitions", "identifiers", "typ"]
 
     def __init__(self,
                  file_link: FileLink,
-                 column_definitions: Mapping[str, Descriptor]):
+                 column_definitions: Mapping[str, Descriptor],
+                 identifiers: Optional[List[str]] = None):
         self.file_link = file_link
         self.column_definitions = column_definitions
+        self.identifiers = identifiers
 
 
 class AraTableDataSource(Serializable['AraTableDataSource'], DataSource):

--- a/tests/informatics/test_data_source.py
+++ b/tests/informatics/test_data_source.py
@@ -9,7 +9,7 @@ from citrine.resources.file_link import FileLink
 
 
 @pytest.fixture(params=[
-    CSVDataSource(FileLink("foo.spam", "http://example.com"), {"spam": RealDescriptor("eggs", lower_bound=0, upper_bound=1.0)}),
+    CSVDataSource(FileLink("foo.spam", "http://example.com"), {"spam": RealDescriptor("eggs", lower_bound=0, upper_bound=1.0)}, ["identifier"]),
     AraTableDataSource(uuid.uuid4(), 1),
     AraTableDataSource(uuid.uuid4(), "2"),
 ])


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR adds an optional `identifiers` parameter to a CSV data source. This provides a means to uniquely identify a row. There may be more than one identifier, and identifiers may overlap with column definitions.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [x] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
