### PR TITLE
Add caveat about CSV files

### DIFF
--- a/docs/source/workflows/data_sources.rst
+++ b/docs/source/workflows/data_sources.rst
@@ -15,6 +15,10 @@ Uploading a new file with the same name will produce a new version of the file w
 The columns in the CSV are extracted and parsed by a mapping of column header names to user-created descriptors.
 Columns in the CSV that are not mapped with a descriptor are ignored.
 
+The CSV must be UTF-8 encoded ASCII text with CRLF line terminators.
+The best way to ensure this is to save the file in a "Comma Separated Values" format and not any of the other small CSV variations.
+For example, Excel's default CSV format, "CSV UTF-8 (Comma Delimited)" is not parseable.
+
 Assume that a file data.csv exists with the following contents:
 
 .. code::

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.17.6',
+      version='0.17.7',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',


### PR DESCRIPTION
# Citrine Python PR

## Description 
Add caveat about using CSV files saved with Excel.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
