### PR TITLE
PLA-3994: list pagination 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.17.7',
+      version='0.17.8',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -144,11 +144,10 @@ class Collection(Generic[ResourceType]):
         for element in collection:
             try:
                 yield self.build(element)
-            except(KeyError, ValueError) as e:
+            except(KeyError, ValueError):
                 # TODO:  Right now this is a hack.  Clean this up soon.
                 # Module collections are not filtering on module type
                 # properly, so we are filtering client-side.
-                print(e)
                 pass
 
     def _page_params(self,

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -119,7 +119,8 @@ class Collection(Generic[ResourceType]):
         """
         path = self._get_path()
 
-        params = self._page_params(page, per_page)
+        module_type = getattr(self, '_module_type', None)
+        params = self._page_params(page, per_page, module_type)
 
         data = self.session.get_resource(path, params=params)
         # A 'None' collection key implies response has a top-level array
@@ -139,10 +140,15 @@ class Collection(Generic[ResourceType]):
                 # properly, so we are filtering client-side.
                 pass
 
-    def _page_params(self, page: Optional[int], per_page: Optional[int]) -> Dict[str, int]:
+    def _page_params(self,
+                     page: Optional[int],
+                     per_page: Optional[int],
+                     module_type: Optional[str] = None) -> Dict[str, int]:
         params = {}
         if page is not None:
             params["page"] = page
         if per_page is not None:
             params["per_page"] = per_page
+        if module_type is not None:
+            params["module_type"] = module_type
         return params

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -103,7 +103,12 @@ class Collection(Generic[ResourceType]):
         params = self._page_params(page, per_page, module_type)
 
         data = self.session.get_resource(path, params=params)
-        next_uri = data.get('next', "")
+
+        try:
+            next_uri = data.get('next', "")
+        except AttributeError:
+            next_uri = ""
+
         # A 'None' collection key implies response has a top-level array
         # of 'ResourceType'
         # TODO: Unify backend return values
@@ -139,10 +144,11 @@ class Collection(Generic[ResourceType]):
         for element in collection:
             try:
                 yield self.build(element)
-            except(KeyError, ValueError):
+            except(KeyError, ValueError) as e:
                 # TODO:  Right now this is a hack.  Clean this up soon.
                 # Module collections are not filtering on module type
                 # properly, so we are filtering client-side.
+                print(e)
                 pass
 
     def _page_params(self,

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Optional, Union, Generic, TypeVar, Iterable, Dict
+from typing import Optional, Union, Generic, TypeVar, Iterable, Dict, Tuple
 from uuid import UUID
 
 from citrine._rest.paginator import Paginator
@@ -99,7 +99,29 @@ class Collection(Generic[ResourceType]):
 
     def _fetch_page(self,
                     page: Optional[int] = None,
-                    per_page: Optional[int] = None):
+                    per_page: Optional[int] = None) -> Tuple[Iterable[dict], str]:
+        """
+        Fetch visible elements in the collection.  This does not handle pagination.
+
+        This method will return the first page of results using the default page/per_page
+        behavior of the backend service.  Specify page/per_page to override these defaults
+        which are passed to the backend service.
+
+        Parameters
+        ---------
+        page: int, optional
+            The "page" of results to list. Default is the first page, which is 1.
+        per_page: int, optional
+            Max number of results to return. Default is 20.
+
+        Returns
+        -------
+        Iterable[dict]
+            Elements in this collection.
+        str
+            The next uri if one is available, empty string otherwise
+
+        """
         path = self._get_path()
 
         module_type = getattr(self, '_module_type', None)
@@ -122,20 +144,15 @@ class Collection(Generic[ResourceType]):
 
         return collection, next_uri
 
-    def _build_collection_elements(self, collection) -> Iterable[ResourceType]:
+    def _build_collection_elements(self,
+                                   collection: Iterable[dict]) -> Iterable[ResourceType]:
         """
-        Fetch visible elements in the collection.  This does not handle pagination.
-
-        This method will return the first page of results using the default page/per_page
-        behaviour of the backend service.  Specify page/per_page to override these defaults
-        which are passed to the backend service.
+        For each element in the collection, build the appropriate resource type.
 
         Parameters
         ---------
-        page: int, optional
-            The "page" of results to list. Default is the first page, which is 1.
-        per_page: int, optional
-            Max number of results to return. Default is 20.
+        collection: Iterable[dict]
+            collection containing the elements to be built
 
         Returns
         -------

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -79,7 +79,10 @@ class Collection(Generic[ResourceType]):
             Resources in this collection.
 
         """
-        return self._paginator.paginate(self._fetch_page, self._build_collection_elements, page, per_page)
+        return self._paginator.paginate(self._fetch_page,
+                                        self._build_collection_elements,
+                                        page,
+                                        per_page)
 
     def update(self, model: CreationType) -> CreationType:
         """Update a particular element of the collection."""
@@ -118,7 +121,6 @@ class Collection(Generic[ResourceType]):
             collection = data[self._collection_key]
 
         return collection, next_uri
-
 
     def _build_collection_elements(self, collection) -> Iterable[ResourceType]:
         """

--- a/src/citrine/_rest/paginator.py
+++ b/src/citrine/_rest/paginator.py
@@ -14,6 +14,7 @@ class Paginator(Generic[ResourceType]):
 
     def paginate(self,
                  page_fetcher: Callable[[Optional[int], int], Iterable[ResourceType]],
+                 collection_builder,
                  page: Optional[int] = None,
                  per_page: int = 100) -> Iterable[ResourceType]:
         """
@@ -49,7 +50,8 @@ class Paginator(Generic[ResourceType]):
         page_idx = page
 
         while True:
-            subset = page_fetcher(page_idx, per_page)
+            subset_collection, next_uri = page_fetcher(page_idx, per_page)
+            subset = collection_builder(subset_collection)
 
             count = 0
             for idx, element in enumerate(subset):
@@ -74,7 +76,7 @@ class Paginator(Generic[ResourceType]):
                 break
 
             # Handle the case where we get an unexpected number of results (e.g. last page)
-            if count == 0 or count < per_page:
+            if next_uri == "" and count < per_page:
                 break
 
             if page_idx is None:

--- a/src/citrine/_rest/paginator.py
+++ b/src/citrine/_rest/paginator.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import TypeVar, Generic, Callable, Optional, Iterable, Any
+from typing import TypeVar, Generic, Callable, Optional, Iterable, Any, Tuple
 
 ResourceType = TypeVar('ResourceType')
 
@@ -13,8 +13,8 @@ class Paginator(Generic[ResourceType]):
     """
 
     def paginate(self,
-                 page_fetcher: Callable[[Optional[int], int], Iterable[ResourceType]],
-                 collection_builder,
+                 page_fetcher: Callable[[Optional[int], int], Tuple[Iterable[dict], str]],
+                 collection_builder: Callable[[Iterable[dict]], Iterable[ResourceType]],
                  page: Optional[int] = None,
                  per_page: int = 100) -> Iterable[ResourceType]:
         """
@@ -28,6 +28,10 @@ class Paginator(Generic[ResourceType]):
 
         Parameters
         ---------
+        page_fetcher: Callable[[Optional[int], int], Tuple[Iterable[dict], str]]
+            Fetches the next page of elements
+        collection_builder: Callable[[Iterable[dict]], Iterable[ResourceType]]
+            Builds each element in the collection into the appropriate resource
         page: int, optional
             The "page" of results to list. Default is to read all pages and yield
             all results.  This option is deprecated.

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -273,7 +273,10 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
             Every object in this collection.
 
         """
-        return self.filter_by_tags([], page, per_page)
+        return self.filter_by_tags([], page, per_page), ""
+
+    def _build_collection_elements(self, collection):
+        return collection
 
     def list(self,
              page: Optional[int] = None,

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -1,6 +1,6 @@
 """Top-level class for all data concepts objects and collections thereof."""
 from abc import abstractmethod, ABC
-from typing import TypeVar, Type, List, Union, Optional, Iterator
+from typing import TypeVar, Type, List, Union, Optional, Iterator, Iterable
 from uuid import UUID
 
 from citrine._rest.collection import Collection
@@ -275,7 +275,22 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         """
         return self.filter_by_tags([], page, per_page), ""
 
-    def _build_collection_elements(self, collection):
+    def _build_collection_elements(self,
+                                   collection: Iterable[dict]) -> Iterable[ResourceType]:
+        """
+        For each element in the collection, build the appropriate resource type.
+
+        Parameters
+        ---------
+        collection: Iterable[dict]
+            collection containing the elements to be built
+
+        Returns
+        -------
+        Iterable[ResourceType]
+            Resources in this collection.
+
+        """
         return collection
 
     def list(self,

--- a/src/citrine/resources/design_space.py
+++ b/src/citrine/resources/design_space.py
@@ -22,6 +22,7 @@ class DesignSpaceCollection(Collection[DesignSpace]):
     _path_template = '/projects/{project_id}/modules'
     _individual_key = None
     _resource = DesignSpace
+    _module_type = 'DESIGN_SPACE'
 
     def __init__(self, project_id: UUID, session: Session = Session()):
         self.project_id = project_id

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -2,7 +2,7 @@
 from uuid import UUID
 import os
 import mimetypes
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Tuple
 from boto3 import client as boto3_client
 from boto3.session import Config
 import requests
@@ -86,7 +86,7 @@ class FileCollection(Collection[FileLink]):
 
     def _fetch_page(self,
                     page: Optional[int] = None,
-                    per_page: Optional[int] = None) -> Iterable[FileLink]:
+                    per_page: Optional[int] = None) -> Tuple[Iterable[FileLink], str]:
         """
         List all visible files in the collection.
 
@@ -101,6 +101,8 @@ class FileCollection(Collection[FileLink]):
         -------
         Iterable[FileLink]
             FileLink objects in this collection.
+        str
+            The next uri if one is available, empty string otherwise
 
         """
         path = self._get_path()

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -112,6 +112,9 @@ class FileCollection(Collection[FileLink]):
 
         response = self.session.get_resource(path=path, params=params)
         collection = response[self._collection_key]
+        return collection, ""
+
+    def _build_collection_elements(self, collection):
         for file in collection:
             yield self.build(self._as_dict_from_resource(file))
 

--- a/src/citrine/resources/predictor.py
+++ b/src/citrine/resources/predictor.py
@@ -22,7 +22,7 @@ class PredictorCollection(Collection[Predictor]):
     _path_template = '/projects/{project_id}/modules'
     _individual_key = None
     _resource = Predictor
-    _module_type = "PREDICTOR"
+    _module_type = 'PREDICTOR'
 
     def __init__(self, project_id: UUID, session: Session):
         self.project_id = project_id

--- a/src/citrine/resources/predictor.py
+++ b/src/citrine/resources/predictor.py
@@ -22,6 +22,7 @@ class PredictorCollection(Collection[Predictor]):
     _path_template = '/projects/{project_id}/modules'
     _individual_key = None
     _resource = Predictor
+    _module_type = "PREDICTOR"
 
     def __init__(self, project_id: UUID, session: Session):
         self.project_id = project_id

--- a/src/citrine/resources/processor.py
+++ b/src/citrine/resources/processor.py
@@ -21,6 +21,7 @@ class ProcessorCollection(Collection[Processor]):
 
     _path_template = '/projects/{project_id}/modules'
     _individual_key = None
+    _module_type = 'PROCESSOR'
 
     def __init__(self, project_id: UUID, session: Session):
         self.project_id = project_id

--- a/src/citrine/resources/table.py
+++ b/src/citrine/resources/table.py
@@ -99,12 +99,13 @@ class TableCollection(Collection[Table]):
         :param per_page: The number of items to fetch per-page.
         :return: An iterable of the versions of the Tables (as Table objects).
         """
-        def fetch_versions(page: Optional[int], per_page: int) -> Iterable[Table]:
+        def fetch_versions(page: Optional[int],
+                           per_page: int) -> Tuple[Iterable[dict], str]:
             data = self.session.get_resource(self._get_path() + '/' + str(uid),
                                              params=self._page_params(page, per_page))
             return (data[self._collection_key], data.get('next', ""))
 
-        def build_versions(collection):
+        def build_versions(collection: Iterable[dict]) -> Iterable[Table]:
             for item in collection:
                 yield self.build(item)
 

--- a/src/citrine/resources/table.py
+++ b/src/citrine/resources/table.py
@@ -102,10 +102,13 @@ class TableCollection(Collection[Table]):
         def fetch_versions(page: Optional[int], per_page: int) -> Iterable[Table]:
             data = self.session.get_resource(self._get_path() + '/' + str(uid),
                                              params=self._page_params(page, per_page))
-            for item in data[self._collection_key]:
+            return (data[self._collection_key], data.get('next', ""))
+
+        def build_versions(collection):
+            for item in collection:
                 yield self.build(item)
 
-        return self._paginator.paginate(fetch_versions, page, per_page)
+        return self._paginator.paginate(fetch_versions, build_versions, page, per_page)
 
     def build(self, data: dict) -> Table:
         """Build an individual Table from a dictionary."""

--- a/tests/resources/test_predictor.py
+++ b/tests/resources/test_predictor.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from citrine.exceptions import ModuleRegistrationFailedException, NotFound
 from citrine.informatics.predictors import GraphPredictor, SimpleMLPredictor
 from citrine.resources.predictor import PredictorCollection
-from tests.utils.session import FakeSession
+from tests.utils.session import FakeSession, FakeCall
 
 
 def test_build(valid_simple_ml_predictor_data):
@@ -94,3 +94,24 @@ def test_mark_predictor_invalid(valid_simple_ml_predictor_data):
     assert first_call.method == 'PUT'
     assert first_call.path == '/projects/{}/modules/{}'.format(collection.project_id, predictor.uid)
     assert not first_call.json['active']
+
+
+def test_list_predictors(valid_simple_ml_predictor_data):
+    # Given
+    session = FakeSession()
+    collection = PredictorCollection(uuid.uuid4(), session)
+    predictor = SimpleMLPredictor.build(valid_simple_ml_predictor_data)
+    session.set_responses(
+        {
+            'entries': [valid_simple_ml_predictor_data, valid_simple_ml_predictor_data],
+            'next': ''
+        })
+
+    # When
+    predictors = list(collection.list(per_page=20))
+
+    # Then
+    expected_call = FakeCall(method='GET', path='/projects/{}/modules'.format(collection.project_id),
+                                   params={'per_page': 20, 'module_type': 'PREDICTOR'})
+    # assert 3 == session.num_calls, session.calls  # This is a little strange, the report is fetched eagerly
+    assert expected_call == session.calls[0]

--- a/tests/rest/test_paginator.py
+++ b/tests/rest/test_paginator.py
@@ -10,24 +10,24 @@ def test_validate_mock_fetcher():
 
     # Make calls (and ignore arguments on the callable), and ensure we get back the above elements, each wrapped in a
     # list, and the final call should be an empty list.
-    assert mock_fetcher("a", "b") == ["a"]
-    assert mock_fetcher() == ["b"]
-    assert mock_fetcher() == []
+    assert mock_fetcher("a", "b") == (["a"], "next_uri")
+    assert mock_fetcher() == (["b"], "next_uri")
+    assert mock_fetcher() == ([], "")
 
 
 def test_paginator_fetches_single_page():
     # Return a single page with 2 elements
-    result = Paginator().paginate(mocked_fetcher(["a", "b"]), per_page=2)
+    result = Paginator().paginate(mocked_fetcher(["a", "b"]), lambda x: x, per_page=2)
     assert list(result) == ["a", "b"]
 
 
 def test_pagination_across_two_pages():
-    result = Paginator().paginate(mocked_fetcher("a", "b"), per_page=1)
+    result = Paginator().paginate(mocked_fetcher("a", "b"), lambda x: x, per_page=1)
     assert list(result) == ["a", "b"]
 
 
 def test_pagination_stops_when_initial_item_repeated():
-    result = Paginator().paginate(mocked_fetcher("a", "b", "a"), per_page=1)
+    result = Paginator().paginate(mocked_fetcher("a", "b", "a"), lambda x: x, per_page=1)
     assert list(result) == ["a", "b"]
 
 
@@ -40,6 +40,7 @@ def mocked_fetcher(*args):
     """
     mock_fetcher = Mock()
     args_in_lists = [list(a) for a in args]
-    args_in_lists.append([])
+    args_in_lists = [(a, "next_uri") for a in args_in_lists]
+    args_in_lists.append(([], ""))
     mock_fetcher.side_effect = list(args_in_lists)
     return mock_fetcher


### PR DESCRIPTION
# Citrine Python PR

## Description 
*This is still WIP*
This PR attempts to address these two main issues:
1. the list endpoints don't make use of the module type filtering functionality of the back end and rely on serialization errors to filter modules client side
2. the pagination of the list endpoint stops prematurely when the  number modules on the client side is less than the number requested by page after the client does filtering and deserialization

Solution summaries:
1. add a `_module_type` field that can be used in the list endpoint (so far only to predictors, but I'm also going to add it to other supported modules)
2. refactor the pagination code to allow for use of the `next` field provided in the backend response field to determine if we are at the end of the pagination

Things I'm still working on:
1. Editing docstrings and type annotations
2. Ensuring full test coverage


### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
