### PR TITLE
formulation descriptor and (some) predictors

### DIFF
--- a/docs/source/workflows/data_sources.rst
+++ b/docs/source/workflows/data_sources.rst
@@ -25,11 +25,11 @@ Assume that a file data.csv exists with the following contents:
 
 .. code::
 
-    Chemical Formula,Gap,Crystallinity
-    Bi2Te3,0.153,Single crystalline
-    Mg2Ge,0.567,Single crystalline
-    GeTe,0.7,Amorphous
-    Sb2Se3,1.15,Polycrystalline
+    Chemical Formula,Gap,Crystallinity,Sample ID
+    Bi2Te3,0.153,Single crystalline,0
+    Mg2Ge,0.567,Single crystalline,1
+    GeTe,0.7,Amorphous,2
+    Sb2Se3,1.15,Polycrystalline,3
 
 That file could be used as the training data for a predictor as:
 
@@ -51,9 +51,7 @@ That file could be used as the training data for a predictor as:
             "Crystallinity": CategoricalDescriptor("Crystallinity", categories=[
                 "Single crystalline", "Amorphous", "Polycrystalline"])
         },
-        # assuming no two row share the same chemical formula,
-        # we may wish to use the column as an identifier
-        identifiers = ["Chemical Formula"]
+        identifiers = ["Sample ID"]
     )
 
     predictor = SimpleMLPredictor(

--- a/docs/source/workflows/data_sources.rst
+++ b/docs/source/workflows/data_sources.rst
@@ -65,17 +65,17 @@ An optional list of identifiers can be specified.
 Identifiers uniquely identify a row and are used in the context of simple mixtures to link from an ingredient to the its properties.
 Each identifier must correspond to a column header name
 No two rows within this column can contain the same value.
-Identifier columns may overlap with the keys defined in the mapping from column header names to descriptors if a column should be parsed as data and used as an identifier.
+If a column should be parsed as data and used as an identifier, identifier columns may overlap with the keys defined in the mapping from column header names to descriptors.
 
 Identifiers are required in two circumstances.
 These circumstances are only relevant if CSV data source represents simple mixture data.
 
 1. Ingredient properties are featurized using a :class:`~citrine.informatics.predictors.GeneralizedMeanPropertyPredictor`.
    In this case, the link from identifier to row is used to compute mean ingredient property values.
-2. Simple mixtures are boiled down to recipes that contain only atomic ingredients using a :class:`~citrine.informatics.predictors.SimpleMixturePredictor`.
-   In this case, links from each mixture's ingredients to its row (which may also be a mixture) are used to to recursively crawl hierarchical blends of blends and construct a recipe that contains only leaf ingredients.
+2. Simple mixtures that contain mixtures are simplified to recipes that contain only atomic ingredients using a :class:`~citrine.informatics.predictors.SimpleMixturePredictor`.
+   In this case, links from each mixture's ingredients to its row (which may also be a mixture) are used to recursively crawl hierarchical blends of blends and construct a recipe that contains only leaf ingredients.
 
-Note, to build a formulation from a CSV data source an :class:`~citrine.informatics.predictors.IngredientsToSimpleMixturePredictor` must be present in the workflow.
+Note: to build a formulation from a CSV data source an :class:`~citrine.informatics.predictors.IngredientsToSimpleMixturePredictor` must be present in the workflow.
 Additionally, each ingredient id used as a key in the predictor's map from ingredient id to its quantity must exist in an identifier column.
 
 As an example, consider the following saline solution data.

--- a/docs/source/workflows/data_sources.rst
+++ b/docs/source/workflows/data_sources.rst
@@ -15,21 +15,15 @@ Uploading a new file with the same name will produce a new version of the file w
 The columns in the CSV are extracted and parsed by a mapping of column header names to user-created descriptors.
 Columns in the CSV that are not mapped with a descriptor are ignored.
 
-An optional list of identifiers can be specified.
-Each identifier is a column header name.
-These may overlap with the keys defined in the mapping from column header names to descriptors if a column should be parsed as data and used as an identifier.
-Identifiers should be globally unique.
-No two rows should contain the same value.
-
 Assume that a file data.csv exists with the following contents:
 
 .. code::
 
-    Chemical Formula,Gap,Crystallinity,Sample ID
-    Bi2Te3,0.153,Single crystalline,0
-    Mg2Ge,0.567,Single crystalline,1
-    GeTe,0.7,Amorphous,2
-    Sb2Se3,1.15,Polycrystalline,3
+    Chemical Formula,Gap,Crystallinity
+    Bi2Te3,0.153,Single crystalline
+    Mg2Ge,0.567,Single crystalline
+    GeTe,0.7,Amorphous
+    Sb2Se3,1.15,Polycrystalline
 
 That file could be used as the training data for a predictor as:
 
@@ -50,8 +44,7 @@ That file could be used as the training data for a predictor as:
             "Gap": RealDescriptor("Band gap", lower_bound=0, upper_bound=20, units="eV"),
             "Crystallinity": CategoricalDescriptor("Crystallinity", categories=[
                 "Single crystalline", "Amorphous", "Polycrystalline"])
-        },
-        identifiers = ["Sample ID"]
+        }
     )
 
     predictor = SimpleMLPredictor(
@@ -66,6 +59,85 @@ That file could be used as the training data for a predictor as:
         outputs = [data_source.column_definitions["Gap"]],
         latent_variables = [],
         training_data = data_source
+    )
+
+An optional list of identifiers can be specified.
+Identifiers uniquely identify a row and are used in the context of simple mixtures to link from an ingredient to the its properties.
+Each identifier must correspond to a column header name
+No two rows within this column can contain the same value.
+Identifier columns may overlap with the keys defined in the mapping from column header names to descriptors if a column should be parsed as data and used as an identifier.
+
+Identifiers are required in two circumstances.
+These circumstances are only relevant if CSV data source represents simple mixture data.
+
+1. Ingredient properties are featurized using a :class:`~citrine.informatics.predictors.GeneralizedMeanPropertyPredictor`.
+   In this case, the link from identifier to row is used to compute mean ingredient property values.
+2. Simple mixtures are boiled down to recipes that contain only atomic ingredients using a :class:`~citrine.informatics.predictors.SimpleMixturePredictor`.
+   In this case, links from each mixture's ingredients to its row (which may also be a mixture) are used to to recursively crawl hierarchical blends of blends and construct a recipe that contains only leaf ingredients.
+
+Note, to build a formulation from a CSV data source an :class:`~citrine.informatics.predictors.IngredientsToSimpleMixturePredictor` must be present in the workflow.
+Additionally, each ingredient id used as a key in the predictor's map from ingredient id to its quantity must exist in an identifier column.
+
+As an example, consider the following saline solution data.
+
++-------------------+----------------+---------------+---------+
+| Ingredient id     | water quantity | salt quantity | density |
++===================+================+===============+=========+
+| hypertonic saline | 0.93           | 0.07          | 1.08    |
++-------------------+----------------+---------------+---------+
+| isotonic saline   | 0.99           | 0.01          | 1.01    |
++-------------------+----------------+---------------+---------+
+| water             |                |               | 1.0     |
++-------------------+----------------+---------------+---------+
+| salt              |                |               | 2.16    |
++-------------------+----------------+---------------+---------+
+
+Hypertonic and isotonic saline are mixtures formed by mixing water and salt.
+Ingredient identifiers are given by the first column.
+A CSV data source and :class:`~citrine.informatics.predictors.IngredientsToSimpleMixturePredictor` can be configured to construct simple mixtures from this data via the following:
+
+.. code:: python
+
+    from citrine.informatics.data_sources import CSVDataSource
+    from citrine.informatics.descriptors import FormulationDescriptor, RealDescriptor
+    from citrine.informatics.predictors import IngredientsToSimpleMixturePredictor
+
+    file_link = dataset.files.upload("./saline_solutions.csv", "saline_solutions.csv")
+
+    # create descriptors for each ingredient quantity
+    water_quantity = RealDescriptor('water quantity', 0, 1)
+    salt_quantity = RealDescriptor('salt quantity', 0, 1)
+
+    # create a descriptor to hold density data
+    density = RealDescriptor('density', lower_bound=0, upper_bound=1000, units='g/cc')
+
+    data_source = CsvDataSource(
+        file_link = file_link,
+        column_definitions = {
+            'water quantity': water_quantity,
+            'salt quantity': salt_quantity,
+            'density': density
+        },
+        identifiers=['Ingredient id']
+    )
+
+    # create a descriptor to hold simple mixtures
+    formulation = FormulationDescriptor('simple mixture')
+
+    IngredientsToSimpleMixturePredictor(
+        name='Ingredients to simple mixture predictor',
+        description='Constructs a mixture from ingredient quantities',
+        output=formulation,
+        # map from ingredient id to its quantity
+        id_to_quantity={
+            'water': water_quantity,
+            'salt': salt_quantity
+        },
+        # label water as a solvent and salt a solute
+        labels={
+            'solvent': ['water'],
+            'solute': ['salt']
+        }
     )
 
 Ara Table Data Source

--- a/docs/source/workflows/data_sources.rst
+++ b/docs/source/workflows/data_sources.rst
@@ -63,7 +63,7 @@ That file could be used as the training data for a predictor as:
 
 An optional list of identifiers can be specified.
 Identifiers uniquely identify a row and are used in the context of simple mixtures to link from an ingredient to the its properties.
-Each identifier must correspond to a column header name
+Each identifier must correspond to a column header name.
 No two rows within this column can contain the same value.
 If a column should be parsed as data and used as an identifier, identifier columns may overlap with the keys defined in the mapping from column header names to descriptors.
 

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -222,7 +222,7 @@ For example, the density of a saline solution can be computed from the densities
 
 .. math::
 
-    d_{saline} = d_{water} * f_{water} + d_{salt} + f_{salt}
+    d_{saline} = d_{water} * f_{water} + d_{salt} * f_{salt}
 
 where :math:`d` is density and :math:`f` is relative ingredient fraction.
 If the densities of water and salt are known, we can compute the expected density of a candidate mixture using this predictor.
@@ -263,7 +263,7 @@ Our leaf ingredient data might resemble:
 
 If ``impute_properties == False``, an error will be thrown every time a mixture that includes boric acid is encountered.
 If ``impute_properties == True`` and no ``default_properties`` are specified, an density of :math:`\left( 1.0 + 2.16 \right) / 2 = 1.58` will be used.
-If a value other than 1.58 should be used, e.g. 2.0, this can be specifeid by setting ``default_properties = {'density': 2.0}``.
+If a value other than 1.58 should be used, e.g. 2.0, this can be specified by setting ``default_properties = {'density': 2.0}``.
 
 The example below show how to configure a mean property predictor to compute mean solute density in simple mixtures.
 

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -104,12 +104,15 @@ If an alias isn't defined, the expression argument is expected to match the desc
 
 The syntax is described in the `mXparser documentation <http://mathparser.org/mxparser-math-collection>`_.
 Citrine-python currently supports the following operators and functions:
+
 - basic operators: addition `+`, subtraction `-`, multiplication `*`, division `/`, exponentiation `^`
 - built-in math functions:
+
   - trigonometric: `sin`, `cos`, `tan`, `asin`, `acos`, `atan`
   - hyperbolic: `sinh`, `cosh`, `tanh`
   - logarithm: `log10`, `ln`
   - exponential: `exp`
+
 - constants: `pi`, `e`
 
 The following example demonstrates how to create an :class:`~citrine.informatics.predictors.ExpressionPredictor`.
@@ -134,8 +137,167 @@ The following example demonstrates how to create an :class:`~citrine.informatics
    # register predictor
    predictor = project.predictors.register(shear_modulus_predictor)
 
+Ingredients to simple mixture predictor
+---------------------------------------
+
+The :class:`~citrine.informatics.predictors.IngredientsToSimpleMixturePredictor` constructs a simple mixture from a list of ingredients.
+Ingredients are specified by a map from ingredient id to the descriptor that contains the ingredient's quantity.
+For example, ``{'water': RealDescriptor('water quantity', 0, 1}`` defines an ingredient ``water`` with quantity held by the descriptor ``water quantity``.
+There must be a corresponding (id, quantity) pair in the map for all possible ingredients.
+If a material does not contain data for a given quantity descriptor key it is assumed that ingredient is not present in the mixture.
+
+Let's add another ingredient ``salt`` to our map and say we are given data in the form:
+
++-------------------+----------------+---------------+----------------+
+| Ingredient id     | water quantity | salt quantity | density (g/cc) |
++===================+================+===============+================+
+| hypertonic saline | 0.93           | 0.07          | 1.08           |
++-------------------+----------------+---------------+----------------+
+| isotonic saline   | 0.99           | 0.01          | 1.01           |
++-------------------+----------------+---------------+----------------+
+| water             |                |               | 1.0            |
++-------------------+----------------+---------------+----------------+
+| salt              |                |               | 2.16           |
++-------------------+----------------+---------------+----------------+
+
+There are two mixtures, hypertonic and isotonic saline formed by mixing water and salt together in different amounts.
+(Note, water and salt are leaf ingredients; and, hence these rows do not contain quantity data.)
+Mixtures are defined by a map from ingredient id to quantity, so this predictor would form 2 mixtures with recipes:
+
+.. code:: python
+
+    # hypertonic saline
+    {'water': 0.93, 'salt': 0.07}
+
+    # isotonic saline
+    {'water': 0.99, 'salt': 0.01}
+
+Ingredients may be given 0 or more labels.
+Labels provide a way to group or distinguish one or more ingredients and can be used to featurize mixtures (discussed in the next section).
+The same label may be given to multiple ingredients, and a single ingredient may be given multiple labels.
+Labels are specified using a map from each label to a list of all ingredients that should be given that label.
+Anytime a recipe contains a non-zero amount of labeled ingredient, the ingredient is assigned the label.
+For example, we may wish to label ``water`` as a solute and ``salt`` as a solvent.
+These labels are specified via:
+
+.. code:: python
+
+    labels = {'solvent': ['water'], 'solute': ['salt']}
+
+The following example illustrates how an :class:`~citrine.informatics.predictors.IngredientsToSimpleMixturePredictor` is constructed for the saline example.
+
+.. code:: python
+
+    from citrine.informatics.descriptors import FormulationDescriptor, RealDescriptor
+    from citrine.informatics.predictors import IngredientsToSimpleMixturePredictor
+
+    # create a descriptor to hold simple mixtures
+    formulation = FormulationDescriptor('simple mixture')
+
+    # create descriptors for each ingredient quantity
+    water_quantity = RealDescriptor('water quantity', 0, 1)
+    salt_quantity = RealDescriptor('salt quantity', 0, 1)
+
+    IngredientsToSimpleMixturePredictor(
+        name='Ingredients to simple mixture predictor',
+        description='Constructs a mixture from ingredient quantities',
+        output=formulation,
+        # map from ingredient id to its quantity
+        id_to_quantity={
+            'water': water_quantity,
+            'salt': salt_quantity
+        },
+        # label water as a solvent and salt a solute
+        labels={
+            'solvent': ['water'],
+            'solute': ['salt']
+        }
+    )
+
+Generalized mean property predictor
+-----------------------------------
+
+Often, properties of a mixture are proportional to the properties of it's ingredients.
+For example, the density of a saline solution can be computed from the densities of water and salt multiplied by their respective amounts:
+
+.. math::
+
+    d_{saline} = d_{water} * f_{water} + d_{salt} + f_{salt}
+
+where :math:`d` is density and :math:`f` is relative ingredient fraction.
+If the densities of water and salt are known, we can compute the expected density of a candidate mixture using this predictor.
+
+The :class:`~citrine.informatics.predictors.GeneralizedMeanPropertyPredictor` computes mean properties of simple mixture ingredients.
+To configure a mean property predictor, we must specify:
+
+- an input descriptor that holds the mixture's recipe and ingredient labels
+- a list of properties to featurize
+- the power of the `generalized mean <https://en.wikipedia.org/wiki/Generalized_mean>`_
+- a data source that contains all ingredients and their properties
+- how to handle missing ingredient properties
+
+An optional label may also be specified if the mean should only be computed over ingredients given a specific label.
+
+Missing ingredient properties can be handled one of three ways:
+
+1. If ``impute_properties == False``, an error will be thrown if an ingredient is missing a featurized property.
+   Use this option if you expect ingredient properties to be dense (always present) and would like to be notified when properties are missing.
+2. If ``impute_properties == True`` and no ``default_properties`` are specified, missing properties will be filled in using the average value across the entire dataset.
+   The average is computed from any row with data corresponding to the missing property, regardless of label or material type (i.e. the average is computed from all leaf ingredients and mixtures).
+3. If ``impute_properties == True`` and ``default_properties`` are specified, the specified property value will be used when an ingredient property is missing (instead of the average over the dataset).
+   This allows complete control over what values are imputed.
+   Default properties cannot be specified if ``impute_properties == False`` (because missing properties are not filled in).
+
+For example, say we add boric acid (a common antiseptic) as a possible ingredient to a saline solution but do not know its density.
+Our leaf ingredient data might resemble:
+
++---------------+----------------+
+| Ingredient id | Density (g/cc) |
++===============+================+
+| water         | 1.0            |
++---------------+----------------+
+| salt          | 2.16           |
++---------------+----------------+
+| boric acid    | N/A            |
++---------------+----------------+
+
+If ``impute_properties == False``, an error will be thrown every time a mixture that includes boric acid is encountered.
+If ``impute_properties == True`` and no ``default_properties`` are specified, an density of :math:`\left( 1.0 + 2.16 \right) / 2 = 1.58` will be used.
+If a value other than 1.58 should be used, e.g. 2.0, this can be specifeid by setting ``default_properties = {'density': 2.0}``.
+
+The example below show how to configure a mean property predictor to compute mean solute density in simple mixtures.
+
+.. code:: python
+
+    from citrine.informatics.data_sources import AraTableDataSource
+    from citrine.informatics.descriptors import FormulationDescriptor
+    from citrine.informatics.predictors import GeneralizedMeanPropertyPredictor
+
+    # descriptor that holds simple mixture data
+    formulation = FormulationDescriptor('simple mixture')
+
+    # table with simple mixtures and their ingredients
+    data_source = AraTableDataSource(table_uid, 0)
+
+    GeneralizedMeanPropertyPredictor(
+        name='Mean property predictor',
+        description='Computes 1-mean ingredient properties',
+        input_descriptor=formulation,
+        # featurize ingredient density
+        properties=['density'],
+        # compute the 1-mean
+        p=1,
+        training_data=data_source,
+        # impute ingredient properties, if missing
+        impute_properties=True,
+        # if missing, use with 2.0
+        default_properties={'density': 2.0},
+        # only featurize ingredients labeled as a solute
+        label='solute'
+    )
+
 Predictor Reports
---------------------
+-----------------
 
 A :doc:`predictor report <predictor_reports>` describes a machine-learned model, for example its settings and what features are important to the model. 
 It does not include performance metrics. To learn more about performance metrics, please see :doc:`PerformanceWorkflows <performance_workflows>`.

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -233,6 +233,7 @@ To configure a mean property predictor, we must specify:
 - an input descriptor that holds the mixture's recipe and ingredient labels
 - a list of properties to featurize
 - the power of the `generalized mean <https://en.wikipedia.org/wiki/Generalized_mean>`_
+  (A power of 1 is equivalent to the arithmetic mean, and a power 2 is equivalent to the root mean square.)
 - a data source that contains all ingredients and their properties
 - how to handle missing ingredient properties
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.22.0',
+      version='0.23.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/informatics/data_sources.py
+++ b/src/citrine/informatics/data_sources.py
@@ -56,7 +56,7 @@ class CSVDataSource(Serializable['CSVDataSource'], DataSource):
     identifiers: Optional[List[str]]
         List of one or more column headers whose values uniquely identify a row. These may overlap
         with ``column_definitions`` if a column should be used as data and as an identifier,
-        but this is not necessary. Identifiers should be globally unique. No two rows should
+        but this is not necessary. Identifiers must be unique within a dataset. No two rows can
         contain the same value.
 
     """

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -16,10 +16,11 @@ class Descriptor(PolymorphicSerializable['Descriptor']):
     def get_type(cls, data) -> Type[Serializable]:
         """Return the subtype."""
         return {
-            "Real": RealDescriptor,
-            "Inorganic": ChemicalFormulaDescriptor,
             "Categorical": CategoricalDescriptor,
+            "Formulation": FormulationDescriptor,
+            "Inorganic": ChemicalFormulaDescriptor,
             "Organic": MolecularStructureDescriptor,
+            "Real": RealDescriptor,
         }[data["type"]]
 
 
@@ -159,3 +160,30 @@ class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):
     def __init__(self, key: str, categories: List[str]):
         self.key: str = key
         self.categories: List[str] = categories
+
+
+class FormulationDescriptor(Serializable['FormulationDescriptor'], Descriptor):
+    """[ALPHA] A descriptor to hold formulations.
+
+    Parameters
+    ----------
+    key: str
+        the key corresponding to a descriptor
+
+    """
+
+    key = properties.String('descriptor_key')
+    typ = properties.String('type', default='Formulation', deserializable=False)
+
+    def __eq__(self, other):
+        try:
+            attrs = ["key", "typ"]
+            return all([
+                self.__getattribute__(key) == other.__getattribute__(key) for key in attrs
+            ])
+        except AttributeError:
+            return False
+
+    def __init__(self, key: str):
+        self.key: str = key
+

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -186,4 +186,3 @@ class FormulationDescriptor(Serializable['FormulationDescriptor'], Descriptor):
 
     def __init__(self, key: str):
         self.key: str = key
-

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -13,7 +13,7 @@ from citrine.resources.report import ReportResource
 from citrine.informatics.modules import Module
 
 __all__ = ['ExpressionPredictor', 'GraphPredictor', 'IngredientsToSimpleMixturePredictor',
-           'Predictor', 'SimpleMLPredictor']
+           'Predictor', 'SimpleMLPredictor', 'GeneralizedMeanPropertyPredictor']
 
 
 class Predictor(Module):

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -383,9 +383,9 @@ class GeneralizedMeanPropertyPredictor(
     input_descriptor = _properties.Object(FormulationDescriptor, 'config.input')
     properties = _properties.List(_properties.String, 'config.properties')
     p = _properties.Float('config.p')
-    impute__properties = _properties.Boolean('config.impute_properties')
+    impute_properties = _properties.Boolean('config.impute_properties')
     training_data = _properties.Object(DataSource, 'config.training_data')
-    default__properties = _properties.Optional(
+    default_properties = _properties.Optional(
         _properties.Mapping(_properties.String, _properties.Float), 'config.default_properties')
     label = _properties.Optional(_properties.String, 'config.label')
     typ = _properties.String('config.type', default='GeneralizedMeanProperty',
@@ -407,6 +407,7 @@ class GeneralizedMeanPropertyPredictor(
                  description: str,
                  input_descriptor: FormulationDescriptor,
                  properties: List[str],
+                 p: float,
                  impute_properties: bool,
                  training_data: DataSource,
                  default_properties: Optional[Dict[str, float]] = None,
@@ -418,6 +419,7 @@ class GeneralizedMeanPropertyPredictor(
         self.description: str = description
         self.input_descriptor: FormulationDescriptor = input_descriptor
         self.properties: List[str] = properties
+        self.p: float = p
         self.impute_properties: bool = impute_properties
         self.training_data = training_data
         self.default_properties: Optional[Dict[str, float]] = default_properties

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -1,7 +1,5 @@
 """Tools for working with Predictors."""
 # flake8: noqa
-from typing import List, Optional, Type, Union
-from abc import abstractmethod
 from typing import Dict, List, Optional, Type, Union
 from uuid import UUID
 
@@ -9,8 +7,8 @@ from citrine._serialization import properties as _properties
 from citrine._serialization.serializable import Serializable
 from citrine._session import Session
 from citrine.informatics.data_sources import DataSource
-from citrine.informatics.descriptors import Descriptor, FormulationDescriptor, RealDescriptor
-from citrine.informatics.descriptors import Descriptor, MolecularStructureDescriptor
+from citrine.informatics.descriptors import Descriptor, FormulationDescriptor, RealDescriptor, \
+    MolecularStructureDescriptor
 from citrine.informatics.reports import Report
 from citrine.resources.report import ReportResource
 from citrine.informatics.modules import Module
@@ -272,10 +270,6 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
     def __str__(self):
         return '<ExpressionPredictor {!r}>'.format(self.name)
 
-    def post_build(self, project_id: UUID, data: dict):
-        """Creates the predictor report object."""
-        self.report = ReportResource(project_id, self.session).get(data['id'])
-
 
 class MolecularStructureFeaturizer(Serializable['MolecularStructureFeaturizer'], Predictor):
     """
@@ -384,10 +378,6 @@ class MolecularStructureFeaturizer(Serializable['MolecularStructureFeaturizer'],
     def __str__(self):
         return '<MolecularStructureFeaturizer {!r}>'.format(self.name)
 
-    def post_build(self, project_id: UUID, data: dict):
-        """Creates the predictor report object."""
-        self.report = ReportResource(project_id, self.session).get(data['id'])
-
 
 class IngredientsToSimpleMixturePredictor(
         Serializable['IngredientsToSimpleMixturePredictor'], Predictor):
@@ -456,10 +446,6 @@ class IngredientsToSimpleMixturePredictor(
 
     def __str__(self):
         return '<IngredientsToSimpleMixturePredictor {!r}>'.format(self.name)
-
-    def post_build(self, project_id: UUID, data: dict):
-        """Creates the predictor report object."""
-        self.report = ReportResource(project_id, self.session).get(data['id'])
 
 
 class GeneralizedMeanPropertyPredictor(
@@ -556,7 +542,3 @@ class GeneralizedMeanPropertyPredictor(
 
     def __str__(self):
         return '<GeneralizedMeanPropertyPredictor {!r}>'.format(self.name)
-
-    def post_build(self, project_id: UUID, data: dict):
-        """Creates the predictor report object."""
-        self.report = ReportResource(project_id, self.session).get(data['id'])

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -1,19 +1,19 @@
 """Tools for working with Predictors."""
 from abc import abstractmethod
-from typing import List, Optional, Type, Union
+from typing import Dict, List, Optional, Type, Union
 from uuid import UUID
 
-from citrine._serialization import properties
+from citrine._serialization import properties as _properties
 from citrine._serialization.serializable import Serializable
 from citrine._session import Session
 from citrine.informatics.data_sources import DataSource
-from citrine.informatics.descriptors import Descriptor
+from citrine.informatics.descriptors import Descriptor, FormulationDescriptor, RealDescriptor
 from citrine.informatics.reports import Report
 from citrine.resources.report import ReportResource
 from citrine.informatics.modules import Module
 
-
-__all__ = ['ExpressionPredictor', 'GraphPredictor', 'Predictor', 'SimpleMLPredictor']
+__all__ = ['ExpressionPredictor', 'GraphPredictor', 'IngredientsToSimpleMixturePredictor', 'Predictor',
+           'SimpleMLPredictor']
 
 
 class Predictor(Module):
@@ -37,6 +37,8 @@ class Predictor(Module):
             "Simple": SimpleMLPredictor,
             "Graph": GraphPredictor,
             "Expression": ExpressionPredictor,
+            "IngredientsToSimpleMixture": IngredientsToSimpleMixturePredictor,
+            "GeneralizedMeanProperty": GeneralizedMeanPropertyPredictor,
         }
         typ = type_dict.get(data['config']['type'])
 
@@ -73,25 +75,25 @@ class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
 
     """
 
-    uid = properties.Optional(properties.UUID, 'id', serializable=False)
-    name = properties.String('config.name')
-    description = properties.Optional(properties.String(), 'config.description')
-    inputs = properties.List(properties.Object(Descriptor), 'config.inputs')
-    outputs = properties.List(properties.Object(Descriptor), 'config.outputs')
-    latent_variables = properties.List(properties.Object(Descriptor), 'config.latent_variables')
-    training_data = properties.Object(DataSource, 'config.training_data')
-    typ = properties.String('config.type', default='Simple', deserializable=False)
-    status = properties.Optional(properties.String(), 'status', serializable=False)
-    status_info = properties.Optional(
-        properties.List(properties.String()),
+    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
+    name = _properties.String('config.name')
+    description = _properties.Optional(_properties.String(), 'config.description')
+    inputs = _properties.List(_properties.Object(Descriptor), 'config.inputs')
+    outputs = _properties.List(_properties.Object(Descriptor), 'config.outputs')
+    latent_variables = _properties.List(_properties.Object(Descriptor), 'config.latent_variables')
+    training_data = _properties.Object(DataSource, 'config.training_data')
+    typ = _properties.String('config.type', default='Simple', deserializable=False)
+    status = _properties.Optional(_properties.String(), 'status', serializable=False)
+    status_info = _properties.Optional(
+        _properties.List(_properties.String()),
         'status_info',
         serializable=False
     )
-    active = properties.Boolean('active', default=True)
+    active = _properties.Boolean('active', default=True)
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
-    module_type = properties.String('module_type', default='PREDICTOR')
-    schema_id = properties.UUID('schema_id', default=UUID('08d20e5f-e329-4de0-a90a-4b5e36b91703'))
+    module_type = _properties.String('module_type', default='PREDICTOR')
+    schema_id = _properties.UUID('schema_id', default=UUID('08d20e5f-e329-4de0-a90a-4b5e36b91703'))
 
     def __init__(self,
                  name: str,
@@ -139,25 +141,25 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
 
     """
 
-    uid = properties.Optional(properties.UUID, 'id', serializable=False)
-    name = properties.String('config.name')
-    description = properties.String('config.description')
-    predictors = properties.List(properties.Union(
-        [properties.UUID, properties.Object(Predictor)]), 'config.predictors')
-    typ = properties.String('config.type', default='Graph', deserializable=False)
+    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
+    name = _properties.String('config.name')
+    description = _properties.String('config.description')
+    predictors = _properties.List(_properties.Union(
+        [_properties.UUID, _properties.Object(Predictor)]), 'config.predictors')
+    typ = _properties.String('config.type', default='Graph', deserializable=False)
     # Graph predictors may not be embedded in other predictors, hence while status is optional
     # for deserializing most predictors, it is required for deserializing a graph
-    status = properties.String('status', serializable=False)
-    status_info = properties.Optional(
-        properties.List(properties.String()),
+    status = _properties.String('status', serializable=False)
+    status_info = _properties.Optional(
+        _properties.List(_properties.String()),
         'status_info',
         serializable=False
     )
-    active = properties.Boolean('active', default=True)
+    active = _properties.Boolean('active', default=True)
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
-    module_type = properties.String('module_type', default='PREDICTOR')
-    schema_id = properties.UUID('schema_id', default=UUID('43c61ad4-7e33-45d0-a3de-504acb4e0737'))
+    module_type = _properties.String('module_type', default='PREDICTOR')
+    schema_id = _properties.UUID('schema_id', default=UUID('43c61ad4-7e33-45d0-a3de-504acb4e0737'))
 
     def __init__(self,
                  name: str,
@@ -225,24 +227,24 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
 
     """
 
-    uid = properties.Optional(properties.UUID, 'id', serializable=False)
-    name = properties.String('config.name')
-    description = properties.String('config.description')
-    expression = properties.String('config.expression')
-    output = properties.Object(Descriptor, 'config.output')
-    aliases = properties.Mapping(properties.String, properties.String, 'config.aliases')
-    typ = properties.String('config.type', default='Expression', deserializable=False)
-    status = properties.Optional(properties.String(), 'status', serializable=False)
-    status_info = properties.Optional(
-        properties.List(properties.String()),
+    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
+    name = _properties.String('config.name')
+    description = _properties.String('config.description')
+    expression = _properties.String('config.expression')
+    output = _properties.Object(Descriptor, 'config.output')
+    aliases = _properties.Mapping(_properties.String, _properties.String, 'config.aliases')
+    typ = _properties.String('config.type', default='Expression', deserializable=False)
+    status = _properties.Optional(_properties.String(), 'status', serializable=False)
+    status_info = _properties.Optional(
+        _properties.List(_properties.String()),
         'status_info',
         serializable=False
     )
-    active = properties.Boolean('active', default=True)
+    active = _properties.Boolean('active', default=True)
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
-    module_type = properties.String('module_type', default='PREDICTOR')
-    schema_id = properties.UUID('schema_id', default=UUID('866e72a6-0a01-4c5f-8c35-146eb2540166'))
+    module_type = _properties.String('module_type', default='PREDICTOR')
+    schema_id = _properties.UUID('schema_id', default=UUID('866e72a6-0a01-4c5f-8c35-146eb2540166'))
 
     def __init__(self,
                  name: str,
@@ -268,6 +270,163 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
 
     def __str__(self):
         return '<ExpressionPredictor {!r}>'.format(self.name)
+
+    def post_build(self, project_id: UUID, data: dict):
+        """Creates the predictor report object."""
+        self.report = ReportResource(project_id, self.session).get(data['id'])
+
+
+class IngredientsToSimpleMixturePredictor(Serializable['IngredientsToSimpleMixturePredictor'], Predictor):
+    """[ALPHA] A predictor interface that constructs a simple mixture from ingredient quantities.
+
+    Parameters
+    ----------
+    name: str
+        name of the configuration
+    description: str
+        description of the predictor
+    output: FormulationDescriptor
+        descriptor that represents the output formulation
+    id_to_quantity: Dict[str, RealDescriptor]
+        Map from ingredient identifier to the descriptor that represents its quantity,
+        e.g. ``{'water': RealDescriptor('water quantity', 0, 1)}``
+    labels: Dict[str, List[str]]
+        Map from each label to all components assigned that label, when present in a mixture,
+        e.g. ``{'solvent': ['water']}``
+
+    """
+
+    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
+    name = _properties.String('config.name')
+    description = _properties.String('config.description')
+    output = _properties.Object(FormulationDescriptor, 'config.output')
+    id_to_quantity = _properties.Mapping(_properties.String, _properties.Object(RealDescriptor),
+                                         'config.id_to_quantity')
+    labels = _properties.Mapping(_properties.String, _properties.List(_properties.String), 'config.labels')
+    typ = _properties.String('config.type', default='IngredientsToSimpleMixture', deserializable=False)
+    status = _properties.Optional(_properties.String(), 'status', serializable=False)
+    status_info = _properties.Optional(
+        _properties.List(_properties.String()),
+        'status_info',
+        serializable=False
+    )
+    active = _properties.Boolean('active', default=True)
+
+    # NOTE: These could go here or in _post_dump - it's unclear which is better right now
+    module_type = _properties.String('module_type', default='PREDICTOR')
+    schema_id = _properties.UUID('schema_id', default=UUID('873e4541-da8a-4698-a981-732c0c729c3d'))
+
+    def __init__(self,
+                 name: str,
+                 description: str,
+                 output: FormulationDescriptor,
+                 id_to_quantity: Dict[str, RealDescriptor],
+                 labels: Dict[str, List[str]],
+                 session: Optional[Session] = None,
+                 report: Optional[Report] = None,
+                 active: bool = True):
+        self.name: str = name
+        self.description: str = description
+        self.output: FormulationDescriptor = output
+        self.id_to_quantity: Dict[str, RealDescriptor] = id_to_quantity
+        self.labels: Dict[str, List[str]] = labels
+        self.session: Optional[Session] = session
+        self.report: Optional[Report] = report
+        self.active: bool = active
+
+    def _post_dump(self, data: dict) -> dict:
+        data['display_name'] = data['config']['name']
+        return data
+
+    def __str__(self):
+        return '<IngredientsToSimpleMixturePredictor {!r}>'.format(self.name)
+
+    def post_build(self, project_id: UUID, data: dict):
+        """Creates the predictor report object."""
+        self.report = ReportResource(project_id, self.session).get(data['id'])
+
+
+class GeneralizedMeanPropertyPredictor(Serializable['GeneralizedMeanPropertyPredictor'], Predictor):
+    """[ALPHA] A predictor interface that mean component properties.
+
+    Parameters
+    ----------
+    name: str
+        name of the configuration
+    description: str
+        description of the predictor
+    input_descriptor: FormulationDescriptor
+        descriptor that represents the input formulation
+    properties: List[str]
+        List of component properties to featurize
+    p: float
+        Power of the generalized mean
+    impute_properties: bool
+        Whether to impute missing component properties
+    training_data: DataSource
+        Source of the training data, which can be either a CSV or an Ara table
+    label: Optional[str]
+        Optional label
+    default_properties: Optional[Dict[str, float]]
+        Default values to use for imputed properties. ``impute_properties`` must be ``True``
+        Defaults are specified as a map from descriptor key to its default value.
+
+    """
+
+    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
+    name = _properties.String('config.name')
+    description = _properties.String('config.description')
+    input_descriptor = _properties.Object(FormulationDescriptor, 'config.input')
+    properties = _properties.List(_properties.String, 'config.properties')
+    p = _properties.Float('config.p')
+    impute__properties = _properties.Boolean('config.impute_properties')
+    training_data = _properties.Object(DataSource, 'config.training_data')
+    default__properties = _properties.Optional(_properties.Mapping(_properties.String, _properties.Float),
+                                               'config.default_properties')
+    label = _properties.Optional(_properties.String, 'config.label')
+    typ = _properties.String('config.type', default='GeneralizedMeanProperty', deserializable=False)
+    status = _properties.Optional(_properties.String(), 'status', serializable=False)
+    status_info = _properties.Optional(
+        _properties.List(_properties.String()),
+        'status_info',
+        serializable=False
+    )
+    active = _properties.Boolean('active', default=True)
+
+    # NOTE: These could go here or in _post_dump - it's unclear which is better right now
+    module_type = _properties.String('module_type', default='PREDICTOR')
+    schema_id = _properties.UUID('schema_id', default=UUID('29e53222-3217-4f81-b3b8-4197a8211ade'))
+
+    def __init__(self,
+                 name: str,
+                 description: str,
+                 input_descriptor: FormulationDescriptor,
+                 properties: List[str],
+                 impute_properties: bool,
+                 training_data: DataSource,
+                 default_properties: Optional[Dict[str, float]] = None,
+                 label: Optional[str] = None,
+                 session: Optional[Session] = None,
+                 report: Optional[Report] = None,
+                 active: bool = True):
+        self.name: str = name
+        self.description: str = description
+        self.input_descriptor: FormulationDescriptor = input_descriptor
+        self.properties: List[str] = properties
+        self.impute_properties: bool = impute_properties
+        self.training_data = training_data
+        self.default_properties: Optional[Dict[str, float]] = default_properties
+        self.label: Optional[str] = label
+        self.session: Optional[Session] = session
+        self.report: Optional[Report] = report
+        self.active: bool = active
+
+    def _post_dump(self, data: dict) -> dict:
+        data['display_name'] = data['config']['name']
+        return data
+
+    def __str__(self):
+        return '<GeneralizedMeanPropertyPredictor {!r}>'.format(self.name)
 
     def post_build(self, project_id: UUID, data: dict):
         """Creates the predictor report object."""

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -351,7 +351,7 @@ class IngredientsToSimpleMixturePredictor(
 
 class GeneralizedMeanPropertyPredictor(
         Serializable['GeneralizedMeanPropertyPredictor'], Predictor):
-    """[ALPHA] A predictor interface that mean component properties.
+    """[ALPHA] A predictor interface that computes generalized mean component properties.
 
     Parameters
     ----------
@@ -390,9 +390,9 @@ class GeneralizedMeanPropertyPredictor(
     label = _properties.Optional(_properties.String, 'config.label')
     typ = _properties.String('config.type', default='GeneralizedMeanProperty',
                              deserializable=False)
-    status = _properties.Optional(_properties.String(), 'status', serializable=False)
+    status = _properties.Optional(_properties.String, 'status', serializable=False)
     status_info = _properties.Optional(
-        _properties.List(_properties.String()),
+        _properties.List(_properties.String),
         'status_info',
         serializable=False
     )

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -12,8 +12,8 @@ from citrine.informatics.reports import Report
 from citrine.resources.report import ReportResource
 from citrine.informatics.modules import Module
 
-__all__ = ['ExpressionPredictor', 'GraphPredictor', 'IngredientsToSimpleMixturePredictor', 'Predictor',
-           'SimpleMLPredictor']
+__all__ = ['ExpressionPredictor', 'GraphPredictor', 'IngredientsToSimpleMixturePredictor',
+           'Predictor', 'SimpleMLPredictor']
 
 
 class Predictor(Module):
@@ -276,7 +276,8 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
         self.report = ReportResource(project_id, self.session).get(data['id'])
 
 
-class IngredientsToSimpleMixturePredictor(Serializable['IngredientsToSimpleMixturePredictor'], Predictor):
+class IngredientsToSimpleMixturePredictor(
+        Serializable['IngredientsToSimpleMixturePredictor'], Predictor):
     """[ALPHA] A predictor interface that constructs a simple mixture from ingredient quantities.
 
     Parameters
@@ -302,8 +303,10 @@ class IngredientsToSimpleMixturePredictor(Serializable['IngredientsToSimpleMixtu
     output = _properties.Object(FormulationDescriptor, 'config.output')
     id_to_quantity = _properties.Mapping(_properties.String, _properties.Object(RealDescriptor),
                                          'config.id_to_quantity')
-    labels = _properties.Mapping(_properties.String, _properties.List(_properties.String), 'config.labels')
-    typ = _properties.String('config.type', default='IngredientsToSimpleMixture', deserializable=False)
+    labels = _properties.Mapping(_properties.String, _properties.List(_properties.String),
+                                 'config.labels')
+    typ = _properties.String('config.type', default='IngredientsToSimpleMixture',
+                             deserializable=False)
     status = _properties.Optional(_properties.String(), 'status', serializable=False)
     status_info = _properties.Optional(
         _properties.List(_properties.String()),
@@ -346,7 +349,8 @@ class IngredientsToSimpleMixturePredictor(Serializable['IngredientsToSimpleMixtu
         self.report = ReportResource(project_id, self.session).get(data['id'])
 
 
-class GeneralizedMeanPropertyPredictor(Serializable['GeneralizedMeanPropertyPredictor'], Predictor):
+class GeneralizedMeanPropertyPredictor(
+        Serializable['GeneralizedMeanPropertyPredictor'], Predictor):
     """[ALPHA] A predictor interface that mean component properties.
 
     Parameters
@@ -381,10 +385,11 @@ class GeneralizedMeanPropertyPredictor(Serializable['GeneralizedMeanPropertyPred
     p = _properties.Float('config.p')
     impute__properties = _properties.Boolean('config.impute_properties')
     training_data = _properties.Object(DataSource, 'config.training_data')
-    default__properties = _properties.Optional(_properties.Mapping(_properties.String, _properties.Float),
-                                               'config.default_properties')
+    default__properties = _properties.Optional(
+        _properties.Mapping(_properties.String, _properties.Float), 'config.default_properties')
     label = _properties.Optional(_properties.String, 'config.label')
-    typ = _properties.String('config.type', default='GeneralizedMeanProperty', deserializable=False)
+    typ = _properties.String('config.type', default='GeneralizedMeanProperty',
+                             deserializable=False)
     status = _properties.Optional(_properties.String(), 'status', serializable=False)
     status_info = _properties.Optional(
         _properties.List(_properties.String()),

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -383,8 +383,8 @@ class GeneralizedMeanPropertyPredictor(
     input_descriptor = _properties.Object(FormulationDescriptor, 'config.input')
     properties = _properties.List(_properties.String, 'config.properties')
     p = _properties.Float('config.p')
-    impute_properties = _properties.Boolean('config.impute_properties')
     training_data = _properties.Object(DataSource, 'config.training_data')
+    impute_properties = _properties.Boolean('config.impute_properties')
     default_properties = _properties.Optional(
         _properties.Mapping(_properties.String, _properties.Float), 'config.default_properties')
     label = _properties.Optional(_properties.String, 'config.label')
@@ -408,8 +408,8 @@ class GeneralizedMeanPropertyPredictor(
                  input_descriptor: FormulationDescriptor,
                  properties: List[str],
                  p: float,
-                 impute_properties: bool,
                  training_data: DataSource,
+                 impute_properties: bool,
                  default_properties: Optional[Dict[str, float]] = None,
                  label: Optional[str] = None,
                  session: Optional[Session] = None,
@@ -420,8 +420,8 @@ class GeneralizedMeanPropertyPredictor(
         self.input_descriptor: FormulationDescriptor = input_descriptor
         self.properties: List[str] = properties
         self.p: float = p
-        self.impute_properties: bool = impute_properties
         self.training_data = training_data
+        self.impute_properties: bool = impute_properties
         self.default_properties: Optional[Dict[str, float]] = default_properties
         self.label: Optional[str] = label
         self.session: Optional[Session] = session

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -366,14 +366,23 @@ class GeneralizedMeanPropertyPredictor(
     p: float
         Power of the generalized mean
     impute_properties: bool
-        Whether to impute missing component properties
+        Whether to impute missing ingredient properties.
+        If ``False`` an error is thrown when a missing ingredient property is encountered.
+        If ``True`` and no ``default_properties`` are specified, then the average over the
+        entire dataset is used.
+        If ``True`` and a default is specified in ``default_properties``, then the specified
+        default is used in place of missing values.
     training_data: DataSource
         Source of the training data, which can be either a CSV or an Ara table
     label: Optional[str]
         Optional label
     default_properties: Optional[Dict[str, float]]
-        Default values to use for imputed properties. ``impute_properties`` must be ``True``
+        Default values to use for imputed properties.
         Defaults are specified as a map from descriptor key to its default value.
+        If not specified and ``impute_properties == True`` the average over the entire dataset
+        will be used to fill in missing values. Any specified defaults will be used in place of
+        the average over the dataset. ``impute_properties`` must be ``True`` if
+        ``default_properties`` are provided.
 
     """
 

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -292,7 +292,7 @@ class IngredientsToSimpleMixturePredictor(
         Map from ingredient identifier to the descriptor that represents its quantity,
         e.g. ``{'water': RealDescriptor('water quantity', 0, 1)}``
     labels: Dict[str, List[str]]
-        Map from each label to all components assigned that label, when present in a mixture,
+        Map from each label to all ingredients assigned that label, when present in a mixture,
         e.g. ``{'solvent': ['water']}``
 
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,8 +231,8 @@ def valid_generalized_mean_property_predictor_data():
             input=FormulationDescriptor('simple mixture').dump(),
             properties=['density'],
             p=2,
-            impute_properties=True,
             training_data=AraTableDataSource(uuid.uuid4(), 0).dump(),
+            impute_properties=True,
             default_properties={'density': 1.0},
             label='solvent'
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,6 +183,63 @@ def valid_expression_predictor_data():
 
 
 @pytest.fixture
+def valid_ing_to_simple_mixture_predictor_data():
+    """Produce valid data used for tests."""
+    from citrine.informatics.descriptors import FormulationDescriptor, RealDescriptor
+    return dict(
+        module_type='PREDICTOR',
+        status='VALID',
+        status_info=[],
+        active=True,
+        display_name='Ingredients to simple mixture predictor',
+        schema_id='873e4541-da8a-4698-a981-732c0c729c3d',
+        id=str(uuid.uuid4()),
+        config=dict(
+            type='IngredientsToSimpleMixture',
+            name='Ingredients to simple mixture predictor',
+            description='Constructs mixtures from ingredients',
+            output=FormulationDescriptor('simple mixture').dump(),
+            id_to_quantity={
+                'water': RealDescriptor('water quantity', 0, 1).dump(),
+                'salt': RealDescriptor('salt quantity', 0, 1).dump()
+            },
+            labels={
+                'solvent': ['water'],
+                'solute': ['salt'],
+            }
+        )
+    )
+
+
+@pytest.fixture
+def valid_generalized_mean_property_predictor_data():
+    """Produce valid data used for tests."""
+    from citrine.informatics.descriptors import FormulationDescriptor
+    from citrine.informatics.data_sources import AraTableDataSource
+    return dict(
+        module_type='PREDICTOR',
+        status='VALID',
+        status_info=[],
+        active=True,
+        display_name='Mean property predictor',
+        schema_id='29e53222-3217-4f81-b3b8-4197a8211ade',
+        id=str(uuid.uuid4()),
+        config=dict(
+            type='GeneralizedMeanProperty',
+            name='Mean property predictor',
+            description='Computes mean ingredient properties',
+            input=FormulationDescriptor('simple mixture').dump(),
+            properties=['density'],
+            p=2,
+            impute_properties=True,
+            training_data=AraTableDataSource(uuid.uuid4(), 0).dump(),
+            default_properties={'density': 1.0},
+            label='solvent'
+        )
+    )
+
+
+@pytest.fixture
 def invalid_predictor_data():
     """Produce valid data used for tests."""
     from citrine.informatics.descriptors import RealDescriptor

--- a/tests/informatics/test_descriptors.py
+++ b/tests/informatics/test_descriptors.py
@@ -10,7 +10,8 @@ from citrine.informatics.descriptors import InorganicDescriptor
     ChemicalFormulaDescriptor('formula'),
     MolecularStructureDescriptor("organic"),
     CategoricalDescriptor("my categorical", ["a", "b"]),
-    CategoricalDescriptor("categorical", ["*"])
+    CategoricalDescriptor("categorical", ["*"]),
+    FormulationDescriptor("formulation")
 ])
 def descriptor(request):
     return request.param

--- a/tests/informatics/test_predictors.py
+++ b/tests/informatics/test_predictors.py
@@ -4,13 +4,18 @@ import pytest
 import uuid
 
 from citrine.informatics.data_sources import AraTableDataSource
-from citrine.informatics.descriptors import RealDescriptor
-from citrine.informatics.predictors import ExpressionPredictor, GraphPredictor, SimpleMLPredictor
+from citrine.informatics.descriptors import RealDescriptor, FormulationDescriptor
+from citrine.informatics.predictors import ExpressionPredictor, GeneralizedMeanPropertyPredictor, GraphPredictor, \
+    SimpleMLPredictor, IngredientsToSimpleMixturePredictor
 
 x = RealDescriptor("x", 0, 100, "")
 y = RealDescriptor("y", 0, 100, "")
 z = RealDescriptor("z", 0, 100, "")
 shear_modulus = RealDescriptor('Property~Shear modulus', lower_bound=0, upper_bound=100, units='GPa')
+formulation = FormulationDescriptor('formulation')
+water_quantity = RealDescriptor('water quantity', 0, 1)
+salt_quantity = RealDescriptor('salt quantity', 0, 1)
+data_source = AraTableDataSource(uuid.UUID('e5c51369-8e71-4ec6-b027-1f92bdc14762'), 0)
 
 
 @pytest.fixture
@@ -21,7 +26,7 @@ def simple_predictor() -> SimpleMLPredictor:
                              inputs=[x],
                              outputs=[z],
                              latent_variables=[y],
-                             training_data=AraTableDataSource(uuid.UUID('e5c51369-8e71-4ec6-b027-1f92bdc14762'), 0))
+                             training_data=data_source)
 
 
 @pytest.fixture
@@ -38,14 +43,47 @@ def expression_predictor() -> ExpressionPredictor:
         description='Computes shear modulus from Youngs modulus and Poissons ratio',
         expression='Y / (2 * (1 + v))',
         output=shear_modulus,
-        aliases = {
-             'Y': "Property~Young's modulus",
-             'v': "Property~Poisson's ratio"
+        aliases={
+            'Y': "Property~Young's modulus",
+            'v': "Property~Poisson's ratio"
         })
 
 
+@pytest.fixture
+def ing_to_simple_mixture_predictor() -> IngredientsToSimpleMixturePredictor:
+    """Build an IngredientsToSimpleMixturePredictor for testing."""
+    return IngredientsToSimpleMixturePredictor(
+        name='Ingredients to simple mixture predictor',
+        description='Constructs a mixture from ingredient quantities',
+        output=formulation,
+        id_to_quantity={
+            'water': water_quantity,
+            'salt': salt_quantity
+        },
+        labels={
+            'solvent': ['water'],
+            'solute': ['salt']
+        }
+    )
+
+
+@pytest.fixture
+def generalized_mean_property_predictor() -> GeneralizedMeanPropertyPredictor:
+    """Build a mean property predictor for testing."""
+    return GeneralizedMeanPropertyPredictor(
+        name='Mean property predictor',
+        description='Computes mean component properties',
+        input_descriptor=formulation,
+        properties=['density'],
+        impute_properties=True,
+        training_data=data_source,
+        default_properties={'density': 1.0},
+        label='solvent'
+    )
+
+
 def test_simple_initialization(simple_predictor):
-    """Make sure the correct fields go to the correct places for the Simple Predictor."""
+    """Make sure the correct fields go to the correct places for a simple predictor."""
     assert simple_predictor.name == 'ML predictor'
     assert simple_predictor.description == 'Predicts z from input x and latent variable y'
     assert len(simple_predictor.inputs) == 1
@@ -72,7 +110,7 @@ def test_simple_post_build(simple_predictor):
 
 
 def test_graph_initialization(graph_predictor):
-    """Make sure the correct fields go to the correct places for the Graph Predictor."""
+    """Make sure the correct fields go to the correct places for a graph predictor."""
     assert graph_predictor.name == 'Graph predictor'
     assert graph_predictor.description == 'description'
     assert len(graph_predictor.predictors) == 2
@@ -92,7 +130,7 @@ def test_graph_post_build(graph_predictor):
 
 
 def test_expression_initialization(expression_predictor):
-    """Make sure the correct fields go to the correct places for the Expression Predictor."""
+    """Make sure the correct fields go to the correct places for an expression predictor."""
     assert expression_predictor.name == 'Expression predictor'
     assert expression_predictor.output.key == 'Property~Shear modulus'
     assert expression_predictor.expression == 'Y / (2 * (1 + v))'
@@ -101,7 +139,7 @@ def test_expression_initialization(expression_predictor):
 
 
 def test_expression_post_build(expression_predictor):
-    """Ensures we get a report from a expression predictor post_build call."""
+    """Ensures we get a report from an expression predictor post_build call."""
     assert expression_predictor.report is None
     session = mock.Mock()
     session.get_resource.return_value = dict(status='OK', report=dict(), uid=uuid.uuid4())
@@ -110,3 +148,50 @@ def test_expression_post_build(expression_predictor):
     assert session.get_resource.call_count == 1
     assert expression_predictor.report is not None
     assert expression_predictor.report.status == 'OK'
+
+
+def test_ing_to_simple_mixture_initialization(ing_to_simple_mixture_predictor):
+    """Make sure the correct fields go to the correct places for an ingredients to simple mixture predictor."""
+    assert ing_to_simple_mixture_predictor.name == 'Ingredients to simple mixture predictor'
+    assert ing_to_simple_mixture_predictor.output.key == 'formulation'
+    assert ing_to_simple_mixture_predictor.id_to_quantity == {'water': water_quantity, 'salt': salt_quantity}
+    assert ing_to_simple_mixture_predictor.labels == {'solvent': ['water'], 'solute': ['salt']}
+    expected_str = '<IngredientsToSimpleMixturePredictor \'Ingredients to simple mixture predictor\'>'
+    assert str(ing_to_simple_mixture_predictor) == expected_str
+
+
+def test_ing_to_simple_mixture_post_build(ing_to_simple_mixture_predictor):
+    """Ensures we get a report from an ingredients to simple mixture predictor post_build call."""
+    assert ing_to_simple_mixture_predictor.report is None
+    session = mock.Mock()
+    session.get_resource.return_value = dict(status='OK', report=dict(), uid=uuid.uuid4())
+    ing_to_simple_mixture_predictor.session = session
+    ing_to_simple_mixture_predictor.post_build(uuid.uuid4(), dict(id=uuid.uuid4()))
+    assert session.get_resource.call_count == 1
+    assert ing_to_simple_mixture_predictor.report is not None
+    assert ing_to_simple_mixture_predictor.report.status == 'OK'
+
+
+def test_generalized_mean_property_initialization(generalized_mean_property_predictor):
+    """Make sure the correct fields go to the correct places for a mean property predictor."""
+    assert generalized_mean_property_predictor.name == 'Mean property predictor'
+    assert generalized_mean_property_predictor.input_descriptor.key == 'formulation'
+    assert generalized_mean_property_predictor.properties == ['density']
+    assert generalized_mean_property_predictor.impute_properties == True
+    assert generalized_mean_property_predictor.training_data == data_source
+    assert generalized_mean_property_predictor.default_properties == {'density': 1.0}
+    assert generalized_mean_property_predictor.label == 'solvent'
+    expected_str = '<GeneralizedMeanPropertyPredictor \'Mean property predictor\'>'
+    assert str(generalized_mean_property_predictor) == expected_str
+
+
+def test_generalized_mean_property_post_build(generalized_mean_property_predictor):
+    """Ensures we get a report from a mean property predictor post_build call."""
+    assert generalized_mean_property_predictor.report is None
+    session = mock.Mock()
+    session.get_resource.return_value = dict(status='OK', report=dict(), uid=uuid.uuid4())
+    generalized_mean_property_predictor.session = session
+    generalized_mean_property_predictor.post_build(uuid.uuid4(), dict(id=uuid.uuid4()))
+    assert session.get_resource.call_count == 1
+    assert generalized_mean_property_predictor.report is not None
+    assert generalized_mean_property_predictor.report.status == 'OK'

--- a/tests/informatics/test_predictors.py
+++ b/tests/informatics/test_predictors.py
@@ -72,12 +72,12 @@ def generalized_mean_property_predictor() -> GeneralizedMeanPropertyPredictor:
     """Build a mean property predictor for testing."""
     return GeneralizedMeanPropertyPredictor(
         name='Mean property predictor',
-        description='Computes mean component properties',
+        description='Computes mean ingredient properties',
         input_descriptor=formulation,
         properties=['density'],
         p=2,
-        impute_properties=True,
         training_data=data_source,
+        impute_properties=True,
         default_properties={'density': 1.0},
         label='solvent'
     )

--- a/tests/informatics/test_predictors.py
+++ b/tests/informatics/test_predictors.py
@@ -75,6 +75,7 @@ def generalized_mean_property_predictor() -> GeneralizedMeanPropertyPredictor:
         description='Computes mean component properties',
         input_descriptor=formulation,
         properties=['density'],
+        p=2,
         impute_properties=True,
         training_data=data_source,
         default_properties={'density': 1.0},
@@ -177,6 +178,7 @@ def test_generalized_mean_property_initialization(generalized_mean_property_pred
     assert generalized_mean_property_predictor.name == 'Mean property predictor'
     assert generalized_mean_property_predictor.input_descriptor.key == 'formulation'
     assert generalized_mean_property_predictor.properties == ['density']
+    assert generalized_mean_property_predictor.p == 2
     assert generalized_mean_property_predictor.impute_properties == True
     assert generalized_mean_property_predictor.training_data == data_source
     assert generalized_mean_property_predictor.default_properties == {'density': 1.0}

--- a/tests/serialization/test_predictors.py
+++ b/tests/serialization/test_predictors.py
@@ -3,7 +3,8 @@ import pytest
 from uuid import UUID
 from copy import deepcopy
 
-from citrine.informatics.predictors import ExpressionPredictor, GraphPredictor, Predictor, SimpleMLPredictor
+from citrine.informatics.predictors import ExpressionPredictor, GeneralizedMeanPropertyPredictor, \
+    GraphPredictor, Predictor, SimpleMLPredictor, IngredientsToSimpleMixturePredictor
 from citrine.informatics.descriptors import RealDescriptor
 
 
@@ -64,6 +65,22 @@ def test_expression_serialization(valid_expression_predictor_data):
     serialized = predictor.dump()
     serialized['id'] = valid_expression_predictor_data['id']
     assert serialized == valid_serialization_output(valid_expression_predictor_data)
+
+
+def test_ing_to_simple_mixture_serialization(valid_ing_to_simple_mixture_predictor_data):
+    """Ensure that a serialized IngredientsToSimpleMixturePredictor looks sane."""
+    predictor = IngredientsToSimpleMixturePredictor.build(valid_ing_to_simple_mixture_predictor_data)
+    serialized = predictor.dump()
+    serialized['id'] = valid_ing_to_simple_mixture_predictor_data['id']
+    assert serialized == valid_serialization_output(valid_ing_to_simple_mixture_predictor_data)
+
+
+def test_generalized_mean_property_serialization(valid_generalized_mean_property_predictor_data):
+    """Ensure that a serialized GeneralizedMeanPropertyPredictor looks sane."""
+    predictor = GeneralizedMeanPropertyPredictor.build(valid_generalized_mean_property_predictor_data)
+    serialized = predictor.dump()
+    serialized['id'] = valid_generalized_mean_property_predictor_data['id']
+    assert serialized == valid_serialization_output(valid_generalized_mean_property_predictor_data)
 
 
 def test_invalid_predictor_type(invalid_predictor_data):


### PR DESCRIPTION
This PR adds a formulation descriptor and two formulations-related predictors: `IngredientsToSimpleMixturePredictor` and `GeneralizedMeanPropertyPredictor`. The former constructs a simple mixture from a list of ingredients. The latter computes generalized mean ingredient properties.