### PR TITLE
Fix deserialization bug when JSON is not as nested as expected

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.18.0',
+      version='0.18.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -79,7 +79,10 @@ class Property(typing.Generic[DeserializedType, SerializedType]):
         value = data
         fields = self.serialization_path.split('.')
         for field in fields:
-            value = value.get(field, self.default)
+            if isinstance(value, dict):
+                value = value.get(field, self.default)
+            else:
+                value = self.default
         base_class = _get_base_class(data, self.serialization_path)
         return self.deserialize(value, base_class=base_class)
 

--- a/tests/serialization/test_reports.py
+++ b/tests/serialization/test_reports.py
@@ -40,6 +40,13 @@ def test_predictor_report_build(valid_predictor_report_data):
     assert exp_model.feature_importances == []
 
 
+def test_empty_report_build():
+    """Build a predictor report when the 'report' field is somehow unfilled."""
+    Report.build(dict(id='7c2dda5d-675a-41b6-829c-e485163f0e43', status='PENDING'))
+    Report.build(dict(id='7c2dda5d-675a-41b6-829c-e485163f0e43', status='PENDING', report=None))
+    Report.build(dict(id='7c2dda5d-675a-41b6-829c-e485163f0e43', status='PENDING', report=dict()))
+
+
 def test_failed_predictor_report_build(valid_predictor_report_data):
     """Modify the predictor report to be invalid and check that the errors are caught."""
     too_many_descriptors = deepcopy(valid_predictor_report_data)


### PR DESCRIPTION
# Citrine Python PR

## Description 
Predictor report deserialization was failing because pending reports return an empty `reports` field, and our deserialization code assumes that the JSON includes sufficiently-nested entries.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
