### PR TITLE
PLA-3998: predictor report bugfix 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.18.2',
+      version='0.18.3',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.18.1',
+      version='0.18.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -83,6 +83,8 @@ class Property(typing.Generic[DeserializedType, SerializedType]):
             if next_value is None:
                 value = self.default
                 break
+            else:
+                value = next_value
 
         base_class = _get_base_class(data, self.serialization_path)
         return self.deserialize(value, base_class=base_class)

--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -83,7 +83,9 @@ class Property(typing.Generic[DeserializedType, SerializedType]):
             next_value = value.get(field)
             if next_value is None:
                 # This occurs if a `field` is unexpectedly not present in the data dictionary
-                # Stop traversing and use the default value
+                # or if its value is null.
+                # Use the default value and stop traversing, even if we have not yet reached
+                # the last field in the serialization path.
                 value = self.default
                 break
             else:

--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -79,10 +79,11 @@ class Property(typing.Generic[DeserializedType, SerializedType]):
         value = data
         fields = self.serialization_path.split('.')
         for field in fields:
-            if isinstance(value, dict):
-                value = value.get(field, self.default)
-            else:
+            next_value = value.get(field)
+            if next_value is None:
                 value = self.default
+                break
+
         base_class = _get_base_class(data, self.serialization_path)
         return self.deserialize(value, base_class=base_class)
 

--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -77,10 +77,13 @@ class Property(typing.Generic[DeserializedType, SerializedType]):
 
     def deserialize_from_dict(self, data: dict) -> DeserializedType:
         value = data
+        # `serialization_path` is expected to be a sequence of nested dictionary keys
         fields = self.serialization_path.split('.')
         for field in fields:
             next_value = value.get(field)
             if next_value is None:
+                # This occurs if a `field` is unexpectedly not present in the data dictionary
+                # Stop traversing and use the default value
                 value = self.default
                 break
             else:

--- a/tests/_serialization/_utils.py
+++ b/tests/_serialization/_utils.py
@@ -1,14 +1,15 @@
-from typing import Type, Any
+from typing import Type, Any, Optional
 
 from citrine._serialization import properties
 
 
-def make_class_with_property(prop_type: Type[properties.Property], field_name: str):
+def make_class_with_property(prop_type: Type[properties.Property], field_name: str, field_path: Optional[str] = None):
     class SampleObject:
         def __init__(self, field_value: Any):
             setattr(self, field_name, field_value)
 
         def __eq__(self, other):
             return getattr(self, field_name) == getattr(other, field_name)
-    setattr(SampleObject, field_name, prop_type(field_name))
+    setattr(SampleObject, field_name,
+            prop_type(serialization_path=field_name if field_path is None else field_path))
     return SampleObject

--- a/tests/_serialization/test_object_serialization.py
+++ b/tests/_serialization/test_object_serialization.py
@@ -15,7 +15,7 @@ class UnserializableClass:
 
 class SampleClass(Serializable):
     """A class to stress the deser scheme's ability to handle objects."""
-    prop_string = String('prop_string')
+    prop_string = String('prop_string.string', default='default')
     prop_value = Object(BaseValue, 'prop_value')
     prop_object = Optional(Object(UnserializableClass), 'prop_object')
 
@@ -31,6 +31,25 @@ def test_gemd_object_serde():
     copy = SampleClass.build(good_obj.dump())
     assert copy.prop_value == good_obj.prop_value
     assert copy.prop_string == good_obj.prop_string
+
+
+def test_default_nested_serde():
+    """Test that defaults work in nested dictionaries."""
+    good_obj = SampleClass("Can be serialized", NominalReal(17, ''))
+    data = good_obj.dump()
+
+    # If 'prop_string.string' is a non-string, that's an error
+    data['prop_string']['string'] = 0
+    with pytest.raises(ValueError):
+        SampleClass.build(data)
+
+    # If data['prop_string'] is an empty dictionary, then the default is used
+    data['prop_string'] = dict()
+    assert SampleClass.build(data).prop_string == 'default'
+
+    # If `data` does not even have a 'prop_string' key, then the default is used
+    del data['prop_string']
+    assert SampleClass.build(data).prop_string == 'default'
 
 
 def test_bad_object_serde():


### PR DESCRIPTION
# Citrine Python PR

## Description 
Improve on the rushed #325 

This makes the logic clearer: we traverse the JSON dictionary until we get to the terminal key. If a key is ever missing traversal stops and we use the default value (if applicable). If the JSON has unexpected structure, that's an error.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
