### PR TITLE
Pla 3998/handle duplicate descriptors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.18.4',
+      version='0.18.5',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/informatics/reports.py
+++ b/src/citrine/informatics/reports.py
@@ -181,7 +181,8 @@ class PredictorReport(Serializable['PredictorReport'], Report):
         as_list = list(it)
         if len(as_list) > 1:
             serialized_descriptors = [d.dump() for d in as_list]
-            warnings.warn("Warning: found multiple descriptors with the key \'{}\': {}"
+            warnings.warn("Warning: found multiple descriptors with the key \'{}\', arbitrarily "
+                          "selecting the first one. The descriptors are: {}"
                           .format(as_list[0].key, serialized_descriptors), RuntimeWarning)
         else:
             return as_list[0]

--- a/src/citrine/informatics/reports.py
+++ b/src/citrine/informatics/reports.py
@@ -2,6 +2,7 @@
 from typing import Optional, Type, List, Dict, TypeVar, Iterable, Any
 from abc import abstractmethod
 from itertools import groupby
+import warnings
 
 from citrine._serialization import properties
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
@@ -179,8 +180,9 @@ class PredictorReport(Serializable['PredictorReport'], Report):
         """
         as_list = list(it)
         if len(as_list) > 1:
-            raise RuntimeError("Error: found multiple descriptors with the key \'{}\': {}."
-                               .format(as_list[0].key, as_list))
+            serialized_descriptors = [d.dump() for d in as_list]
+            warnings.warn("Warning: found multiple descriptors with the key \'{}\': {}"
+                          .format(as_list[0].key, serialized_descriptors), RuntimeWarning)
         else:
             return as_list[0]
 

--- a/src/citrine/informatics/reports.py
+++ b/src/citrine/informatics/reports.py
@@ -184,8 +184,7 @@ class PredictorReport(Serializable['PredictorReport'], Report):
             warnings.warn("Warning: found multiple descriptors with the key \'{}\', arbitrarily "
                           "selecting the first one. The descriptors are: {}"
                           .format(as_list[0].key, serialized_descriptors), RuntimeWarning)
-        else:
-            return as_list[0]
+        return as_list[0]
 
     @staticmethod
     def _collapse_model_settings(model: ModelSummary):

--- a/tests/serialization/test_reports.py
+++ b/tests/serialization/test_reports.py
@@ -47,14 +47,14 @@ def test_empty_report_build():
     Report.build(dict(id='7c2dda5d-675a-41b6-829c-e485163f0e43', status='PENDING', report=dict()))
 
 
-def test_failed_predictor_report_build(valid_predictor_report_data):
-    """Modify the predictor report to be invalid and check that the errors are caught."""
+def test_bad_predictor_report_build(valid_predictor_report_data):
+    """Modify the predictor report to be non-ideal and check the behavior."""
     too_many_descriptors = deepcopy(valid_predictor_report_data)
     # Multiple descriptors with the same key
     other_x = RealDescriptor("x", 0, 100, "")
     too_many_descriptors['report']['descriptors'].append(other_x.dump())
-    with pytest.raises(RuntimeError):
-        Report.build(too_many_descriptors)
+    # this should build but throw a warning
+    Report.build(too_many_descriptors)
 
     # A key that appears in inputs and/or outputs, but there is no corresponding descriptor.
     # This is done twice for coverage, once to catch a missing input and once for a missing output.

--- a/tests/serialization/test_reports.py
+++ b/tests/serialization/test_reports.py
@@ -54,7 +54,6 @@ def test_bad_predictor_report_build(valid_predictor_report_data):
     # Multiple descriptors with the same key
     other_x = RealDescriptor("x", 0, 100, "")
     too_many_descriptors['report']['descriptors'].append(other_x.dump())
-    Report.build(too_many_descriptors)
     with warnings.catch_warnings(record=True) as w:
         Report.build(too_many_descriptors)
         assert len(w) == 1

--- a/tests/serialization/test_reports.py
+++ b/tests/serialization/test_reports.py
@@ -1,6 +1,7 @@
 """Tests for citrine.informatics.reports serialization."""
 import pytest
 from copy import deepcopy
+import warnings
 
 from citrine.informatics.descriptors import RealDescriptor
 from citrine.informatics.reports import Report, ModelSummary, FeatureImportanceReport
@@ -53,8 +54,11 @@ def test_bad_predictor_report_build(valid_predictor_report_data):
     # Multiple descriptors with the same key
     other_x = RealDescriptor("x", 0, 100, "")
     too_many_descriptors['report']['descriptors'].append(other_x.dump())
-    # this should build but throw a warning
     Report.build(too_many_descriptors)
+    with warnings.catch_warnings(record=True) as w:
+        Report.build(too_many_descriptors)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, RuntimeWarning)
 
     # A key that appears in inputs and/or outputs, but there is no corresponding descriptor.
     # This is done twice for coverage, once to catch a missing input and once for a missing output.


### PR DESCRIPTION
# Citrine Python PR

## Description 
Gracefully handle multiple descriptors in a predictor report that have the same key.
PLA-4056

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
