### PR TITLE
Add predictor responses method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.20.0',
+      version='0.21.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.21.0',
+      version='0.22.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/descriptors.py
+++ b/src/citrine/resources/descriptors.py
@@ -29,7 +29,7 @@ class DescriptorMethods:
         Returns
         -------
         List[Descriptor]
-            The computable responses of the predictor given the provided inputs.
+            The computable responses of the predictor given the provided input space (as descriptors).
 
         """
         response = self.session.post_resource(

--- a/src/citrine/resources/descriptors.py
+++ b/src/citrine/resources/descriptors.py
@@ -17,19 +17,20 @@ class DescriptorMethods:
     def from_predictor_responses(self, predictor: Predictor,
                                  inputs: List[Descriptor]) -> List[Descriptor]:
         """
-        [ALPHA] Get responses for a predictor, given a set of inputs.
+        [ALPHA] Get responses for a predictor, given an input space.
 
         Parameters
         ----------
         predictor : Predictor
             The predictor whose available responses are to be computed.
         inputs : List[Descriptor]
-            The inputs to the predictor
+            The input space to the predictor.
 
         Returns
         -------
         List[Descriptor]
-            The computable responses of the predictor given the provided input space (as descriptors).
+            The computable responses of the predictor given the provided input space (as
+            descriptors).
 
         """
         response = self.session.post_resource(

--- a/src/citrine/resources/descriptors.py
+++ b/src/citrine/resources/descriptors.py
@@ -14,7 +14,8 @@ class DescriptorMethods:
         self.project_id = project_id
         self.session: Session = session
 
-    def from_predictor_responses(self, predictor: Predictor, inputs: List[Descriptor]) -> List[Descriptor]:
+    def from_predictor_responses(self, predictor: Predictor,
+                                 inputs: List[Descriptor]) -> List[Descriptor]:
         """
         [ALPHA] Get responses for a predictor, given a set of inputs.
 

--- a/src/citrine/resources/descriptors.py
+++ b/src/citrine/resources/descriptors.py
@@ -21,8 +21,10 @@ class DescriptorMethods:
 
         Parameters
         ----------
-        predictor The predictor whose available responses are to be computed.
-        inputs The inputs to the predictor
+        predictor : Predictor
+            The predictor whose available responses are to be computed.
+        inputs : List[Descriptor]
+            The inputs to the predictor
 
         Returns
         -------

--- a/src/citrine/resources/descriptors.py
+++ b/src/citrine/resources/descriptors.py
@@ -1,0 +1,39 @@
+from typing import List
+from uuid import UUID
+
+from citrine._session import Session
+from citrine.informatics.descriptors import Descriptor
+from citrine.informatics.predictors import Predictor
+
+
+# Not a full Collection since CRUD operations are not valid for Descriptors
+class DescriptorMethods:
+    """[ALPHA] A set of methods returning descriptors which require connection to the backend."""
+
+    def __init__(self, project_id: UUID, session: Session):
+        self.project_id = project_id
+        self.session: Session = session
+
+    def from_predictor_responses(self, predictor: Predictor, inputs: List[Descriptor]) -> List[Descriptor]:
+        """
+        [ALPHA] Get responses for a predictor, given a set of inputs.
+
+        Parameters
+        ----------
+        predictor The predictor whose available responses are to be computed.
+        inputs The inputs to the predictor
+
+        Returns
+        -------
+        List[Descriptor]
+            The computable responses of the predictor given the provided inputs.
+
+        """
+        response = self.session.post_resource(
+            path='/projects/{}/material-descriptors/predictor-responses'.format(self.project_id),
+            json={
+                'predictor': predictor.dump()['config'],
+                'inputs': [i.dump() for i in inputs]
+            }
+        )
+        return [Descriptor.build(r) for r in response['responses']]

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -106,7 +106,7 @@ class Project(Resource['Project']):
 
     @property
     def descriptors(self) -> DescriptorMethods:
-        """Return a resource containing a set of methods returning descriptors."""
+        """[ALPHA] Return a resource containing a set of methods returning descriptors."""
         return DescriptorMethods(self.uid, self.session)
 
     @property

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from citrine._session import Session
 from citrine.resources.ara_definition import AraDefinitionCollection
+from citrine.resources.descriptors import DescriptorMethods
 from citrine.resources.module import ModuleCollection
 from citrine.resources.design_space import DesignSpaceCollection
 from citrine.resources.processor import ProcessorCollection
@@ -102,6 +103,11 @@ class Project(Resource['Project']):
     def predictors(self) -> PredictorCollection:
         """Return a resource representing all visible predictors."""
         return PredictorCollection(self.uid, self.session)
+
+    @property
+    def descriptors(self) -> DescriptorMethods:
+        """Return a resource containing a set of methods returning descriptors."""
+        return DescriptorMethods(self.uid, self.session)
 
     @property
     def workflows(self) -> WorkflowCollection:

--- a/tests/resources/test_descriptors.py
+++ b/tests/resources/test_descriptors.py
@@ -1,0 +1,49 @@
+from uuid import uuid4
+
+from citrine.informatics.descriptors import MolecularStructureDescriptor, RealDescriptor
+from citrine.informatics.predictors import MolecularStructureFeaturizer
+from citrine.resources.descriptors import DescriptorMethods
+from tests.utils.session import FakeSession
+
+
+def test_from_predictor_responses():
+    session = FakeSession()
+    col = 'smiles'
+    response_json = {
+        'responses': [  # shortened sample response
+            {
+                'category': 'Real',
+                'descriptor_key': 'khs.sNH3 KierHallSmarts for {}'.format(col),
+                'units': '',
+                'lower_bound': 0,
+                'upper_bound': 1000000000
+            },
+            {
+                'category': 'Real',
+                'descriptor_key': 'khs.dsN KierHallSmarts for {}'.format(col),
+                'units': '',
+                'lower_bound': 0,
+                'upper_bound': 1000000000
+            },
+        ]
+    }
+    session.set_response(response_json)
+    descriptors = DescriptorMethods(uuid4(), session)
+    featurizer = MolecularStructureFeaturizer(
+        name="Molecule featurizer",
+        description="description",
+        descriptor=MolecularStructureDescriptor(col),
+        features=["all"],
+        excludes=["standard"]
+    )
+    results = descriptors.from_predictor_responses(featurizer, [MolecularStructureDescriptor(col)])
+    assert results == [
+        RealDescriptor(
+            key=r['descriptor_key'],
+            lower_bound=r['lower_bound'],
+            upper_bound=r['upper_bound'],
+        ) for r in response_json['responses']
+    ]
+    assert session.last_call.path == '/projects/{}/material-descriptors/predictor-responses'\
+        .format(descriptors.project_id)
+    assert session.last_call.method == 'POST'

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -159,6 +159,10 @@ def test_modules_get_project_id(project):
     assert project.uid == project.modules.project_id
 
 
+def test_descriptors_get_project_id(project):
+    assert project.uid == project.descriptors.project_id
+
+
 def test_processors_get_project_id(project):
     assert project.uid == project.processors.project_id
 


### PR DESCRIPTION
# Citrine Python PR

## Description 
Adds the ability to get predictor responses (descriptors) given a set of inputs.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
