### PR TITLE
PLA-3626 Add molecular structure column support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.23.0',
+      version='0.24.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/ara/columns.py
+++ b/src/citrine/ara/columns.py
@@ -20,6 +20,17 @@ class CompositionSortOrder(BaseEnumeration):
     QUANTITY = "quantity"
 
 
+class ChemicalDisplayFormat(BaseEnumeration):
+    """[ALPHA] Format to use when rendering a molecular structure.
+
+    * SMILES Simplified molecular-input line-entry system
+    * INCHI International Chemical Identifier
+    """
+
+    SMILES = "smiles"
+    INCHI = "inchi"
+
+
 class Column(PolymorphicSerializable['Column']):
     """[ALPHA] A column in the Ara table, defined as some operation on a variable.
 
@@ -48,7 +59,8 @@ class Column(PolymorphicSerializable['Column']):
             MeanColumn, StdDevColumn, QuantileColumn, OriginalUnitsColumn,
             MostLikelyCategoryColumn, MostLikelyProbabilityColumn,
             FlatCompositionColumn, ComponentQuantityColumn,
-            NthBiggestComponentNameColumn, NthBiggestComponentQuantityColumn
+            NthBiggestComponentNameColumn, NthBiggestComponentQuantityColumn,
+            MolecularStructureColumn
         ]
         res = next((x for x in types if x.typ == data["type"]), None)
         if res is None:
@@ -353,3 +365,27 @@ class IdentityColumn(Serializable['IdentityColumn'], Column):
     def __init__(self, *,
                  data_source: str):
         self.data_source = data_source
+
+
+class MolecularStructureColumn(Serializable['MolecularStructureColumn'], Column):
+    """[ALPHA] Column containing a rendering of a molecular structure value.
+
+    Parameters
+    ----------
+    data_source: str
+        name of the variable to use when populating the column
+    format: ChemicalDisplayFormat
+        the format in which to display the molecular structure
+
+    """
+
+    data_source = properties.String('data_source')
+    format = properties.Enumeration(ChemicalDisplayFormat, 'format')
+    typ = properties.String('type', default="molecular_structure_column", deserializable=False)
+
+    def _attrs(self) -> List[str]:
+        return ["data_source", "format", "typ"]
+
+    def __init__(self, *, data_source: str, format: ChemicalDisplayFormat):
+        self.data_source = data_source
+        self.format = format

--- a/src/citrine/ara/columns.py
+++ b/src/citrine/ara/columns.py
@@ -368,7 +368,7 @@ class IdentityColumn(Serializable['IdentityColumn'], Column):
 
 
 class MolecularStructureColumn(Serializable['MolecularStructureColumn'], Column):
-    """[ALPHA] Column containing a rendering of a molecular structure value.
+    """[ALPHA] Column containing a representation of a molecular structure.
 
     Parameters
     ----------

--- a/src/citrine/resources/ara_job.py
+++ b/src/citrine/resources/ara_job.py
@@ -77,7 +77,7 @@ class JobStatusResponse(Resource['JobStatusResponse']):
         the type of job for this status report
     status: str
         the actual status of the job.
-        One of "Submitted", "Pending", "Running", "Success", or "Failure".
+        One of "Running", "Success", or "Failure".
     tasks: List[TaskNode]
         all of the constituent task required to complete this job
     output: Optional[Map[String,String]]

--- a/tests/ara/test_columns.py
+++ b/tests/ara/test_columns.py
@@ -1,10 +1,7 @@
 """Tests for citrine.informatics.columns."""
 import pytest
 
-from citrine.ara.columns import MeanColumn, IdentityColumn, Column, StdDevColumn, QuantileColumn, \
-    OriginalUnitsColumn, MostLikelyProbabilityColumn, MostLikelyCategoryColumn, \
-    FlatCompositionColumn, CompositionSortOrder, ComponentQuantityColumn, \
-    NthBiggestComponentNameColumn, NthBiggestComponentQuantityColumn
+from citrine.ara.columns import *
 
 
 @pytest.fixture(params=[
@@ -19,6 +16,7 @@ from citrine.ara.columns import MeanColumn, IdentityColumn, Column, StdDevColumn
     ComponentQuantityColumn(data_source="formula", component_name="Si", normalize=True),
     NthBiggestComponentNameColumn(data_source="formula", n=1),
     NthBiggestComponentQuantityColumn(data_source="formula", n=2),
+    MolecularStructureColumn(data_source="molecule", format=ChemicalDisplayFormat.SMILES)
 ])
 def column(request):
     return request.param


### PR DESCRIPTION
# Citrine Python PR

## Description 
Adds support for displaying molecular structures in SMILES or InChI in a table.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
