### PR TITLE
PLA-3758 - Add IngredientFractionsPredictor

### DIFF
--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -347,6 +347,34 @@ The following example demonstrates how to create a predictor that computes the t
         labels=['solute', 'solvent']
     )
 
+Ingredient Fractions Predictor
+------------------------------
+
+The :class:`~citrine.informatics.predictors.IngredientFractionsPredictor` is used to expand a formulation recipe into a ``(RealDescriptor, ContinuousDistribution)`` pair for each ingredient in the formulation.
+
+An ``IngredientFractionsPredictor`` can be created as shown below.
+
+.. code:: python
+
+    from citrine.informatics.predictors import IngredientFractionsPredictor
+    from citrine.informatics.descriptors import FormulationDescriptor
+
+    IngredientFractionsPredictor(
+        name="Ingredient Fractions Predictor",
+        description="compute ingredient fractions for provided ingredients",
+        input_descriptor=FormulationDescriptor("formulation")
+        ingredients=['water', 'alcohol']
+    )
+
+If particular ingredients are not present in the provided ingredients list, it will be given a fraction of ``0.0``.
+For example, if a formulation has components ``(water -> 1.0)``, then the predictor as defined above would compue two responses:
+
+    - ``water fraction in formulation -> 1.0``
+    - ``alcohol fraction in formulation -> 0.0``
+
+
+If the formulation contains an ingredient that wasn't specified when the predictor was created, then an error will be thrown.
+
 Predictor Reports
 -----------------
 

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -215,7 +215,7 @@ The following example illustrates how an :class:`~citrine.informatics.predictors
     )
 
 Simple mixture predictor
----------------------------------------
+------------------------
 
 Simple mixtures may contain ingredients that are blends of other simple mixtures.
 Along the lines of the example above, hypertonic saline can be mixed with water to form isotonic saline.
@@ -325,6 +325,37 @@ The example below show how to configure a mean property predictor to compute mea
         label='solute'
     )
 
+Ingredient Fractions Predictor
+------------------------------
+
+The :class:`~citrine.informatics.predictors.IngredientFractionsPredictor` featurizes ingredient fractions in a simple mixture.
+The predictor is configured by specifying a descriptor that contains simple mixture data and a list of known ingredients to featurize.
+The list of ingredients should be the list of all possible ingredients for the input mixture.
+If the mixture contains an ingredient that wasn't specified when the predictor was created, an error will be thrown.
+
+For each featurized ingredient, the predictor will inspect the recipe and compute a response equal to the ingredient's total fraction in the recipe.
+If an ingredient is not present in the mixture's recipe, the response for that ingredient fraction will be 0.
+For example, given a recipe ``{'water': 0.9, 'salt': 0.1}`` and featurized ingredients ``['water', 'salt', 'boric acid']``,
+this predictor would compute outputs:
+
+- ``water share in simple mixture == 0.9``
+- ``salt share in simple mixture == 0.1``
+- ``boric acid share in simple mixture == 0.0``
+
+The example below shows how to configure an ``IngredientFractionsPredictor`` that computes these responses.
+
+.. code:: python
+
+    from citrine.informatics.predictors import IngredientFractionsPredictor
+    from citrine.informatics.descriptors import FormulationDescriptor
+
+    IngredientFractionsPredictor(
+        name='Ingredient Fractions Predictor',
+        description='Computes fractions of provided ingredients',
+        input_descriptor=FormulationDescriptor('simple mixture')
+        ingredients=['water', 'salt', 'boric acid']
+    )
+
 Label fractions predictor
 -------------------------
 
@@ -346,34 +377,6 @@ The following example demonstrates how to create a predictor that computes the t
         input_descriptor=formulation,
         labels=['solute', 'solvent']
     )
-
-Ingredient Fractions Predictor
-------------------------------
-
-The :class:`~citrine.informatics.predictors.IngredientFractionsPredictor` is used to expand a formulation recipe into a ``(RealDescriptor, ContinuousDistribution)`` pair for each ingredient in the formulation.
-
-An ``IngredientFractionsPredictor`` can be created as shown below.
-
-.. code:: python
-
-    from citrine.informatics.predictors import IngredientFractionsPredictor
-    from citrine.informatics.descriptors import FormulationDescriptor
-
-    IngredientFractionsPredictor(
-        name="Ingredient Fractions Predictor",
-        description="compute ingredient fractions for provided ingredients",
-        input_descriptor=FormulationDescriptor("formulation")
-        ingredients=['water', 'alcohol']
-    )
-
-If particular ingredients are not present in the provided ingredients list, it will be given a fraction of ``0.0``.
-For example, if a formulation has components ``(water -> 1.0)``, then the predictor as defined above would compue two responses:
-
-    - ``water fraction in formulation -> 1.0``
-    - ``alcohol fraction in formulation -> 0.0``
-
-
-If the formulation contains an ingredient that wasn't specified when the predictor was created, then an error will be thrown.
 
 Predictor Reports
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.26.0',
+      version='0.27.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.26.2',
+      version='0.27.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -5,6 +5,14 @@ from citrine._serialization.serializable import Serializable
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
 from citrine._serialization import properties
 
+__all__ = ['Descriptor',
+           'RealDescriptor',
+           'ChemicalFormulaDescriptor',
+           'InorganicDescriptor',
+           'MolecularStructureDescriptor',
+           'CategoricalDescriptor',
+           'FormulationDescriptor']
+
 
 class Descriptor(PolymorphicSerializable['Descriptor']):
     """[ALPHA] A Citrine Descriptor describes the range of values that a quantity can take on.

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -668,3 +668,60 @@ class LabelFractionsPredictor(Serializable['LabelFractionsPredictor'], Predictor
 
     def __str__(self):
         return '<LabelFractionsPredictor {!r}>'.format(self.name)
+
+
+class IngredientFractionsPredictor(Serializable["IngredientFractionsPredictor"], Predictor):
+    """[ALPHA] A predictor interface that allows expressing ingredient fractions.
+
+    Parameters
+    ----------
+    name: str
+        name of the configuration
+    description: str
+        the description of the predictor
+    input_descriptor: FormulationDescriptor
+        descriptor that represents the input formulation
+    ingredients: List[str]
+
+    """
+    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
+    name = _properties.String('config.name')
+    description = _properties.String('config.description')
+    input_descriptor = _properties.Object(FormulationDescriptor, 'config.input')
+    ingredients = _properties.List(_properties.String, 'config.ingredient_names')
+
+    # NOTE: These could go here or in _post_dump - it's unclear which is better right now
+    module_type = _properties.String('module_type', default='PREDICTOR')
+    schema_id = _properties.UUID('schema_id', default=UUID('eb02a095-8cdc-45d8-bc82-1013b6e8e700'))
+    typ = _properties.String('config.type', default='IngredientFractions',
+                             deserializable=False)
+    status = _properties.Optional(_properties.String, 'status', serializable=False)
+    status_info = _properties.Optional(
+        _properties.List(_properties.String),
+        'status_info',
+        serializable=False
+    )
+    active = _properties.Boolean('active', default=True)
+
+    def __init__(self,
+                 name: str,
+                 description: str,
+                 input_descriptor: FormulationDescriptor,
+                 ingredients: List[str],
+                 session: Optional[Session] = None,
+                 report: Optional[Report] = None,
+                 active: bool = True):
+        self.name: str = name
+        self.description: str = description
+        self.input_descriptor: FormulationDescriptor = input_descriptor
+        self.ingredients: List[str] = ingredients
+        self.session: Optional[Session] = session
+        self.report: Optional[Report] = report
+        self.active: bool = active
+
+    def _post_dump(self, data: dict) -> dict:
+        data['display_name'] = data['config']['name']
+        return data
+
+    def __str__(self):
+        return '<IngredientFractionsPredictor {!r}>'.format(self.name)

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -51,7 +51,7 @@ class Predictor(Module):
             "GeneralizedMeanProperty": GeneralizedMeanPropertyPredictor,
             "LabelFractions": LabelFractionsPredictor,
             "SimpleMixture": SimpleMixturePredictor,
-            "IngredientFractions": IngredientFractionsPredictor
+            "IngredientFractions": IngredientFractionsPredictor,
         }
         typ = type_dict.get(data['config']['type'])
 
@@ -673,7 +673,7 @@ class LabelFractionsPredictor(Serializable['LabelFractionsPredictor'], Predictor
 
 
 class IngredientFractionsPredictor(Serializable["IngredientFractionsPredictor"], Predictor):
-    """[ALPHA] A predictor interface that allows expressing ingredient fractions.
+    """[ALPHA] A predictor interface that computes ingredient fractions.
 
     Parameters
     ----------
@@ -684,7 +684,9 @@ class IngredientFractionsPredictor(Serializable["IngredientFractionsPredictor"],
     input_descriptor: FormulationDescriptor
         descriptor that represents the input formulation
     ingredients: List[str]
-
+        list of ingredients to featurize.
+        This list should contain all possible ingredients.
+        If an unknown ingredient is encountered, an error will be thrown.
     """
     uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
     name = _properties.String('config.name')

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -21,7 +21,8 @@ __all__ = ['ExpressionPredictor',
            'MolecularStructureFeaturizer',
            'GeneralizedMeanPropertyPredictor',
            'LabelFractionsPredictor',
-           'SimpleMixturePredictor']
+           'SimpleMixturePredictor',
+           'IngredientFractionsPredictor']
 
 
 class Predictor(Module):
@@ -50,6 +51,7 @@ class Predictor(Module):
             "GeneralizedMeanProperty": GeneralizedMeanPropertyPredictor,
             "LabelFractions": LabelFractionsPredictor,
             "SimpleMixture": SimpleMixturePredictor,
+            "IngredientFractions": IngredientFractionsPredictor
         }
         typ = type_dict.get(data['config']['type'])
 
@@ -688,7 +690,7 @@ class IngredientFractionsPredictor(Serializable["IngredientFractionsPredictor"],
     name = _properties.String('config.name')
     description = _properties.String('config.description')
     input_descriptor = _properties.Object(FormulationDescriptor, 'config.input')
-    ingredients = _properties.List(_properties.String, 'config.ingredient_names')
+    ingredients = _properties.List(_properties.String, 'config.ingredients')
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -330,13 +330,13 @@ def valid_ingredient_fractions_predictor_data():
         status='VALID',
         status_info=[],
         active=True,
-        display_name="Ingredient fractions predictor",
-        schema_id="eb02a095-8cdc-45d8-bc82-1013b6e8e700",
+        display_name='Ingredient fractions predictor',
+        schema_id='eb02a095-8cdc-45d8-bc82-1013b6e8e700',
         id=str(uuid.uuid4()),
         config=dict(
             type='IngredientFractions',
-            name="Ingredient fractions predictor",
-            description="Computes ingredient fractions",
+            name='Ingredient fractions predictor',
+            description='Computes ingredient fractions',
             input=FormulationDescriptor('ingredients').dump(),
             ingredients=['Blue dye', 'Red dye']
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,6 +321,27 @@ def valid_label_fractions_predictor_data():
         )
     )
 
+@pytest.fixture
+def valid_ingredient_fractions_predictor_data():
+    """Produce valid data used for tests."""
+    from citrine.informatics.descriptors import FormulationDescriptor
+    return dict(
+        module_type='PREDICTOR',
+        status='VALID',
+        status_info=[],
+        active=True,
+        display_name="Ingredient fractions predictor",
+        schema_id="eb02a095-8cdc-45d8-bc82-1013b6e8e700",
+        id=str(uuid.uuid4()),
+        config=dict(
+            type='IngredientFractions',
+            name="Ingredient fractions predictor",
+            description="Computes ingredient fractions",
+            input=FormulationDescriptor('ingredients').dump(),
+            ingredient_names=['Blue dye', 'Red dye']
+        )
+    )
+
 
 @pytest.fixture
 def invalid_predictor_data():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -338,7 +338,7 @@ def valid_ingredient_fractions_predictor_data():
             name="Ingredient fractions predictor",
             description="Computes ingredient fractions",
             input=FormulationDescriptor('ingredients').dump(),
-            ingredient_names=['Blue dye', 'Red dye']
+            ingredients=['Blue dye', 'Red dye']
         )
     )
 

--- a/tests/informatics/test_predictors.py
+++ b/tests/informatics/test_predictors.py
@@ -124,7 +124,7 @@ def ingredient_fractions_predictor() -> IngredientFractionsPredictor:
     """Build a Ingredient Fractions predictor for testing."""
     return IngredientFractionsPredictor(
         name='Ingredient fractions predictor',
-        description='Computes mean ingredient properties',
+        description='Computes total ingredient fractions',
         input_descriptor=formulation,
         ingredients=["Green Paste", "Blue Paste"]
     )
@@ -327,7 +327,7 @@ def test_simple_mixture_relation_post_build(simple_mixture_predictor):
 
 
 def test_ingredient_fractions_property_initialization(ingredient_fractions_predictor):
-    """Make sure the correct fields go to the correct places for an ingredients to ingredient_fractions_predictor."""
+    """Make sure the correct fields go to the correct places for an ingredient fractions predictor."""
     assert ingredient_fractions_predictor.name == 'Ingredient fractions predictor'
     assert ingredient_fractions_predictor.input_descriptor.key == 'formulation'
     assert ingredient_fractions_predictor.ingredients == ["Green Paste", "Blue Paste"]

--- a/tests/serialization/test_predictors.py
+++ b/tests/serialization/test_predictors.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 from citrine.informatics.predictors import ExpressionPredictor, GeneralizedMeanPropertyPredictor, \
     GraphPredictor, Predictor, SimpleMLPredictor, IngredientsToSimpleMixturePredictor, \
-    LabelFractionsPredictor, SimpleMixturePredictor
+    LabelFractionsPredictor, SimpleMixturePredictor, IngredientFractionsPredictor
 from citrine.informatics.descriptors import RealDescriptor
 
 
@@ -97,6 +97,14 @@ def test_label_fractions_serialization(valid_label_fractions_predictor_data):
     serialized = predictor.dump()
     serialized['id'] = valid_label_fractions_predictor_data['id']
     assert serialized == valid_serialization_output(valid_label_fractions_predictor_data)
+
+
+def test_ingredient_fractions_serialization(valid_ingredient_fractions_predictor_data):
+    """"Ensure that a serialized IngredientsFractionsPredictor looks sane."""
+    predictor = IngredientFractionsPredictor.build(valid_ingredient_fractions_predictor_data)
+    serialized = predictor.dump()
+    serialized["id"] = valid_ingredient_fractions_predictor_data['id']
+    assert serialized == valid_serialization_output(valid_ingredient_fractions_predictor_data)
 
 
 def test_invalid_predictor_type(invalid_predictor_data):


### PR DESCRIPTION
# Citrine Python PR

## Description 

  Add the IngredientFractionsPredictor to the
  set of available predictors in the `predictors` module.

  Add tests to both informatics and serialization test
  files.

  Document this new predictor in the docs.
  NOTE: Heavily sourced from the [Solution Design Doc](https://citrine.atlassian.net/wiki/spaces/~375952471/pages/219643922/Simple+mixture+support+on+the+Citrine+Platform#Compute-ingredient-fractions-from-a-recipe-designed)

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
