### PR TITLE
Bug/pla 3449 connection reset error fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.26.0',
+      version='0.26.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -70,7 +70,8 @@ class Session(requests.Session):
         """Optionally refresh our access token (if the previous one is about to expire)."""
         data = {'refresh_token': self.refresh_token}
 
-        response = self._request_with_retry('POST', self._versioned_base_url() + 'tokens/refresh', json=data)
+        response = self._request_with_retry('POST', self._versioned_base_url() + 'tokens/refresh',
+                                            json=data)
 
         if response.status_code != 200:
             raise UnauthorizedRefreshToken()
@@ -80,8 +81,7 @@ class Session(requests.Session):
         )
 
     def _request_with_retry(self, method, uri, **kwargs):
-        """Wrap a request with a try/except to retry when ConnectionErrors are seen"""
-
+        """Wrap a request with a try/except to retry when ConnectionErrors are seen."""
         # The urllib3 Retry object does not handle this situation so retry manually"
         try:
             response = self.request(method, uri, **kwargs)

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -4,7 +4,6 @@ from logging import getLogger
 from datetime import datetime, timedelta
 
 from requests import Response
-from requests.exceptions import ConnectionError
 from json.decoder import JSONDecodeError
 from urllib3.util.retry import Retry
 
@@ -23,14 +22,6 @@ import requests
 # expiring during the check for expiration
 EXPIRATION_BUFFER_MILLIS: timedelta = timedelta(milliseconds=5000)
 logger = getLogger(__name__)
-
-
-class ConnectionRetry(Retry):
-    def _is_connection_error(self, err):
-        """ Extend the Retry super class to include Requests ConnectionError as a retry-able
-        connection error.
-        """
-        return super()._is_connection_error(err) or isinstance(err, ConnectionError)
 
 
 class Session(requests.Session):
@@ -59,12 +50,12 @@ class Session(requests.Session):
         # Custom adapter so we can use custom retry parameters. The default HTTP status
         # codes for retries are [503, 413, 429]. We're using status_force list to add
         # additional codes to retry on, focusing on specific CloudFlare 5XX errors.
-        retries = ConnectionRetry(total=10,
-                                  connect=5,
-                                  read=5,
-                                  status=5,
-                                  backoff_factor=0.25,
-                                  status_forcelist=[500, 502, 504, 520, 521, 522, 524, 527])
+        retries = Retry(total=10,
+                        connect=5,
+                        read=5,
+                        status=5,
+                        backoff_factor=0.25,
+                        status_forcelist=[500, 502, 504, 520, 521, 522, 524, 527])
         adapter = requests.adapters.HTTPAdapter(max_retries=retries)
         self.mount('https://', adapter)
         self.mount('http://', adapter)
@@ -78,8 +69,9 @@ class Session(requests.Session):
     def _refresh_access_token(self) -> None:
         """Optionally refresh our access token (if the previous one is about to expire)."""
         data = {'refresh_token': self.refresh_token}
-        response = self.request(
-            'POST', self._versioned_base_url() + 'tokens/refresh', json=data)
+
+        response = self._request_with_retry('POST', self._versioned_base_url() + 'tokens/refresh', json=data)
+
         if response.status_code != 200:
             raise UnauthorizedRefreshToken()
         self.access_token = response.json()['access_token']
@@ -87,28 +79,42 @@ class Session(requests.Session):
             jwt.decode(self.access_token, verify=False)['exp']
         )
 
+    def _request_with_retry(self, method, uri, **kwargs):
+        """Wrap a request with a try/except to retry when ConnectionErrors are seen"""
+
+        # The urllib3 Retry object does not handle this situation so retry manually"
+        try:
+            response = self.request(method, uri, **kwargs)
+        except requests.exceptions.ConnectionError:
+            logger.warning('requests.exceptions.ConnectionError seen, retrying request')
+            response = self.request(method, uri, **kwargs)
+
+        return response
+
     def checked_request(self, method: str, path: str,
                         version: str = 'v1', **kwargs) -> requests.Response:
         """Check response status code and throw an exception if relevant."""
+        logger.debug('BEGIN request details:')
+        logger.debug('\tmethod: {}'.format(method))
+        logger.debug('\tpath: {}'.format(path))
+        logger.debug('\tversion: {}'.format(version))
+
         if self._is_access_token_expired():
             self._refresh_access_token()
         uri = self._versioned_base_url(version) + path.lstrip('/')
 
-        logger.debug('BEGIN request details:')
-        logger.debug('\tmethod: {}'.format(method))
-        logger.debug('\tpath: {}'.format(path))
         logger.debug('\turi: {}'.format(uri))
-        logger.debug('\tversion: {}'.format(version))
+
         for k, v in kwargs.items():
             logger.debug('\t{}: {}'.format(k, v))
         logger.debug('END request details.')
 
-        response = self.request(method, uri, **kwargs)
+        response = self._request_with_retry(method, uri, **kwargs)
 
         try:
             if response.status_code == 401 and response.json().get("reason") == "invalid-token":
                 self._refresh_access_token()
-                response = self.request(method, uri, **kwargs)
+                response = self._request_with_retry(method, uri, **kwargs)
         except ValueError:
             # Ignore ValueErrors thrown by attempting to decode json bodies. This
             # might occur if we get a 401 response without a JSON body


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR adds a workaround to retry a request if a request.exceptions.ConnectionError is seen.  This is the specific error we see when we attempt to make a request using a stale Request session.  We see this in the e2e tests when using the 'other_user' session, since this is only used by a small number of tests and cached for the session.  We typically see this with a call to other_user.users.me() which will fail at some point roughly 10 minutes into the build.

While the urllib3 Retry object is supposed to handle retries of connections, it does not handle Requests ConnectionError exceptions.  Subclassing Retry and extending this also did not work as expected.  Wrapping the requests in a try/except is low tech but has worked well in manual tests with a Citrine session older than 10 minutes.

There is a small amount of refactoring so all requests use a new method that retries a request if this error is seen, including _refresh_access_token().  The method names and signatures have not been modified so this should not break any existing code.

Note, this should also fix a longstanding issue of ConnectionError/ConnectionResetError in Jupyter notebooks.

This relates to issue PLA-3449

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
