### PR TITLE
Extended the number of exceptions handled in _request_with_retry()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.28.0',
+      version='0.28.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR extends the types of exceptions we handle in _request_with_retry(), specifically requests.exceptions.ChunkedEncodingError and the built-in ConnectionError which is distinct from requests.exceptions.ConnectionError.  If the request uses a stale connection it will raise a ConnectionError and sometimes a ChunkedEncodingError.

These types of exceptions all indicate that the request was not actioned on the server.  Retrying the request will create a new connection and often succeed.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
