### PR TITLE
increase the page width of the python docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,6 +80,6 @@ html_theme_options = {
     'sidebar_collapse': False,
     'head_font_family': ['Barlow', 'Helvetica', 'Arial', 'Sans-Serif'],
     'font_family': ['Lusitana', 'Times New Roman', 'serif'],
-    'page_width': '960px', # default is 940 https://github.com/bitprophet/alabaster/blob/master/alabaster/theme.conf#L29
-    'sidebar_width': '240px' # default is 220 https://github.com/bitprophet/alabaster/blob/master/alabaster/theme.conf#L38
+    'page_width': '1024px', # default is 940 https://github.com/bitprophet/alabaster/blob/master/alabaster/theme.conf#L29
+    'sidebar_width': '250px' # default is 220 https://github.com/bitprophet/alabaster/blob/master/alabaster/theme.conf#L38
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,5 +79,7 @@ html_theme_options = {
     'github_repo': 'citrine-python',
     'sidebar_collapse': False,
     'head_font_family': ['Barlow', 'Helvetica', 'Arial', 'Sans-Serif'],
-    'font_family': ['Lusitana', 'Times New Roman', 'serif']
+    'font_family': ['Lusitana', 'Times New Roman', 'serif'],
+    'page_width': '960px', # default is 940 https://github.com/bitprophet/alabaster/blob/master/alabaster/theme.conf#L29
+    'sidebar_width': '240px' # default is 220 https://github.com/bitprophet/alabaster/blob/master/alabaster/theme.conf#L38
 }

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.28.1',
+      version='0.28.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',


### PR DESCRIPTION
I'm wondering if anyone else considers the default width of the python docs unusable. This PR adjusts them slightly.