### PR TITLE
Fix missing end paren in docs

### DIFF
--- a/docs/source/getting_started/connecting.rst
+++ b/docs/source/getting_started/connecting.rst
@@ -9,7 +9,7 @@ To create a client, you must specify the specific site that you want to connect 
 
     from citrine import Citrine
     import os
-    citrine_client = Citrine(host="stage.citrine-platform.com", api_key=os.environ.get("CITRINE_API_KEY")
+    citrine_client = Citrine(host="stage.citrine-platform.com", api_key=os.environ.get("CITRINE_API_KEY"))
 
 Your API key serves both as your identity and your password.
 Anyone with your API key can take actions as you would on the platform.

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.28.2',
+      version='0.28.3',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',


### PR DESCRIPTION
Quick fix to add an end paren in the docs for creating a client instance.

# Citrine Python PR

## Description 
Please briefly explain the goal of the changes/this PR.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
