### PR TITLE
Fixes to allow us to list the ara definitions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.29.1',
+      version='0.29.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.28.3',
+      version='0.28.4',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -12,7 +12,7 @@ from citrine._session import Session
 from citrine.resources.process_template import ProcessTemplate  # noqa: F401
 from citrine.ara.columns import Column, MeanColumn, IdentityColumn, OriginalUnitsColumn
 from citrine.ara.rows import Row
-from citrine.ara.variables import Variable, IngredientIdentifierByProcessTemplateAndName,\
+from citrine.ara.variables import Variable, IngredientIdentifierByProcessTemplateAndName, \
     IngredientQuantityByProcessAndName, IngredientQuantityDimension
 
 
@@ -208,7 +208,8 @@ class AraDefinitionCollection(Collection[AraDefinition]):
     _path_template = 'projects/{project_id}/ara-definitions'
     _collection_key = 'definitions'
 
-    # NOTE: This isn't actually an 'individual key' - both parts (version and definition) are necessary
+    # NOTE: This isn't actually an 'individual key' - both parts (version and
+    # definition) are necessary
     _individual_key = None
 
     def __init__(self, project_id: UUID, session: Session):
@@ -299,8 +300,7 @@ class AraDefinitionCollection(Collection[AraDefinition]):
         return self.session.post_resource(path, body)
 
     def register(self, defn: AraDefinition) -> AraDefinition:
-        """
-        [ALPHA] Register an Ara Definition.
+        """[ALPHA] Register an Ara Definition.
 
         If the provided AraDefinition does not have a definition_uid, create a new element of the
         AraDefinitionCollection by registering the provided AraDefinition. If the provided
@@ -313,11 +313,11 @@ class AraDefinitionCollection(Collection[AraDefinition]):
 
         TODO: Consider validating that a resource exists at the given uid before updating.
             The code to do so is not yet implemented on the backend
-
         """
-
-        # TODO: This is dumping our AraDefinition (which encapsulates both the definition properties, versioned
-        # properties, as well as the definition JSON) into the Ara Definition JSON blob ('definition')- probably not ideal.
+        # TODO: This is dumping our AraDefinition (which encapsulates both
+        #  the definition properties, versioned properties, as well as the
+        #  definition JSON) into the Ara Definition JSON blob ('definition')
+        #  - probably not ideal.
         body = {"definition": defn.dump()}
         if defn.definition_uid is None:
             data = self.session.post_resource(self._get_path(), body)

--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -312,7 +312,11 @@ class AraDefinitionCollection(Collection[AraDefinition]):
 
         TODO: Consider validating that a resource exists at the given uid before updating.
             The code to do so is not yet implemented on the backend
+
         """
+
+        # TODO: This is dumping our AraDefinition (which encapsulates both the definition properties, versioned
+        # properties, as well as the definition JSON) into the Ara Definition JSON blob ('definition')- probably not ideal.
         body = {"definition": defn.dump()}
         if defn.definition_uid is None:
             data = self.session.post_resource(self._get_path(), body)

--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -41,6 +41,7 @@ class AraDefinition(Resource["AraDefinition"]):
 
     @staticmethod
     def _get_dups(lst: List) -> List:
+        # Hmmn, this looks like a potentially costly operation?!
         return [x for x in lst if lst.count(x) > 1]
 
     definition_uid = properties.Optional(properties.UUID(), 'definition_id')
@@ -205,7 +206,10 @@ class AraDefinitionCollection(Collection[AraDefinition]):
     """[ALPHA] Represents the collection of all Ara Definitions associated with a project."""
 
     _path_template = 'projects/{project_id}/ara-definitions'
-    _individual_key = 'version'
+    _collection_key = 'definitions'
+
+    # NOTE: This isn't actually an 'individual key' - both parts (version and definition) are necessary
+    _individual_key = None
 
     def __init__(self, project_id: UUID, session: Session):
         self.project_id = project_id
@@ -221,10 +225,10 @@ class AraDefinitionCollection(Collection[AraDefinition]):
 
     def build(self, data: dict) -> AraDefinition:
         """[ALPHA] Build an individual Ara Definition from a dictionary."""
-        defn = AraDefinition.build(data['ara_definition'])
-        defn.definition_uid = data['definition_id']
-        defn.version_number = data['version_number']
-        defn.version_uid = data['id']
+        defn = AraDefinition.build(data['version']['ara_definition'])
+        defn.definition_uid = data['definition']['id']
+        defn.version_number = data['version']['version_number']
+        defn.version_uid = data['version']['id']
         defn.project_id = self.project_id
         defn.session = self.session
         return defn

--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -225,10 +225,11 @@ class AraDefinitionCollection(Collection[AraDefinition]):
 
     def build(self, data: dict) -> AraDefinition:
         """[ALPHA] Build an individual Ara Definition from a dictionary."""
-        defn = AraDefinition.build(data['version']['ara_definition'])
+        version_data = data['version']
+        defn = AraDefinition.build(version_data['ara_definition'])
+        defn.version_number = version_data['version_number']
+        defn.version_uid = version_data['id']
         defn.definition_uid = data['definition']['id']
-        defn.version_number = data['version']['version_number']
-        defn.version_uid = data['version']['id']
         defn.project_id = self.project_id
         defn.session = self.session
         return defn

--- a/tests/resources/test_ara_definition.py
+++ b/tests/resources/test_ara_definition.py
@@ -290,7 +290,7 @@ def test_register_existing(collection, session):
 
     # Ensure we PUT if we were called with a definition id
     assert session.last_call.method == "PUT"
-    assert session.last_call.path == f"projects/{project_id}/ara-definitions/6b608f78-e341-422c-8076-35adc8828545"
+    assert session.last_call.path == "projects/{}/ara-definitions/6b608f78-e341-422c-8076-35adc8828545".format(project_id)
 
 
 def test_update(collection, session):
@@ -315,7 +315,7 @@ def test_update(collection, session):
 
     # Ensure we POST if we weren't created with a definition id
     assert session.last_call.method == "PUT"
-    assert session.last_call.path == f"projects/{project_id}/ara-definitions/6b608f78-e341-422c-8076-35adc8828545"
+    assert session.last_call.path == "projects/{}/ara-definitions/6b608f78-e341-422c-8076-35adc8828545".format(project_id)
 
 
 def test_update_unregistered_fail(collection, session):

--- a/tests/resources/test_ara_definition.py
+++ b/tests/resources/test_ara_definition.py
@@ -1,4 +1,3 @@
-import json
 from uuid import UUID, uuid4
 
 import pytest
@@ -11,9 +10,8 @@ from citrine.ara.variables import AttributeByTemplate, RootInfo, IngredientQuant
 from citrine.resources.ara_definition import AraDefinitionCollection, AraDefinition
 from citrine.resources.project import Project
 from citrine.resources.process_template import ProcessTemplate
-from tests.utils.factories import AraDefinitionFactory
+from tests.utils.factories import AraDefinitionResponseDataFactory
 from tests.utils.session import FakeSession, FakeCall
-
 
 @pytest.fixture
 def session() -> FakeSession:
@@ -41,7 +39,7 @@ def collection(session) -> AraDefinitionCollection:
 @pytest.fixture
 def ara_definition() -> AraDefinition:
     def _ara_definition():
-        return AraDefinition.build(AraDefinitionFactory())
+        return AraDefinition.build(AraDefinitionResponseDataFactory())
     return _ara_definition
 
 
@@ -51,23 +49,27 @@ def empty_defn() -> AraDefinition:
 
 
 def test_get_ara_definition_metadata(collection, session):
+    """Get with version gets TBD"""
+
     # Given
     project_id = '6b608f78-e341-422c-8076-35adc8828545'
-    ara_definition = AraDefinitionFactory()
-    session.set_response({"version": ara_definition})
+    ara_definition_response = AraDefinitionResponseDataFactory()
+    session.set_response(ara_definition_response)
+    defn_id = ara_definition_response["definition"]["id"]
+    ver_number = ara_definition_response["version"]["version_number"]
 
     # When
-    retrieved_ara_definition: AraDefinition = collection.get_with_version(ara_definition["definition_id"], ara_definition["version_number"])
+    retrieved_ara_definition: AraDefinition = collection.get_with_version(defn_id, ver_number)
 
     # Then
     assert 1 == session.num_calls
     expect_call = FakeCall(
         method="GET",
-        path="projects/{}/ara-definitions/{}/versions/{}".format(project_id, ara_definition["definition_id"], ara_definition["version_number"])
+        path="projects/{}/ara-definitions/{}/versions/{}".format(project_id, defn_id, ver_number)
     )
     assert session.last_call == expect_call
-    assert str(retrieved_ara_definition.definition_uid) == ara_definition["definition_id"]
-    assert retrieved_ara_definition.version_number == ara_definition["version_number"]
+    assert str(retrieved_ara_definition.definition_uid) == defn_id
+    assert retrieved_ara_definition.version_number == ver_number
 
 
 def test_init_ara_definition():
@@ -241,81 +243,89 @@ def test_add_all_ingredients(session, project):
 
 def test_register_new(collection, session):
     """Test the behavior of AraDefinitionCollection.register() on an unregistered AraDefinition"""
+
     # Given
     project_id = '6b608f78-e341-422c-8076-35adc8828545'
-    ara_definition = AraDefinitionFactory()
-    ara_definition["definition_id"] = None
-    ara_definition["id"] = None
-    ara_definition["version_number"] = None
-    session.set_response({"version": ara_definition})
+    ara_definition = AraDefinition(name="name", description="description", datasets=[], rows=[], variables=[], columns=[])
+
+    ara_definition_response = AraDefinitionResponseDataFactory()
+    defn_uid = ara_definition_response["definition"]["id"]
+    ver_uid = ara_definition_response["version"]["id"]
+    session.set_response(ara_definition_response)
 
     # When
-    collection.register(collection.build(ara_definition))
+    registered = collection.register(ara_definition)
 
     # Then
-    assert 1 == session.num_calls
-    expect_call = FakeCall(
-        method="POST",
-        path="projects/{}/ara-definitions".format(project_id),
-        json={"definition": collection.build(ara_definition).dump()}
-    )
-    assert session.last_call == expect_call
+    assert registered.definition_uid == UUID(defn_uid)
+    assert registered.version_uid == UUID(ver_uid)
+    assert session.num_calls == 1
+
+    # Ensure we POST if we weren't created with a definition id
+    assert session.last_call.method == "POST"
+    assert session.last_call.path == "projects/{}/ara-definitions".format(project_id)
 
 
 def test_register_existing(collection, session):
     """Test the behavior of AraDefinitionCollection.register() on a registered AraDefinition"""
     # Given
     project_id = '6b608f78-e341-422c-8076-35adc8828545'
-    ara_definition = AraDefinitionFactory()
-    definition_uid = ara_definition["definition_id"]
-    assert definition_uid is not None
-    session.set_response({"version": ara_definition})
+    # ara_definition = AraDefinitionResponseDataFactory()
+    # definition_uid = ara_definition["definition_id"]
+
+    ara_definition = AraDefinition(name="name", description="description", datasets=[], rows=[], variables=[], columns=[],
+                                   definition_uid = UUID('6b608f78-e341-422c-8076-35adc8828545'))
+
+    ara_definition_response = AraDefinitionResponseDataFactory()
+    defn_uid = ara_definition_response["definition"]["id"]
+    ver_uid = ara_definition_response["version"]["id"]
+    session.set_response(ara_definition_response)
 
     # When
-    collection.register(collection.build(ara_definition))
+    registered = collection.register(ara_definition)
 
-    # Then
-    assert 1 == session.num_calls
-    expect_call = FakeCall(
-        method="PUT",
-        path="projects/{}/ara-definitions/{}".format(project_id, definition_uid),
-        json={"definition": collection.build(ara_definition).dump()}
-    )
-    assert session.last_call == expect_call
+    assert registered.definition_uid == UUID(defn_uid)
+    assert registered.version_uid == UUID(ver_uid)
+    assert session.num_calls == 1
+
+    # Ensure we PUT if we were called with a definition id
+    assert session.last_call.method == "PUT"
+    assert session.last_call.path == f"projects/{project_id}/ara-definitions/6b608f78-e341-422c-8076-35adc8828545"
 
 
 def test_update(collection, session):
     """Test the behavior of AraDefinitionCollection.update() on a registered AraDefinition"""
     # Given
     project_id = '6b608f78-e341-422c-8076-35adc8828545'
-    ara_definition = AraDefinitionFactory()
-    definition_uid = ara_definition["definition_id"]
-    assert definition_uid is not None
-    session.set_response({"version": ara_definition})
+    ara_definition = AraDefinition(name="name", description="description", datasets=[], rows=[], variables=[], columns=[],
+                                   definition_uid = UUID('6b608f78-e341-422c-8076-35adc8828545'))
+
+    ara_definition_response = AraDefinitionResponseDataFactory()
+    defn_uid = ara_definition_response["definition"]["id"]
+    ver_uid = ara_definition_response["version"]["id"]
+    session.set_response(ara_definition_response)
 
     # When
-    collection.update(collection.build(ara_definition))
+    registered = collection.update(ara_definition)
 
     # Then
-    assert 1 == session.num_calls
-    expect_call = FakeCall(
-        method="PUT",
-        path="projects/{}/ara-definitions/{}".format(project_id, definition_uid),
-        json={"definition": collection.build(ara_definition).dump()}
-    )
-    assert session.last_call == expect_call
+    assert registered.definition_uid == UUID(defn_uid)
+    assert registered.version_uid == UUID(ver_uid)
+    assert session.num_calls == 1
+
+    # Ensure we POST if we weren't created with a definition id
+    assert session.last_call.method == "PUT"
+    assert session.last_call.path == f"projects/{project_id}/ara-definitions/6b608f78-e341-422c-8076-35adc8828545"
 
 
 def test_update_unregistered_fail(collection, session):
     """Test that AraDefinitionCollection.update() fails on an unregistered AraDefinition"""
+
     # Given
-    project_id = '6b608f78-e341-422c-8076-35adc8828545'
-    ara_definition = AraDefinitionFactory()
-    ara_definition["definition_id"] = None
-    ara_definition["id"] = None
-    ara_definition["version_number"] = None
-    session.set_response({"version": ara_definition})
+
+    ara_definition = AraDefinition(name="name", description="description", datasets=[], rows=[], variables=[], columns=[],
+                                   definition_uid = None)
 
     # When
     with pytest.raises(ValueError, match="Cannot update Ara Definition without a definition_uid."):
-        collection.update(collection.build(ara_definition))
+        collection.update(ara_definition)

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -43,7 +43,8 @@ class ListTableVersionsDataFactory(factory.DictFactory):
     tables = [TableDataFactory()]
 
 
-class AraDefinitionDataFactory(factory.DictFactory):
+class AraDefinitionJSONDataFactory(factory.DictFactory):
+    """ This is simply the JSON Blob stored in an Ara Definition Version"""
     name = factory.Faker("company")
     description = factory.Faker('bs')
     rows = []
@@ -51,13 +52,19 @@ class AraDefinitionDataFactory(factory.DictFactory):
     variables = []
     datasets = []
 
-
-class AraDefinitionFactory(factory.DictFactory):
-    ara_definition = factory.SubFactory(AraDefinitionDataFactory)
+class AraDefinitionVersionJSONDataFactory(factory.DictFactory):
+    ara_definition = factory.SubFactory(AraDefinitionJSONDataFactory)
     id = factory.Faker('uuid4')
     version_number = randrange(10)
-    definition_id = factory.Faker('uuid4')
 
+class WithIdDataFactory(factory.DictFactory):
+    id = factory.Faker('uuid4')
+
+class AraDefinitionResponseDataFactory(factory.DictFactory):
+    """This is the AraDefinition object that encapsulates both version and definition info from the server"""
+
+    definition = factory.SubFactory(WithIdDataFactory)
+    version = factory.SubFactory(AraDefinitionVersionJSONDataFactory)
 
 class DatasetDataFactory(factory.DictFactory):
     id = factory.Faker('uuid4')


### PR DESCRIPTION
This changes some ara definitions stuff to allow listing of ara definitions.

Specifically:
 - using the proper collection key
 - removing the individual key
 - using properties from both version and definition when building an AraDefinition

Ken's e2e test exercises this code path.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
