### PR TITLE
Feature/pla 3507 batch write

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.28.3',
+      version='0.29.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -186,40 +186,44 @@ class Dataset(Resource['Dataset']):
         """Return a resource representing all files in the dataset."""
         return FileCollection(self.project_id, self.uid, self.session)
 
-    def register(self, data_concepts_resource: ResourceType, dry_run=False) -> ResourceType:
-        """Register a data concepts resource to the appropriate collection."""
+    def _collection_for(self, data_concepts_resource):
         if isinstance(data_concepts_resource, MeasurementTemplate):
-            return self.measurement_templates.register(data_concepts_resource, dry_run)
+            return self.measurement_templates
         if isinstance(data_concepts_resource, MeasurementSpec):
-            return self.measurement_specs.register(data_concepts_resource, dry_run)
+            return self.measurement_specs
         if isinstance(data_concepts_resource, MeasurementRun):
-            return self.measurement_runs.register(data_concepts_resource, dry_run)
+            return self.measurement_runs
 
         if isinstance(data_concepts_resource, MaterialTemplate):
-            return self.material_templates.register(data_concepts_resource, dry_run)
+            return self.material_templates
         if isinstance(data_concepts_resource, MaterialSpec):
-            return self.material_specs.register(data_concepts_resource, dry_run)
+            return self.material_specs
         if isinstance(data_concepts_resource, MaterialRun):
-            return self.material_runs.register(data_concepts_resource, dry_run)
+            return self.material_runs
 
         if isinstance(data_concepts_resource, ProcessTemplate):
-            return self.process_templates.register(data_concepts_resource, dry_run)
+            return self.process_templates
         if isinstance(data_concepts_resource, ProcessSpec):
-            return self.process_specs.register(data_concepts_resource, dry_run)
+            return self.process_specs
         if isinstance(data_concepts_resource, ProcessRun):
-            return self.process_runs.register(data_concepts_resource, dry_run)
+            return self.process_runs
 
         if isinstance(data_concepts_resource, IngredientSpec):
-            return self.ingredient_specs.register(data_concepts_resource, dry_run)
+            return self.ingredient_specs
         if isinstance(data_concepts_resource, IngredientRun):
-            return self.ingredient_runs.register(data_concepts_resource, dry_run)
+            return self.ingredient_runs
 
         if isinstance(data_concepts_resource, PropertyTemplate):
-            return self.property_templates.register(data_concepts_resource, dry_run)
+            return self.property_templates
         if isinstance(data_concepts_resource, ParameterTemplate):
-            return self.parameter_templates.register(data_concepts_resource, dry_run)
+            return self.parameter_templates
         if isinstance(data_concepts_resource, ConditionTemplate):
-            return self.condition_templates.register(data_concepts_resource, dry_run)
+            return self.condition_templates
+
+    def register(self, data_concepts_resource: ResourceType, dry_run=False) -> ResourceType:
+        """Register a data concepts resource to the appropriate collection."""
+        return self._collection_for(data_concepts_resource)\
+            .register(data_concepts_resource, dry_run=dry_run)
 
     def register_all(self, data_concepts_resources: List[ResourceType],
                      dry_run=False) -> List[ResourceType]:

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -42,6 +42,19 @@ def test_register_material_run(collection, session):
     assert "<Material run 'Test MR 123'>" == str(registered)
 
 
+def test_register_all(collection, session):
+    runs = [MaterialRunFactory(name='1'), MaterialRunFactory(name='2'),  MaterialRunFactory(name='3')]
+    session.set_response({'objects': [r.dump() for r in runs]})
+    registered = collection.register_all(runs)
+    assert [r.name for r in runs] == [r.name for r in registered]
+    assert len(session.calls) == 1
+    assert session.calls[0].method == 'PUT'
+    assert session.calls[0].path == 'projects/{}/datasets/{}/material-runs/batch'.format(
+        collection.project_id, collection.dataset_id)
+    with pytest.raises(RuntimeError):
+        MaterialRunCollection(collection.project_id, dataset_id=None, session=session).register_all([])
+
+
 def test_dry_run_register_material_run(collection, session):
     # Given
     session.set_response(MaterialRunDataFactory(name='Test MR 123'))


### PR DESCRIPTION
# Citrine Python PR

## Description 
Adds new batch write method for data concepts collections, `register_all`.

Note that there will likely be changes to API limits for batch size and to the validation error response structure in the near future. What those changes will be is unclear at the moment.

My initial testing shows a reduction in ingest time for the breads dataset (308 objects of mixed types) from 53s to 6s, and a reduction of write time for 100 empty process specs from 17s to 0.67s.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
