### PR TITLE
Pla 4302/prdictor config in report

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.31.0',
+      version='0.32.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/informatics/reports.py
+++ b/src/citrine/informatics/reports.py
@@ -3,6 +3,7 @@ from typing import Optional, Type, List, Dict, TypeVar, Iterable, Any
 from abc import abstractmethod
 from itertools import groupby
 import warnings
+from uuid import UUID
 
 from citrine._serialization import properties
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
@@ -76,6 +77,8 @@ class ModelSummary(Serializable['ModelSummary']):
     ----------
     name: str
         the name of the model
+    type_: str
+        the type of the model (e.g., "ML Model", "Featurizer", etc.)
     inputs: List[Descriptor]
         list of input descriptors
     outputs: List[Descriptor]
@@ -84,27 +87,40 @@ class ModelSummary(Serializable['ModelSummary']):
         settings of the model, as a dictionary (details depend on model type)
     feature_importances: List[FeatureImportanceReport]
         list of feature importance reports, one for each output
+    predictor_name: str
+        the name of the predictor that created this model
+    predictor_uid: Optional[uuid]
+        the uid of the predictor that created this model
 
     """
 
     name = properties.String('name')
+    type_ = properties.String('type')
     inputs = properties.List(properties.String(), 'inputs')
     outputs = properties.List(properties.String(), 'outputs')
     model_settings = properties.Raw('model_settings')
     feature_importances = properties.List(
         properties.Object(FeatureImportanceReport), 'feature_importances')
+    predictor_name = properties.String('predictor_configuration_name', default='')
+    predictor_uid = properties.Optional(properties.UUID(), 'predictor_configuration_uid')
 
     def __init__(self,
                  name: str,
+                 type_: str,
                  inputs: List[Descriptor],
                  outputs: List[Descriptor],
                  model_settings: Dict[str, Any],
-                 feature_importances: List[FeatureImportanceReport]):
+                 feature_importances: List[FeatureImportanceReport],
+                 predictor_name: str,
+                 predictor_uid: Optional[UUID] = None):
         self.name = name
+        self.type_ = type_
         self.inputs = inputs
         self.outputs = outputs
         self.model_settings = model_settings
         self.feature_importances = feature_importances
+        self.predictor_name = predictor_name
+        self.predictor_uid = predictor_uid
 
     def __str__(self):
         return '<ModelSummary {!r}>'.format(self.name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,7 @@ def valid_predictor_report_data():
             models=[
                 dict(
                     name='GeneralLoloModel_1',
-                    type='GeneralLoloModel',
+                    type='ML Model',
                     inputs=[x.key],
                     outputs=[y.key],
                     display_name='ML Model',
@@ -220,11 +220,12 @@ def valid_predictor_report_data():
                             importances=dict(x=1.00),
                             top_features=5
                         )
-                    ]
+                    ],
+                    predictor_configuration_name="Predict y from x with ML"
                 ),
                 dict(
                     name='GeneralLosslessModel_2',
-                    type='GeneralLosslessModel',
+                    type='Analytic Model',
                     inputs=[x.key, y.key],
                     outputs=[z.key],
                     display_name='GeneralLosslessModel_2',
@@ -235,7 +236,9 @@ def valid_predictor_report_data():
                             children=[]
                         )
                     ],
-                    feature_importances=[]
+                    feature_importances=[],
+                    predictor_configuration_name="Expression for z",
+                    predictor_configuration_uid="249bf32c-6f3d-4a93-9387-94cc877f170c"
                 )
             ],
             descriptors=[x.dump(), y.dump(), z.dump()]

--- a/tests/informatics/test_informatics.py
+++ b/tests/informatics/test_informatics.py
@@ -20,7 +20,7 @@ informatics_string_data = [
     (LIScore("LI(z)", "score for z", [], []), "<LIScore 'LI(z)'>"),
     (EIScore("EI(x)", "score for x", [], [], []), "<EIScore 'EI(x)'>"),
     (FeatureImportanceReport("reflectivity", {}), "<FeatureImportanceReport 'reflectivity'>"),
-    (ModelSummary("my model", [], [], {}, []), "<ModelSummary 'my model'>"),
+    (ModelSummary("my model", "ML Model", [], [], {}, [], "predictor name"), "<ModelSummary 'my model'>"),
 ]
 
 

--- a/tests/informatics/test_reports.py
+++ b/tests/informatics/test_reports.py
@@ -18,8 +18,10 @@ def test_model_summary_init():
     z = RealDescriptor('z', 0, 1)
     feat_importance = FeatureImportanceReport(output_key='z', importances={'x': 0.8, 'y': 0.2})
     ModelSummary(name='General model',
+                 type_="ML Model",
                  inputs=[x, y],
                  outputs=[z],
                  model_settings={'optimization restarts': 15, 'backpropagation': False},
-                 feature_importances=[feat_importance]
+                 feature_importances=[feat_importance],
+                 predictor_name="a predictor"
                  )

--- a/tests/serialization/test_reports.py
+++ b/tests/serialization/test_reports.py
@@ -2,6 +2,7 @@
 import pytest
 from copy import deepcopy
 import warnings
+from uuid import UUID
 
 from citrine.informatics.descriptors import RealDescriptor
 from citrine.informatics.reports import Report, ModelSummary, FeatureImportanceReport
@@ -21,6 +22,7 @@ def test_predictor_report_build(valid_predictor_report_data):
 
     lolo_model: ModelSummary = report.model_summaries[0]
     assert lolo_model.name == 'GeneralLoloModel_1'
+    assert lolo_model.type_ == 'ML Model'
     assert lolo_model.inputs == [x]
     assert lolo_model.outputs == [y]
     assert lolo_model.model_settings == {
@@ -30,15 +32,20 @@ def test_predictor_report_build(valid_predictor_report_data):
         'Use jackknife': True
     }
     assert lolo_model.feature_importances[0].dump() == FeatureImportanceReport('y', {'x': 1.0}).dump()
+    assert lolo_model.predictor_name == 'Predict y from x with ML'
+    assert lolo_model.predictor_uid is None
 
     exp_model: ModelSummary = report.model_summaries[1]
     assert exp_model.name == 'GeneralLosslessModel_2'
+    assert exp_model.type_ == 'Analytic Model'
     assert exp_model.inputs == [x, y]
     assert exp_model.outputs == [z]
     assert exp_model.model_settings == {
         "Expression": "(z) <- (x + y)"
     }
     assert exp_model.feature_importances == []
+    assert exp_model.predictor_name == 'Expression for z'
+    assert exp_model.predictor_uid == UUID("249bf32c-6f3d-4a93-9387-94cc877f170c")
 
 
 def test_empty_report_build():


### PR DESCRIPTION
# Citrine Python PR

## Description 
Include predictor name and uid as well as model type in model report.

This is waiting on both https://github.com/CitrineInformatics/platform-backend/pull/1213 and https://github.com/CitrineInformatics/platform-backend/pull/1227
*edit* actually, we can merge this before the platform-backend PRs. If the `predictor_configuration_name` and/or `predictor_configuration_uid` fields are empty, the client defaults to empty strings.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [X] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
