### PR TITLE
Remove CitrineID from object constructor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.33.0',
+      version='0.34.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.32.1',
+      version='0.33.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_utils/functions.py
+++ b/src/citrine/_utils/functions.py
@@ -1,61 +1,30 @@
-from typing import Dict, Any
-from copy import deepcopy
+from typing import Any
 from urllib.parse import urlparse
-from uuid import uuid4, UUID
 import os
 
 from gemd.entity.link_by_uid import LinkByUID
 
-
-def set_default_uid(id_dict: Dict[str, str]) -> Dict[str, str]:
-    """
-    Validates a dictionary of ids, adding a default id if necessary.
-
-    The scope 'id' is reserved for a Citrine id, and it must be a UUID4.
-    If there is no id with scope 'id', it is set to an automatically generated UUID4.
-    If 'id' corresponds to an id that is not a UUID4, an exception is thrown.
-
-    :return the input id dictionary, with the Citrine id added, if necessary.
-
-    """
-    reserved_scope = 'id'
-    if isinstance(id_dict, dict):
-        if reserved_scope in id_dict:
-            try:
-                # If id_dict['id'] is a string of a valid uuid, then this call will be successful
-                UUID(id_dict[reserved_scope])
-            except Exception:
-                raise ValueError("{} scope must correspond to a UUID, "
-                                 "instead got {}".format(reserved_scope, id_dict[reserved_scope]))
-            return id_dict
-        else:
-            id_dict_copy = deepcopy(id_dict)
-            id_dict_copy[reserved_scope] = str(uuid4())
-            return id_dict_copy
-    elif id_dict is None:
-        return {reserved_scope: str(uuid4())}
-    else:
-        raise Exception("Cannot validate id for {}".format(id_dict))
+CITRINE_SCOPE = 'id'
 
 
 def get_object_id(object_or_id):
     """Extract the citrine id from a data concepts object or LinkByUID."""
     from gemd.entity.attribute.base_attribute import BaseAttribute
     from citrine.resources.data_concepts import DataConcepts
+
     if isinstance(object_or_id, BaseAttribute):
         raise ValueError("Attributes do not have ids.")
-    citrine_scope = 'id'
     if isinstance(object_or_id, DataConcepts):
-        citrine_id = object_or_id.uids.get(citrine_scope)
+        citrine_id = object_or_id.uids.get(CITRINE_SCOPE)
         if citrine_id is not None:
             return citrine_id
         raise ValueError("Data concepts object {!r} must have a citrine uuid with "
-                         "scope".format(object_or_id, citrine_scope))
+                         "scope".format(object_or_id, CITRINE_SCOPE))
     if isinstance(object_or_id, LinkByUID):
-        if object_or_id.scope == citrine_scope:
+        if object_or_id.scope == CITRINE_SCOPE:
             return object_or_id.id
         raise ValueError("LinkByUID must be scoped to citrine scope {}, "
-                         "instead is {}".format(citrine_scope, object_or_id.scope))
+                         "instead is {}".format(CITRINE_SCOPE, object_or_id.scope))
     raise TypeError("{} must be a data concepts object or LinkByUID".format(object_or_id))
 
 

--- a/src/citrine/resources/condition_template.py
+++ b/src/citrine/resources/condition_template.py
@@ -46,10 +46,12 @@ class ConditionTemplate(AttributeTemplate, Resource['ConditionTemplate'], GEMDCo
     def __init__(self,
                  name: str,
                  bounds: BaseBounds,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None
                  ):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDConditionTemplate.typ)
         GEMDConditionTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
                                        uids=uids, description=description)

--- a/src/citrine/resources/condition_template.py
+++ b/src/citrine/resources/condition_template.py
@@ -5,7 +5,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Mapping, Object
-from citrine._utils.functions import set_default_uid
 from citrine.resources.attribute_templates import AttributeTemplate, AttributeTemplateCollection
 from citrine.resources.data_concepts import DataConcepts
 from gemd.entity.bounds.base_bounds import BaseBounds
@@ -47,13 +46,13 @@ class ConditionTemplate(AttributeTemplate, Resource['ConditionTemplate'], GEMDCo
     def __init__(self,
                  name: str,
                  bounds: BaseBounds,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None
                  ):
         DataConcepts.__init__(self, GEMDConditionTemplate.typ)
         GEMDConditionTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
-                                       uids=set_default_uid(uids), description=description)
+                                       uids=uids, description=description)
 
     def __str__(self):
         return '<Condition template {!r}>'.format(self.name)

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -402,7 +402,7 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         path = self._get_path()
         params = {'dry_run': dry_run}
 
-        json = GEMDJson(scope=CITRINE_SCOPE)  # This apparent no-op populates uids
+        json = GEMDJson(scope=CITRINE_SCOPE)
         [json.dumps(x) for x in models]  # This apparent no-op populates uids
 
         objects = [replace_objects_with_links(scrub_none(model.dump())) for model in models]

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -16,6 +16,8 @@ from gemd.entity.dict_serializable import DictSerializable
 from gemd.entity.link_by_uid import LinkByUID
 from gemd.json import GEMDJson
 
+CITRINE_SCOPE = 'id'
+
 
 class DataConcepts(PolymorphicSerializable['DataConcepts'], DictSerializable, ABC):
     """
@@ -194,7 +196,7 @@ class DataConcepts(PolymorphicSerializable['DataConcepts'], DictSerializable, AB
         """Get a DataConcepts-compatible json serializer/deserializer."""
         if cls.json_support is None:
             DataConcepts._make_class_dict()
-            cls.json_support = GEMDJson()
+            cls.json_support = GEMDJson(scope=CITRINE_SCOPE)
             cls.json_support.register_classes(
                 {k: v for k, v in DataConcepts.class_dict.items() if k != "link_by_uid"}
             )
@@ -405,7 +407,7 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         )
         return [self.build(obj) for obj in response_data['objects']]
 
-    def get(self, uid: Union[UUID, str], scope: str = 'id') -> ResourceType:
+    def get(self, uid: Union[UUID, str], scope: str = CITRINE_SCOPE) -> ResourceType:
         """
         Get the element of the collection with ID equal to uid.
 
@@ -414,7 +416,7 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         uid: Union[UUID, str]
             The ID.
         scope: str
-            The scope of the uid, defaults to Citrine scope ('id')
+            The scope of the uid, defaults to Citrine scope (CITRINE_SCOPE)
 
         Returns
         -------
@@ -607,7 +609,7 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
             params=params)
         return (self.build(raw) for raw in raw_objects)
 
-    def delete(self, uid: Union[UUID, str], scope: str = 'id', dry_run: bool = False):
+    def delete(self, uid: Union[UUID, str], scope: str = CITRINE_SCOPE, dry_run: bool = False):
         """
         Delete the element of the collection with ID equal to uid.
 
@@ -616,7 +618,7 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         uid: Union[UUID, str]
             The ID.
         scope: str
-            The scope of the uid, defaults to Citrine scope ('id')
+            The scope of the uid, defaults to Citrine scope (CITRINE_SCOPE)
         dry_run: bool
             Whether to actually delete the item or run a dry run of the delete operation.
             Dry run is intended to be used for validation. Default: false

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -365,6 +365,8 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         # know how to replace the objects with link-by-uids. loads() converts this string into
         # nested gemd objects, and then the final dumps() converts that to a json-ready string
         # in which all of the object references have been replaced with link-by-uids.
+
+        GEMDJson(scope=CITRINE_SCOPE).dumps(model)  # This apparent no-op populates uids
         dumped_data = replace_objects_with_links(scrub_none(model.dump()))
         data = self.session.post_resource(path, dumped_data, params=params)
         full_model = self.build(data)
@@ -399,6 +401,10 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
             raise RuntimeError("Must specify a dataset in order to register a data model object.")
         path = self._get_path()
         params = {'dry_run': dry_run}
+
+        json = GEMDJson(scope=CITRINE_SCOPE)  # This apparent no-op populates uids
+        [json.dumps(x) for x in models]  # This apparent no-op populates uids
+
         objects = [replace_objects_with_links(scrub_none(model.dump())) for model in models]
         response_data = self.session.put_resource(
             path + '/batch',

--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -83,7 +83,7 @@ class IngredientRun(ObjectRun, Resource['IngredientRun'], GEMDIngredientRun):
 
     def __init__(self,
                  name: Optional[str] = None,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  material: Optional[GEMDMaterialRun] = None,
@@ -95,6 +95,8 @@ class IngredientRun(ObjectRun, Resource['IngredientRun'], GEMDIngredientRun):
                  labels: Optional[List[str]] = None,
                  spec: Optional[GEMDIngredientSpec] = None,
                  file_links: Optional[List[FileLink]] = None):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDIngredientRun.typ)
         GEMDIngredientRun.__init__(self, uids=uids, tags=tags, notes=notes,
                                    material=material, process=process,

--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -6,7 +6,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Mapping, String, LinkOrElse, Object
 from citrine._serialization.properties import Optional as PropertyOptional
-from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.object_runs import ObjectRun, ObjectRunCollection
 from gemd.entity.file_link import FileLink
@@ -84,7 +83,7 @@ class IngredientRun(ObjectRun, Resource['IngredientRun'], GEMDIngredientRun):
 
     def __init__(self,
                  name: Optional[str] = None,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  material: Optional[GEMDMaterialRun] = None,
@@ -97,7 +96,7 @@ class IngredientRun(ObjectRun, Resource['IngredientRun'], GEMDIngredientRun):
                  spec: Optional[GEMDIngredientSpec] = None,
                  file_links: Optional[List[FileLink]] = None):
         DataConcepts.__init__(self, GEMDIngredientRun.typ)
-        GEMDIngredientRun.__init__(self, uids=set_default_uid(uids), tags=tags, notes=notes,
+        GEMDIngredientRun.__init__(self, uids=uids, tags=tags, notes=notes,
                                    material=material, process=process,
                                    mass_fraction=mass_fraction, volume_fraction=volume_fraction,
                                    number_fraction=number_fraction,

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -6,7 +6,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Mapping, String, LinkOrElse, Object
 from citrine._serialization.properties import Optional as PropertyOptional
-from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.object_specs import ObjectSpec, ObjectSpecCollection
 from gemd.entity.file_link import FileLink
@@ -78,7 +77,7 @@ class IngredientSpec(ObjectSpec, Resource['IngredientSpec'], GEMDIngredientSpec)
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  material: Optional[GEMDMaterialSpec] = None,
@@ -90,7 +89,7 @@ class IngredientSpec(ObjectSpec, Resource['IngredientSpec'], GEMDIngredientSpec)
                  labels: Optional[List[str]] = None,
                  file_links: Optional[List[FileLink]] = None):
         DataConcepts.__init__(self, GEMDIngredientSpec.typ)
-        GEMDIngredientSpec.__init__(self, uids=set_default_uid(uids), tags=tags, notes=notes,
+        GEMDIngredientSpec.__init__(self, uids=uids, tags=tags, notes=notes,
                                     material=material, process=process,
                                     mass_fraction=mass_fraction, volume_fraction=volume_fraction,
                                     number_fraction=number_fraction,

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -77,7 +77,7 @@ class IngredientSpec(ObjectSpec, Resource['IngredientSpec'], GEMDIngredientSpec)
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  material: Optional[GEMDMaterialSpec] = None,
@@ -88,6 +88,9 @@ class IngredientSpec(ObjectSpec, Resource['IngredientSpec'], GEMDIngredientSpec)
                  absolute_quantity: Optional[ContinuousValue] = None,
                  labels: Optional[List[str]] = None,
                  file_links: Optional[List[FileLink]] = None):
+        if uids is None:
+            uids = dict()
+
         DataConcepts.__init__(self, GEMDIngredientSpec.typ)
         GEMDIngredientSpec.__init__(self, uids=uids, tags=tags, notes=notes,
                                     material=material, process=process,

--- a/src/citrine/resources/material_run.py
+++ b/src/citrine/resources/material_run.py
@@ -76,13 +76,15 @@ class MaterialRun(ObjectRun, Resource['MaterialRun'], GEMDMaterialRun):
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  process: Optional[GEMDProcessRun] = None,
                  sample_type: Optional[str] = "unknown",
                  spec: Optional[GEMDMaterialSpec] = None,
                  file_links: Optional[List[FileLink]] = None):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDMaterialRun.typ)
         GEMDMaterialRun.__init__(self, name=name, uids=uids,
                                  tags=tags, process=process,

--- a/src/citrine/resources/material_run.py
+++ b/src/citrine/resources/material_run.py
@@ -11,7 +11,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, LinkOrElse, Mapping, Object
-from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.material_spec import MaterialSpecCollection
 from citrine.resources.object_runs import ObjectRun, ObjectRunCollection
@@ -77,7 +76,7 @@ class MaterialRun(ObjectRun, Resource['MaterialRun'], GEMDMaterialRun):
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  process: Optional[GEMDProcessRun] = None,
@@ -85,7 +84,7 @@ class MaterialRun(ObjectRun, Resource['MaterialRun'], GEMDMaterialRun):
                  spec: Optional[GEMDMaterialSpec] = None,
                  file_links: Optional[List[FileLink]] = None):
         DataConcepts.__init__(self, GEMDMaterialRun.typ)
-        GEMDMaterialRun.__init__(self, name=name, uids=set_default_uid(uids),
+        GEMDMaterialRun.__init__(self, name=name, uids=uids,
                                  tags=tags, process=process,
                                  sample_type=sample_type, spec=spec,
                                  file_links=file_links, notes=notes)

--- a/src/citrine/resources/material_spec.py
+++ b/src/citrine/resources/material_spec.py
@@ -9,7 +9,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, LinkOrElse, Mapping, Object
-from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.object_specs import ObjectSpec, ObjectSpecCollection
 from gemd.entity.attribute.property_and_conditions import PropertyAndConditions
@@ -66,7 +65,7 @@ class MaterialSpec(ObjectSpec, Resource['MaterialSpec'], GEMDMaterialSpec):
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  process: Optional[GEMDProcessSpec] = None,
@@ -74,7 +73,7 @@ class MaterialSpec(ObjectSpec, Resource['MaterialSpec'], GEMDMaterialSpec):
                  template: Optional[GEMDMaterialTemplate] = None,
                  file_links: Optional[List[FileLink]] = None):
         DataConcepts.__init__(self, GEMDMaterialSpec.typ)
-        GEMDMaterialSpec.__init__(self, name=name, uids=set_default_uid(uids),
+        GEMDMaterialSpec.__init__(self, name=name, uids=uids,
                                   tags=tags, process=process, properties=properties,
                                   template=template, file_links=file_links, notes=notes)
 

--- a/src/citrine/resources/material_spec.py
+++ b/src/citrine/resources/material_spec.py
@@ -65,13 +65,15 @@ class MaterialSpec(ObjectSpec, Resource['MaterialSpec'], GEMDMaterialSpec):
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  process: Optional[GEMDProcessSpec] = None,
                  properties: Optional[List[PropertyAndConditions]] = None,
                  template: Optional[GEMDMaterialTemplate] = None,
                  file_links: Optional[List[FileLink]] = None):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDMaterialSpec.typ)
         GEMDMaterialSpec.__init__(self, name=name, uids=uids,
                                   tags=tags, process=process, properties=properties,

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -56,7 +56,7 @@ class MaterialTemplate(ObjectTemplate, Resource['MaterialTemplate'], GEMDMateria
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  properties: Optional[Sequence[Union[PropertyTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[PropertyTemplate, LinkByUID,
@@ -67,6 +67,8 @@ class MaterialTemplate(ObjectTemplate, Resource['MaterialTemplate'], GEMDMateria
         # properties is a list, each element of which is a PropertyTemplate OR is a list with
         # 2 entries: [PropertyTemplate, BaseBounds]. Python typing is not expressive enough, so
         # the typing above is more general.
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDMaterialTemplate.typ)
         GEMDMaterialTemplate.__init__(self, name=name, properties=properties,
                                       uids=uids, tags=tags,

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -6,7 +6,6 @@ from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, \
     LinkOrElse
-from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.object_templates import ObjectTemplateCollection, ObjectTemplate
 from citrine.resources.property_template import PropertyTemplate
@@ -57,7 +56,7 @@ class MaterialTemplate(ObjectTemplate, Resource['MaterialTemplate'], GEMDMateria
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  properties: Optional[Sequence[Union[PropertyTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[PropertyTemplate, LinkByUID,
@@ -70,7 +69,7 @@ class MaterialTemplate(ObjectTemplate, Resource['MaterialTemplate'], GEMDMateria
         # the typing above is more general.
         DataConcepts.__init__(self, GEMDMaterialTemplate.typ)
         GEMDMaterialTemplate.__init__(self, name=name, properties=properties,
-                                      uids=set_default_uid(uids), tags=tags,
+                                      uids=uids, tags=tags,
                                       description=description)
 
     def __str__(self):

--- a/src/citrine/resources/measurement_run.py
+++ b/src/citrine/resources/measurement_run.py
@@ -72,7 +72,7 @@ class MeasurementRun(ObjectRun, Resource['MeasurementRun'], GEMDMeasurementRun):
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  conditions: Optional[List[Condition]] = None,
@@ -82,6 +82,8 @@ class MeasurementRun(ObjectRun, Resource['MeasurementRun'], GEMDMeasurementRun):
                  material: Optional[GEMDMaterialRun] = None,
                  file_links: Optional[List[FileLink]] = None,
                  source: Optional[PerformedSource] = None):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDMeasurementRun.typ)
         GEMDMeasurementRun.__init__(self, name=name, uids=uids,
                                     material=material,

--- a/src/citrine/resources/measurement_run.py
+++ b/src/citrine/resources/measurement_run.py
@@ -6,7 +6,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Object, Mapping, LinkOrElse
-from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.object_runs import ObjectRun, ObjectRunCollection
 from gemd.entity.attribute.condition import Condition
@@ -73,7 +72,7 @@ class MeasurementRun(ObjectRun, Resource['MeasurementRun'], GEMDMeasurementRun):
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  conditions: Optional[List[Condition]] = None,
@@ -84,7 +83,7 @@ class MeasurementRun(ObjectRun, Resource['MeasurementRun'], GEMDMeasurementRun):
                  file_links: Optional[List[FileLink]] = None,
                  source: Optional[PerformedSource] = None):
         DataConcepts.__init__(self, GEMDMeasurementRun.typ)
-        GEMDMeasurementRun.__init__(self, name=name, uids=set_default_uid(uids),
+        GEMDMeasurementRun.__init__(self, name=name, uids=uids,
                                     material=material,
                                     tags=tags, conditions=conditions, properties=properties,
                                     parameters=parameters, spec=spec,

--- a/src/citrine/resources/measurement_spec.py
+++ b/src/citrine/resources/measurement_spec.py
@@ -60,13 +60,15 @@ class MeasurementSpec(ObjectSpec, Resource['MeasurementSpec'], GEMDMeasurementSp
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  conditions: Optional[List[Condition]] = None,
                  parameters: Optional[List[Parameter]] = None,
                  template: Optional[GEMDMeasurementTemplate] = None,
                  file_links: Optional[List[FileLink]] = None):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDMeasurementSpec.typ)
         GEMDMeasurementSpec.__init__(self, name=name, uids=uids,
                                      tags=tags, conditions=conditions, parameters=parameters,

--- a/src/citrine/resources/measurement_spec.py
+++ b/src/citrine/resources/measurement_spec.py
@@ -6,7 +6,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Object, Mapping, LinkOrElse
-from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.object_specs import ObjectSpec, ObjectSpecCollection
 from gemd.entity.attribute.condition import Condition
@@ -61,7 +60,7 @@ class MeasurementSpec(ObjectSpec, Resource['MeasurementSpec'], GEMDMeasurementSp
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  conditions: Optional[List[Condition]] = None,
@@ -69,7 +68,7 @@ class MeasurementSpec(ObjectSpec, Resource['MeasurementSpec'], GEMDMeasurementSp
                  template: Optional[GEMDMeasurementTemplate] = None,
                  file_links: Optional[List[FileLink]] = None):
         DataConcepts.__init__(self, GEMDMeasurementSpec.typ)
-        GEMDMeasurementSpec.__init__(self, name=name, uids=set_default_uid(uids),
+        GEMDMeasurementSpec.__init__(self, name=name, uids=uids,
                                      tags=tags, conditions=conditions, parameters=parameters,
                                      template=template, file_links=file_links, notes=notes)
 

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -6,7 +6,6 @@ from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, \
     LinkOrElse
-from citrine._utils.functions import set_default_uid
 from citrine.resources.condition_template import ConditionTemplate
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.object_templates import ObjectTemplate, ObjectTemplateCollection
@@ -75,7 +74,7 @@ class MeasurementTemplate(ObjectTemplate,
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  properties: Optional[Sequence[Union[PropertyTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[PropertyTemplate, LinkByUID,
@@ -96,7 +95,7 @@ class MeasurementTemplate(ObjectTemplate,
         DataConcepts.__init__(self, GEMDMeasurementTemplate.typ)
         GEMDMeasurementTemplate.__init__(self, name=name, properties=properties,
                                          conditions=conditions, parameters=parameters, tags=tags,
-                                         uids=set_default_uid(uids), description=description)
+                                         uids=uids, description=description)
 
     def __str__(self):
         return '<Measurement template {!r}>'.format(self.name)

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -74,7 +74,7 @@ class MeasurementTemplate(ObjectTemplate,
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  properties: Optional[Sequence[Union[PropertyTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[PropertyTemplate, LinkByUID,
@@ -92,6 +92,8 @@ class MeasurementTemplate(ObjectTemplate,
                                                      ]]] = None,
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDMeasurementTemplate.typ)
         GEMDMeasurementTemplate.__init__(self, name=name, properties=properties,
                                          conditions=conditions, parameters=parameters, tags=tags,

--- a/src/citrine/resources/parameter_template.py
+++ b/src/citrine/resources/parameter_template.py
@@ -5,7 +5,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Mapping, Object
-from citrine._utils.functions import set_default_uid
 from citrine.resources.attribute_templates import AttributeTemplate, AttributeTemplateCollection
 from citrine.resources.data_concepts import DataConcepts
 from gemd.entity.bounds.base_bounds import BaseBounds
@@ -47,12 +46,12 @@ class ParameterTemplate(AttributeTemplate, Resource['ParameterTemplate'], GEMDPa
     def __init__(self,
                  name: str,
                  bounds: BaseBounds,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None):
         DataConcepts.__init__(self, GEMDParameterTemplate.typ)
         GEMDParameterTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
-                                       uids=set_default_uid(uids), description=description)
+                                       uids=uids, description=description)
 
     def __str__(self):
         return '<Parameter template {!r}>'.format(self.name)

--- a/src/citrine/resources/parameter_template.py
+++ b/src/citrine/resources/parameter_template.py
@@ -46,9 +46,11 @@ class ParameterTemplate(AttributeTemplate, Resource['ParameterTemplate'], GEMDPa
     def __init__(self,
                  name: str,
                  bounds: BaseBounds,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDParameterTemplate.typ)
         GEMDParameterTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
                                        uids=uids, description=description)

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -6,7 +6,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Mapping, Object, LinkOrElse
-from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.object_runs import ObjectRun, ObjectRunCollection
 from gemd.entity.attribute.condition import Condition
@@ -75,7 +74,7 @@ class ProcessRun(ObjectRun, Resource['ProcessRun'], GEMDProcessRun):
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  conditions: Optional[List[Condition]] = None,
@@ -84,7 +83,7 @@ class ProcessRun(ObjectRun, Resource['ProcessRun'], GEMDProcessRun):
                  file_links: Optional[List[FileLink]] = None,
                  source: Optional[PerformedSource] = None):
         DataConcepts.__init__(self, GEMDProcessRun.typ)
-        GEMDProcessRun.__init__(self, name=name, uids=set_default_uid(uids),
+        GEMDProcessRun.__init__(self, name=name, uids=uids,
                                 tags=tags, conditions=conditions, parameters=parameters,
                                 spec=spec, file_links=file_links, notes=notes, source=source)
 

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -74,7 +74,7 @@ class ProcessRun(ObjectRun, Resource['ProcessRun'], GEMDProcessRun):
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  conditions: Optional[List[Condition]] = None,
@@ -82,6 +82,8 @@ class ProcessRun(ObjectRun, Resource['ProcessRun'], GEMDProcessRun):
                  spec: Optional[GEMDProcessSpec] = None,
                  file_links: Optional[List[FileLink]] = None,
                  source: Optional[PerformedSource] = None):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDProcessRun.typ)
         GEMDProcessRun.__init__(self, name=name, uids=uids,
                                 tags=tags, conditions=conditions, parameters=parameters,

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -70,7 +70,7 @@ class ProcessSpec(ObjectSpec, Resource['ProcessSpec'], GEMDProcessSpec):
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  conditions: Optional[List[Condition]] = None,
@@ -78,6 +78,8 @@ class ProcessSpec(ObjectSpec, Resource['ProcessSpec'], GEMDProcessSpec):
                  template: Optional[GEMDProcessTemplate] = None,
                  file_links: Optional[List[FileLink]] = None
                  ):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDProcessSpec.typ)
         GEMDProcessSpec.__init__(self, name=name, uids=uids,
                                  tags=tags, conditions=conditions, parameters=parameters,

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -6,7 +6,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Mapping, Object, LinkOrElse
-from citrine._utils.functions import set_default_uid
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.object_specs import ObjectSpec, ObjectSpecCollection
 from gemd.entity.attribute.condition import Condition
@@ -71,7 +70,7 @@ class ProcessSpec(ObjectSpec, Resource['ProcessSpec'], GEMDProcessSpec):
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  tags: Optional[List[str]] = None,
                  notes: Optional[str] = None,
                  conditions: Optional[List[Condition]] = None,
@@ -80,7 +79,7 @@ class ProcessSpec(ObjectSpec, Resource['ProcessSpec'], GEMDProcessSpec):
                  file_links: Optional[List[FileLink]] = None
                  ):
         DataConcepts.__init__(self, GEMDProcessSpec.typ)
-        GEMDProcessSpec.__init__(self, name=name, uids=set_default_uid(uids),
+        GEMDProcessSpec.__init__(self, name=name, uids=uids,
                                  tags=tags, conditions=conditions, parameters=parameters,
                                  template=template, file_links=file_links, notes=notes)
 

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -66,7 +66,7 @@ class ProcessTemplate(ObjectTemplate, Resource['ProcessTemplate'], GEMDProcessTe
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  conditions: Optional[Sequence[Union[ConditionTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[ConditionTemplate, LinkByUID,
@@ -81,6 +81,8 @@ class ProcessTemplate(ObjectTemplate, Resource['ProcessTemplate'], GEMDProcessTe
                  allowed_names: Optional[List[str]] = None,
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDProcessTemplate.typ)
         GEMDProcessTemplate.__init__(self, name=name, uids=uids,
                                      conditions=conditions, parameters=parameters, tags=tags,

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -6,7 +6,6 @@ from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Mapping, Object, SpecifiedMixedList, \
     LinkOrElse
-from citrine._utils.functions import set_default_uid
 from citrine.resources.condition_template import ConditionTemplate
 from citrine.resources.data_concepts import DataConcepts
 from citrine.resources.object_templates import ObjectTemplate, ObjectTemplateCollection
@@ -67,7 +66,7 @@ class ProcessTemplate(ObjectTemplate, Resource['ProcessTemplate'], GEMDProcessTe
 
     def __init__(self,
                  name: str,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  conditions: Optional[Sequence[Union[ConditionTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[ConditionTemplate, LinkByUID,
@@ -83,7 +82,7 @@ class ProcessTemplate(ObjectTemplate, Resource['ProcessTemplate'], GEMDProcessTe
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None):
         DataConcepts.__init__(self, GEMDProcessTemplate.typ)
-        GEMDProcessTemplate.__init__(self, name=name, uids=set_default_uid(uids),
+        GEMDProcessTemplate.__init__(self, name=name, uids=uids,
                                      conditions=conditions, parameters=parameters, tags=tags,
                                      description=description, allowed_labels=allowed_labels,
                                      allowed_names=allowed_names)

--- a/src/citrine/resources/property_template.py
+++ b/src/citrine/resources/property_template.py
@@ -46,9 +46,11 @@ class PropertyTemplate(AttributeTemplate, Resource['PropertyTemplate'], GEMDProp
     def __init__(self,
                  name: str,
                  bounds: BaseBounds,
-                 uids: Optional[Dict[str, str]] = dict(),
+                 uids: Optional[Dict[str, str]] = None,
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None):
+        if uids is None:
+            uids = dict()
         DataConcepts.__init__(self, GEMDPropertyTemplate.typ)
         GEMDPropertyTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
                                       uids=uids, description=description)

--- a/src/citrine/resources/property_template.py
+++ b/src/citrine/resources/property_template.py
@@ -5,7 +5,6 @@ from citrine._rest.resource import Resource
 from citrine._serialization.properties import List as PropertyList
 from citrine._serialization.properties import Optional as PropertyOptional
 from citrine._serialization.properties import String, Mapping, Object
-from citrine._utils.functions import set_default_uid
 from citrine.resources.attribute_templates import AttributeTemplate, AttributeTemplateCollection
 from citrine.resources.data_concepts import DataConcepts
 from gemd.entity.bounds.base_bounds import BaseBounds
@@ -47,12 +46,12 @@ class PropertyTemplate(AttributeTemplate, Resource['PropertyTemplate'], GEMDProp
     def __init__(self,
                  name: str,
                  bounds: BaseBounds,
-                 uids: Optional[Dict[str, str]] = None,
+                 uids: Optional[Dict[str, str]] = dict(),
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None):
         DataConcepts.__init__(self, GEMDPropertyTemplate.typ)
         GEMDPropertyTemplate.__init__(self, name=name, bounds=bounds, tags=tags,
-                                      uids=set_default_uid(uids), description=description)
+                                      uids=uids, description=description)
 
     def __str__(self):
         return '<Property template {!r}>'.format(self.name)

--- a/tests/_util/test_functions.py
+++ b/tests/_util/test_functions.py
@@ -5,20 +5,10 @@ from mock import patch, call, MagicMock, mock_open
 from gemd.entity.bounds.real_bounds import RealBounds
 from gemd.entity.link_by_uid import LinkByUID
 
-from citrine._utils.functions import set_default_uid, get_object_id, validate_type, object_to_link_by_uid, \
+from citrine._utils.functions import get_object_id, validate_type, object_to_link_by_uid, \
     rewrite_s3_links_locally, write_file_locally
 from gemd.entity.attribute.property import Property
 from citrine.resources.condition_template import ConditionTemplate
-
-
-def test_set_default_id_non_uuid():
-    with pytest.raises(ValueError):
-        set_default_uid({'id': 'not-valid'})
-
-
-def test_set_default_id_non_dict():
-    with pytest.raises(Exception):
-        set_default_uid('not a dict')
 
 
 def test_get_object_id_from_base_attribute():

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -311,6 +311,7 @@ def test_register_all_data_concepts(dataset):
     for obj in expected:
         assert len(obj.uids) == 1  # All should now have exactly 1 id
         for pair in obj.uids.items():
+            assert pair not in seen_ids  # All ids are different
             seen_ids.add(pair)
     for obj in registered:
         for pair in obj.uids.items():

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -229,8 +229,33 @@ def test_register_data_concepts(dataset):
     }
 
     for collection, obj in expected.items():
-        dataset.register(obj)
+        assert len(obj.uids) == 0
+        registered = dataset.register(obj)
+        assert len(obj.uids) == 1
+        assert len(registered.uids) == 1
         assert basename(dataset.session.calls[-1].path) == basename(collection._path_template)
+        for pair in obj.uids.items():
+            assert pair[1] == registered.uids[pair[0]]
+
+
+def test_register_data_concepts_no_mutate(dataset):
+    """Check that register routes to the correct collections"""
+    expected = {
+        MaterialTemplateCollection: MaterialTemplate("foo",
+                                                     uids={'scope1': 'A',
+                                                           'scope2': 'B'
+                                                           }
+                                                     ),
+        MaterialSpecCollection: MaterialSpec("foo",
+                                             uids={'id': str(uuid4())}
+                                             ),
+    }
+    for collection, obj in expected.items():
+        len_before = len(obj.uids)
+        registered = dataset.register(obj)
+        assert len(obj.uids) == len_before
+        for pair in registered.uids.items():
+            assert pair[1] == obj.uids.get(pair[0], 'No such key')
 
 
 def test_register_all_data_concepts(dataset):
@@ -277,8 +302,20 @@ def test_register_all_data_concepts(dataset):
         parameter_template: ParameterTemplateCollection,
         condition_template: ConditionTemplateCollection
     }
+    for obj in expected:
+        assert len(obj.uids) == 0  # All should be without ids
     registered = dataset.register_all(expected.keys())
     assert len(registered) == len(expected)
+
+    seen_ids = set()
+    for obj in expected:
+        assert len(obj.uids) == 1  # All should now have exactly 1 id
+        for pair in obj.uids.items():
+            seen_ids.add(pair)
+    for obj in registered:
+        for pair in obj.uids.items():
+            assert pair in seen_ids  # registered items have the same ids
+
     call_basenames = [call.path.split('/')[-2] for call in dataset.session.calls]
     collection_basenames = [basename(collection._path_template) for collection in expected.values()]
     assert set(call_basenames) == set(collection_basenames)

--- a/tests/serialization/test_material_run.py
+++ b/tests/serialization/test_material_run.py
@@ -48,7 +48,7 @@ def test_serialization():
 def test_process_attachment():
     """Test that a process can be attached to a material, and that the connection survives serde"""
     cake = MaterialRun('Final cake')
-    cake.process = ProcessRun('Icing')
+    cake.process = ProcessRun('Icing', uids={'id': '12345'})
     cake_data = cake.dump()
 
     cake_copy = loads(dumps(cake_data)).as_dict()

--- a/tests/serialization/test_object_template.py
+++ b/tests/serialization/test_object_template.py
@@ -36,5 +36,6 @@ def test_object_template_serde():
     assert ProcessTemplate.build(proc_template.dump()) == proc_template
 
     # Check that serde still works if the template is a LinkByUID
+    pressure_template.uids['id'] = '12345'  # uids['id'] not populated by default
     proc_template.conditions[0][0] = LinkByUID('id', pressure_template.uids['id'])
     assert ProcessTemplate.build(proc_template.dump()) == proc_template


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR is to change default behavior of citrine-python objects derived from gemd-python BaseEntities so that a CitrineID is only populated immediately prior to sending the object to the server (or, more generally, when we try to serialize things).  This should bring behavior in gemd-python and citrine-python more in line.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [X] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
