### PR TITLE
Enable project deletion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.32.1',
+      version='0.33.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -365,7 +365,3 @@ class ProjectCollection(Collection[Project]):
 
         """
         return super().register(Project(name, description))
-
-    def delete(self, uuid):
-        """Delete the project with the provided uid."""
-        raise NotImplementedError("Delete is not supported for projects")

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -280,8 +280,12 @@ def test_delete_project(collection, session):
     uid = '151199ec-e9aa-49a1-ac8e-da722aaf74c4'
 
     # When
-    with pytest.raises(NotImplementedError):
-        collection.delete(uid)
+    resp = collection.delete(uid)
+
+    # Then
+    assert 1 == session.num_calls
+    expected_call = FakeCall(method='DELETE', path='/projects/{}'.format(uid))
+    assert expected_call == session.last_call
 
 
 def test_list_members(project, session):


### PR DESCRIPTION
# Citrine Python PR

## Description 
This small PR enables deletion of projects in citrine-python.  Removing the delete method from the Project class allows the superclass to make a DELETE call to the product API using the appropriate path ('projects/{project_uid}').

This is a new feature so should not break any existing functionality.  I have tested this branch with the e2es to delete projects when the tests are complete.  All e2es run successfully with the devkit approach (testing locally).

This is required by https://github.com/CitrineInformatics/nextgen-devkit/pull/548 and is part of PLA-4239.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
