### PR TITLE
Revert "Enable project deletion"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.33.0',
+      version='0.32.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.32.1',
+      version='0.33.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -365,3 +365,7 @@ class ProjectCollection(Collection[Project]):
 
         """
         return super().register(Project(name, description))
+
+    def delete(self, uuid):
+        """Delete the project with the provided uid."""
+        raise NotImplementedError("Delete is not supported for projects")

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -280,12 +280,8 @@ def test_delete_project(collection, session):
     uid = '151199ec-e9aa-49a1-ac8e-da722aaf74c4'
 
     # When
-    resp = collection.delete(uid)
-
-    # Then
-    assert 1 == session.num_calls
-    expected_call = FakeCall(method='DELETE', path='/projects/{}'.format(uid))
-    assert expected_call == session.last_call
+    with pytest.raises(NotImplementedError):
+        collection.delete(uid)
 
 
 def test_list_members(project, session):


### PR DESCRIPTION
Reverts CitrineInformatics/citrine-python#352

I'm not sure how this could have introduced any failures for our e2es, but the test_project_list job is failing now.  I think it's best to revert this change and find out what is causing it.  I suspect it might be something else.