### PR TITLE
Make MIME types insensitive to capitals in file extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.34.0',
+      version='0.34.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -214,7 +214,7 @@ class FileCollection(Collection[FileLink]):
         """
         path = self._get_path() + "/uploads"
         extension = os.path.splitext(file_path)[1]
-        mime_type = mimetypes.types_map[extension]
+        mime_type = mimetypes.types_map[extension.lower()]
         file_size = os.stat(file_path).st_size
         assert isinstance(file_size, int)
         upload_json = {

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -95,7 +95,7 @@ def test_upload(mock_isfile, mock_stat, mock_open, mock_boto3_client, collection
     mock_open.return_value.__enter__.return_value = 'Random file contents'
     mock_boto3_client.return_value = FakeS3Client({'VersionId': '3'})
 
-    dest_name = 'foo.txt'
+    dest_names = ['foo.txt', 'foo.TXT']  # Verify that capitalization in extension is fine
     file_id = '12345'
     version = '13'
 
@@ -122,13 +122,15 @@ def test_upload(mock_isfile, mock_stat, mock_open, mock_boto3_client, collection
         ]
     }
 
-    session.set_responses(uploads_response, file_info_response)
-    file_link = collection.upload(dest_name)
+    for dest_name in dest_names:
+        session.set_responses(uploads_response, file_info_response)
+        file_link = collection.upload(dest_name)
 
-    assert session.num_calls == 2
-    url = 'projects/{}/datasets/{}/files/{}/versions/{}'\
-        .format(collection.project_id, collection.dataset_id, file_id, version)
-    assert file_link.dump() == FileLink(dest_name, url=url).dump()
+        url = 'projects/{}/datasets/{}/files/{}/versions/{}'\
+            .format(collection.project_id, collection.dataset_id, file_id, version)
+        assert file_link.dump() == FileLink(dest_name, url=url).dump()
+
+    assert session.num_calls == 4
 
 
 def test_upload_missing_file(collection):

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -133,7 +133,7 @@ def test_upload(mock_isfile, mock_stat, mock_open, mock_boto3_client, collection
     assert session.num_calls == 4
 
 
-@pytest.mark.xfail(reason="MIME type resolution depends on file extension")
+@pytest.mark.xfail(reason="PLA-4395: MIME type resolution depends on file extension")
 @patch('citrine.resources.file_link.boto3_client')
 @patch('citrine.resources.file_link.open')
 @patch('citrine.resources.file_link.os.stat')


### PR DESCRIPTION
# Citrine Python PR

## Description 
At present, a capitalized file extension (e.g., .JPG) causes a key error as the MIME type dictionary in the mimetypes package is all lower case.  This patches this immediate issue, though leaves open the issue of throwing exceptions if a file extension doesn't align with our expectation.

I've added an XFail for the latter problem.  Maybe we should just change the invocation to a `get` with default `'application/octet-stream'`, but I don't feel comfortable executing on that without discussion.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [X] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
