### PR TITLE
Feature/pla 4305 xor gem table variables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.34.0',
+      version='0.35.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -640,7 +640,7 @@ class XOR(Serializable['XOR'], Variable):
     typ = properties.String('type', default="xor", deserializable=False)
 
     def _attrs(self) -> List[str]:
-        return ["name", "headers", "variables"]
+        return ["name", "headers", "variables", "typ"]
 
     def __init__(self, *, name, headers, variables):
         self.name = name

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -37,12 +37,9 @@ class Variable(PolymorphicSerializable['Variable']):
         pass  # pragma: no cover
 
     def __eq__(self, other):
-        try:
-            return type(self) == type(other) and all([
-                getattr(self, key) == getattr(other, key) for key in self._attrs()
-            ])
-        except AttributeError:
-            return False
+        return type(self) == type(other) and all([
+            getattr(self, key) == getattr(other, key) for key in self._attrs()
+        ])
 
     @classmethod
     def get_type(cls, data) -> Type[Serializable]:

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -620,8 +620,8 @@ class XOR(Serializable['XOR'], Variable):
     which produces a real numeric quantity.
 
     The input variables to XOR need not exist elsewhere in the table definition, and the name and
-    headers assigned to them have no bearing on how the table is constructed. That they are required
-    at all is simply a limitation of the current API.
+    headers assigned to them have no bearing on how the table is constructed. That they are
+    required at all is simply a limitation of the current API.
 
     Parameters
     ---------
@@ -631,6 +631,7 @@ class XOR(Serializable['XOR'], Variable):
         sequence of column headers
     variables: list[Variable]
         set of 2 or more Variables to XOR
+
     """
 
     name = properties.String('name')

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -38,8 +38,8 @@ class Variable(PolymorphicSerializable['Variable']):
 
     def __eq__(self, other):
         try:
-            return all([
-                self.__getattribute__(key) == other.__getattribute__(key) for key in self._attrs()
+            return type(self) == type(other) and all([
+                getattr(self, key) == getattr(other, key) for key in self._attrs()
             ])
         except AttributeError:
             return False

--- a/tests/ara/test_variables.py
+++ b/tests/ara/test_variables.py
@@ -8,6 +8,7 @@ from gemd.entity.link_by_uid import LinkByUID
 
 @pytest.fixture(params=[
     RootInfo(name="root name", headers=["Root", "Name"], field="name"),
+    XOR(name="root name or sample_type", headers=["Root", "Info"], variables=[RootInfo(name="root name", headers=["Root", "Name"], field="name"), RootInfo(name="root name", headers=["Root", "Sample Type"], field="sample_type")]),
     AttributeByTemplate(name="density", headers=["density"], template=LinkByUID(scope="templates", id="density"), attribute_constraints=[[LinkByUID(scope="templates", id="density"), RealBounds(0, 100, "g/cm**3")]]),
     AttributeByTemplateAfterProcessTemplate(name="density", headers=["density"], attribute_template=LinkByUID(scope="template", id="density"), process_template=LinkByUID(scope="template", id="process")),
     AttributeByTemplateAndObjectTemplate(name="density", headers=["density"], attribute_template=LinkByUID(scope="template", id="density"), object_template=LinkByUID(scope="template", id="object")),


### PR DESCRIPTION
# Citrine Python PR

## Description 
Adds new XOR variable for GEM table building. Also fixes bug where `IngredientQuantityInOutput` would serialize with the type hint of `IngredientIdentifierInOutput`, which may have cause the backend to deserialize an instance of the latter rather than the former.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
