### PR TITLE
Revert "PLA-2151 Make bounds on object templates optional"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gemd==0.9.0
+gemd==0.8.0
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.15.4

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.36.0',
+      version='0.35.3',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',
@@ -68,7 +68,7 @@ setup(name='citrine',
           "pyjwt>=1.7.1,<2",
           "arrow>=0.15.4,<0.16",
           "strip-hints>=0.1.8,<0.2",
-          "gemd>=0.9,<0.10",
+          "gemd>=0.8,<0.9",
           "boto3>=1.9.226,<2",
           "botocore>=1.12.226,<2",
           "deprecation>=2.0.7,<3",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.35.3',
+      version='0.36.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/attributes/__init__.py
+++ b/src/citrine/attributes/__init__.py
@@ -1,0 +1,1 @@
+"""Resources that represent attributes."""

--- a/src/citrine/attributes/condition.py
+++ b/src/citrine/attributes/condition.py
@@ -1,0 +1,10 @@
+# flake8: noqa
+"""A resource that represents a condition attribute."""
+import deprecation
+from gemd.entity.attribute.condition import Condition as GEMDCondition
+
+
+@deprecation.deprecated(deprecated_in="0.8.0", removed_in="0.9.0",
+                        details="Use gemd.entity.attribute.condition instead")
+class Condition(GEMDCondition):
+    pass

--- a/src/citrine/attributes/parameter.py
+++ b/src/citrine/attributes/parameter.py
@@ -1,0 +1,10 @@
+# flake8: noqa
+"""A resource that represents a parameter attribute."""
+import deprecation
+from gemd.entity.attribute.parameter import Parameter as GEMDParameter
+
+
+@deprecation.deprecated(deprecated_in="0.8.0", removed_in="0.9.0",
+                        details="Use gemd.entity.attribute.parameter instead")
+class Parameter(GEMDParameter):
+    pass

--- a/src/citrine/attributes/property.py
+++ b/src/citrine/attributes/property.py
@@ -1,0 +1,11 @@
+# flake8: noqa
+"""A resource that represents a property attribute."""
+import deprecation
+from gemd.entity.attribute.property import Property as GEMDProperty
+
+
+@deprecation.deprecated(deprecated_in="0.8.0", removed_in="0.9.0",
+                        details="Use gemd.entity.attribute.property instead")
+class Property(GEMDProperty):
+    pass
+

--- a/src/citrine/attributes/property_and_conditions.py
+++ b/src/citrine/attributes/property_and_conditions.py
@@ -1,0 +1,11 @@
+# flake8: noqa
+"""A resource that represents a property attribute."""
+import deprecation
+from gemd.entity.attribute.property_and_conditions import PropertyAndConditions as \
+    GEMDPropertyAndConditions
+
+
+@deprecation.deprecated(deprecated_in="0.8.0", removed_in="0.9.0",
+                        details="Use gemd.entity.attribute.property_and_conditions instead")
+class PropertyAndConditions(GEMDPropertyAndConditions):
+    pass

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -51,7 +51,7 @@ class MaterialTemplate(ObjectTemplate, Resource['MaterialTemplate'], GEMDMateria
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
     properties = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'properties')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'properties')
     typ = String('type')
 
     def __init__(self,
@@ -60,7 +60,7 @@ class MaterialTemplate(ObjectTemplate, Resource['MaterialTemplate'], GEMDMateria
                  properties: Optional[Sequence[Union[PropertyTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[PropertyTemplate, LinkByUID,
-                                                                    Optional[BaseBounds]]]
+                                                                    BaseBounds]]
                                                      ]]] = None,
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None):

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -65,11 +65,11 @@ class MeasurementTemplate(ObjectTemplate,
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
     properties = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'properties')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'properties')
     conditions = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'conditions')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'conditions')
     parameters = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'parameters')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'parameters')
     typ = String('type')
 
     def __init__(self,
@@ -78,17 +78,17 @@ class MeasurementTemplate(ObjectTemplate,
                  properties: Optional[Sequence[Union[PropertyTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[PropertyTemplate, LinkByUID,
-                                                                    Optional[BaseBounds]]]
+                                                                    BaseBounds]]
                                                      ]]] = None,
                  conditions: Optional[Sequence[Union[ConditionTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[ConditionTemplate, LinkByUID,
-                                                                    Optional[BaseBounds]]]
+                                                                    BaseBounds]]
                                                      ]]] = None,
                  parameters: Optional[Sequence[Union[ParameterTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[ParameterTemplate, LinkByUID,
-                                                                    Optional[BaseBounds]]]
+                                                                    BaseBounds]]
                                                      ]]] = None,
                  description: Optional[str] = None,
                  tags: Optional[List[str]] = None):

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -57,9 +57,9 @@ class ProcessTemplate(ObjectTemplate, Resource['ProcessTemplate'], GEMDProcessTe
     uids = Mapping(String('scope'), String('id'), 'uids')
     tags = PropertyOptional(PropertyList(String()), 'tags')
     conditions = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'conditions')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'conditions')
     parameters = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'parameters')
+        SpecifiedMixedList([LinkOrElse, Object(BaseBounds)])), 'parameters')
     allowed_labels = PropertyOptional(PropertyList(String()), 'allowed_labels')
     allowed_names = PropertyOptional(PropertyList(String()), 'allowed_names')
     typ = String('type')
@@ -70,12 +70,12 @@ class ProcessTemplate(ObjectTemplate, Resource['ProcessTemplate'], GEMDProcessTe
                  conditions: Optional[Sequence[Union[ConditionTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[ConditionTemplate, LinkByUID,
-                                                                    Optional[BaseBounds]]]
+                                                                    BaseBounds]]
                                                      ]]] = None,
                  parameters: Optional[Sequence[Union[ParameterTemplate,
                                                      LinkByUID,
                                                      Sequence[Union[ParameterTemplate, LinkByUID,
-                                                                    Optional[BaseBounds]]]
+                                                                    BaseBounds]]
                                                      ]]] = None,
                  allowed_labels: Optional[List[str]] = None,
                  allowed_names: Optional[List[str]] = None,

--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,8 @@ exclude = tests/*
 
 [pytest]
 testpaths = tests
+
+[run]
+omit =
+    # skip deprecated sources
+    src/citrine/attributes/*


### PR DESCRIPTION
testing behavior of `scrub_none` with these changes was overlooked

Reverts CitrineInformatics/citrine-python#361