### PR TITLE
Bumped version and enabled project delete

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.36.3',
+      version='0.37.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -365,7 +365,3 @@ class ProjectCollection(Collection[Project]):
 
         """
         return super().register(Project(name, description))
-
-    def delete(self, uuid):
-        """Delete the project with the provided uid."""
-        raise NotImplementedError("Delete is not supported for projects")

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -280,8 +280,12 @@ def test_delete_project(collection, session):
     uid = '151199ec-e9aa-49a1-ac8e-da722aaf74c4'
 
     # When
-    with pytest.raises(NotImplementedError):
-        collection.delete(uid)
+    resp = collection.delete(uid)
+
+    # Then
+    assert 1 == session.num_calls
+    expected_call = FakeCall(method='DELETE', path='/projects/{}'.format(uid))
+    assert expected_call == session.last_call
 
 
 def test_list_members(project, session):


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR enabled project deletion.  This was previously enabled in #352 and reverted in #353 due to a bug in the project listing endpoint in the accounts service.  This bug has been fixed.  I have tested this code extensively in a local docker-compose environment and it's working as expected.

This PR is required so we can delete test projects after running the nextgen-devkit e2es.  This will help reduce the accumulation of projects and resources in development.

Please do not merge this before this other PR is merged: https://github.com/CitrineInformatics/nextgen-devkit/pull/577.  This PR skips a test that expected project deletion to fail.  We will refactor this test to check that project deletion works properly once this PR is merged.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [X] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
