### PR TITLE
PLA-4139 Add type_selector to table config variables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.38.2',
+      version='0.39.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -30,7 +30,7 @@ class DataObjectTypeSelector(BaseEnumeration):
     """[ALPHA] The strategy for selecting types to consider for variable matching.
 
     Variables can potentially match many objects in a material history, creating
-    ambiguity around the which value should be assigned. In particular, 
+    ambiguity around which value should be assigned. In particular, 
     associated runs and specs often share attributes and thus will often match 
     the same variable. To enable disambiguation in such
     circumstances, many variables allow specification of a `type_selector`, with

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -30,15 +30,14 @@ class DataObjectTypeSelector(BaseEnumeration):
     """[ALPHA] The strategy for selecting types to consider for variable matching.
 
     Variables can potentially match many objects in a material history, creating
-    ambiguity around which value should be assigned. In particular, 
-    associated runs and specs often share attributes and thus will often match 
-    the same variable. To enable disambiguation in such
-    circumstances, many variables allow specification of a `type_selector`, with
-    the following choices:
+    ambiguity around which value should be assigned. In particular, associated
+    runs and specs often share attributes and thus will often match the same
+    variable. To enable disambiguation in such circumstances, many variables allow
+    specification of a `type_selector`, with the following choices:
 
     * RUN_ONLY only match run objects
     * SPEC_ONLY only match spec objects
-    * PREFER_RUN match either run or spec objects, and if both types match 
+    * PREFER_RUN match either run or spec objects, and if both types match
                  only return the result for runs
     * ANY match either run or spec objects, and if both types match
           return an ambiguous error result

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -129,7 +129,7 @@ class AttributeByTemplate(Serializable['AttributeByTemplate'], Variable):
         are expressed as Bounds.  Attributes are expressed with links. The attribute that the
         variable is being set to may be the target of a constraint as well.
     type_selector: DataObjectTypeSelector
-        strategy for selecting data object types to consider when matching.
+        strategy for selecting data object types to consider when matching, defaults to PREFER_RUN
 
     """
 
@@ -180,7 +180,7 @@ class AttributeByTemplateAfterProcessTemplate(
         are expressed as Bounds.  Attributes are expressed with links. The attribute that the
         variable is being set to may be the target of a constraint as well.
     type_selector: DataObjectTypeSelector
-        strategy for selecting data object types to consider when matching.
+        strategy for selecting data object types to consider when matching, defaults to PREFER_RUN
 
     """
 
@@ -240,7 +240,7 @@ class AttributeByTemplateAndObjectTemplate(
         are expressed as Bounds.  Attributes are expressed with links. The attribute that the
         variable is being set to may be the target of a constraint as well.
     type_selector: DataObjectTypeSelector
-        strategy for selecting data object types to consider when matching.
+        strategy for selecting data object types to consider when matching, defaults to PREFER_RUN
 
     """
 
@@ -293,7 +293,7 @@ class IngredientIdentifierByProcessTemplateAndName(
     scope: str
         scope of the identifier (default: the Citrine scope)
     type_selector: DataObjectTypeSelector
-        strategy for selecting data object types to consider when matching.
+        strategy for selecting data object types to consider when matching, defaults to PREFER_RUN
 
     """
 
@@ -346,7 +346,7 @@ class IngredientLabelByProcessAndName(Serializable['IngredientLabelByProcessAndN
     label: str
         label to test
     type_selector: DataObjectTypeSelector
-        strategy for selecting data object types to consider when matching.
+        strategy for selecting data object types to consider when matching, defaults to PREFER_RUN
 
     """
 
@@ -395,7 +395,7 @@ class IngredientQuantityByProcessAndName(
         dimension of the ingredient quantity: absolute quantity, number, mass, or volume fraction.
         valid options are defined by :class:`~citrine.ara.variables.IngredientQuantityDimension`
     type_selector: DataObjectTypeSelector
-        strategy for selecting data object types to consider when matching.
+        strategy for selecting data object types to consider when matching, defaults to PREFER_RUN
 
     """
 
@@ -495,7 +495,7 @@ class AttributeInOutput(Serializable['AttributeInOutput'], Variable):
         are expressed as Bounds.  Attributes are expressed with links. The attribute that the
         variable is being set to may be the target of a constraint as well.
     type_selector: DataObjectTypeSelector
-        strategy for selecting data object types to consider when matching.
+        strategy for selecting data object types to consider when matching, defaults to PREFER_RUN
 
     """
 
@@ -572,7 +572,7 @@ class IngredientIdentifierInOutput(Serializable['IngredientIdentifierInOutput'],
         These process templates are inclusive.
         The ingredient may be present in these processes but not after.
     type_selector: DataObjectTypeSelector
-        strategy for selecting data object types to consider when matching.
+        strategy for selecting data object types to consider when matching, defaults to PREFER_RUN
 
     """
 
@@ -642,7 +642,7 @@ class IngredientQuantityInOutput(Serializable['IngredientQuantityInOutput'], Var
         These process templates are inclusive.
         The ingredient may be present in these processes but not after.
     type_selector: DataObjectTypeSelector
-        strategy for selecting data object types to consider when matching.
+        strategy for selecting data object types to consider when matching, defaults to PREFER_RUN
 
     """
 

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -26,6 +26,28 @@ class IngredientQuantityDimension(BaseEnumeration):
     NUMBER = "number"
 
 
+class DataObjectTypeSelector(BaseEnumeration):
+    """[ALPHA] The strategy for selecting types to consider for variable matching.
+
+    Variables can potentially match many objects in a material history, creating
+    ambiguity around the which value should be assigned. In particular, runs and
+    specs can often match the same variable. To enable disambiguation in such
+    circumstances, many variables allow specification of a `type_selector`, with
+    the following choices:
+
+    * RUN_ONLY only match run objects
+    * SPEC_ONLY only match spec objects
+    * PREFER_RUN match run objects, but match spec objects if no run is found,
+                 no ambiguity when both run and spec match
+    * ANY match run and spec objects, ambiguous when both run and spec match
+    """
+
+    RUN_ONLY = "run_only"
+    SPEC_ONLY = "spec_only"
+    PREFER_RUN = "prefer_run"
+    ANY = "any"
+
+
 class Variable(PolymorphicSerializable['Variable']):
     """[ALPHA] A variable that can be assigned values present in material histories.
 
@@ -106,6 +128,8 @@ class AttributeByTemplate(Serializable['AttributeByTemplate'], Variable):
         constraints on object attributes in the target object that must be satisfied. Constraints
         are expressed as Bounds.  Attributes are expressed with links. The attribute that the
         variable is being set to may be the target of a constraint as well.
+    type_selector: DataObjectTypeSelector
+        strategy for selecting data object types to consider when matching.
 
     """
 
@@ -118,20 +142,23 @@ class AttributeByTemplate(Serializable['AttributeByTemplate'], Variable):
                 [properties.Object(LinkByUID), properties.Object(BaseBounds)]
             )
         ), 'attribute_constraints')
+    type_selector = properties.Enumeration(DataObjectTypeSelector, "type_selector")
     typ = properties.String('type', default="attribute_by_template", deserializable=False)
 
     def _attrs(self) -> List[str]:
-        return ["name", "headers", "template", "attribute_constraints", "typ"]
+        return ["name", "headers", "template", "attribute_constraints", "type_selector", "typ"]
 
     def __init__(self, *,
                  name: str,
                  headers: List[str],
                  template: LinkByUID,
-                 attribute_constraints: Optional[List[List[Union[LinkByUID, BaseBounds]]]] = None):
+                 attribute_constraints: Optional[List[List[Union[LinkByUID, BaseBounds]]]] = None,
+                 type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
         self.name = name
         self.headers = headers
         self.template = template
         self.attribute_constraints = attribute_constraints
+        self.type_selector = type_selector
 
 
 class AttributeByTemplateAfterProcessTemplate(
@@ -152,6 +179,8 @@ class AttributeByTemplateAfterProcessTemplate(
         constraints on object attributes in the target object that must be satisfied. Constraints
         are expressed as Bounds.  Attributes are expressed with links. The attribute that the
         variable is being set to may be the target of a constraint as well.
+    type_selector: DataObjectTypeSelector
+        strategy for selecting data object types to consider when matching.
 
     """
 
@@ -165,23 +194,26 @@ class AttributeByTemplateAfterProcessTemplate(
                 [properties.Object(LinkByUID), properties.Object(BaseBounds)]
             )
         ), 'attribute_constraints')
+    type_selector = properties.Enumeration(DataObjectTypeSelector, "type_selector")
     typ = properties.String('type', default="attribute_after_process", deserializable=False)
 
     def _attrs(self) -> List[str]:
         return ["name", "headers", "attribute_template", "process_template",
-                "attribute_constraints", "typ"]
+                "attribute_constraints", "type_selector", "typ"]
 
     def __init__(self, *,
                  name: str,
                  headers: List[str],
                  attribute_template: LinkByUID,
                  process_template: LinkByUID,
-                 attribute_constraints: Optional[List[List[Union[LinkByUID, BaseBounds]]]] = None):
+                 attribute_constraints: Optional[List[List[Union[LinkByUID, BaseBounds]]]] = None,
+                 type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
         self.name = name
         self.headers = headers
         self.attribute_template = attribute_template
         self.process_template = process_template
         self.attribute_constraints = attribute_constraints
+        self.type_selector = type_selector
 
 
 class AttributeByTemplateAndObjectTemplate(
@@ -207,6 +239,8 @@ class AttributeByTemplateAndObjectTemplate(
         constraints on object attributes in the target object that must be satisfied. Constraints
         are expressed as Bounds.  Attributes are expressed with links. The attribute that the
         variable is being set to may be the target of a constraint as well.
+    type_selector: DataObjectTypeSelector
+        strategy for selecting data object types to consider when matching.
 
     """
 
@@ -220,23 +254,26 @@ class AttributeByTemplateAndObjectTemplate(
                 [properties.Object(LinkByUID), properties.Object(BaseBounds)]
             )
         ), 'attribute_constraints')
+    type_selector = properties.Enumeration(DataObjectTypeSelector, "type_selector")
     typ = properties.String('type', default="attribute_by_object", deserializable=False)
 
     def _attrs(self) -> List[str]:
         return ["name", "headers", "attribute_template", "object_template",
-                "attribute_constraints", "typ"]
+                "attribute_constraints", "type_selector", "typ"]
 
     def __init__(self, *,
                  name: str,
                  headers: List[str],
                  attribute_template: LinkByUID,
                  object_template: LinkByUID,
-                 attribute_constraints: List[List[Union[LinkByUID, BaseBounds]]] = None):
+                 attribute_constraints: List[List[Union[LinkByUID, BaseBounds]]] = None,
+                 type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
         self.name = name
         self.headers = headers
         self.attribute_template = attribute_template
         self.object_template = object_template
         self.attribute_constraints = attribute_constraints
+        self.type_selector = type_selector
 
 
 class IngredientIdentifierByProcessTemplateAndName(
@@ -255,6 +292,8 @@ class IngredientIdentifierByProcessTemplateAndName(
         name of ingredient
     scope: str
         scope of the identifier (default: the Citrine scope)
+    type_selector: DataObjectTypeSelector
+        strategy for selecting data object types to consider when matching.
 
     """
 
@@ -263,22 +302,26 @@ class IngredientIdentifierByProcessTemplateAndName(
     process_template = properties.Object(LinkByUID, 'process_template')
     ingredient_name = properties.String('ingredient_name')
     scope = properties.String('scope')
+    type_selector = properties.Enumeration(DataObjectTypeSelector, "type_selector")
     typ = properties.String('type', default="ing_id_by_process_and_name", deserializable=False)
 
     def _attrs(self) -> List[str]:
-        return ["name", "headers", "process_template", "ingredient_name", "scope", "typ"]
+        return ["name", "headers", "process_template", "ingredient_name", "scope",
+                "type_selector", "typ"]
 
     def __init__(self, *,
                  name: str,
                  headers: List[str],
                  process_template: LinkByUID,
                  ingredient_name: str,
-                 scope: str):
+                 scope: str,
+                 type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
         self.name = name
         self.headers = headers
         self.process_template = process_template
         self.ingredient_name = ingredient_name
         self.scope = scope
+        self.type_selector = type_selector
 
 
 class IngredientLabelByProcessAndName(Serializable['IngredientLabelByProcessAndName'], Variable):
@@ -302,6 +345,8 @@ class IngredientLabelByProcessAndName(Serializable['IngredientLabelByProcessAndN
         name of ingredient
     label: str
         label to test
+    type_selector: DataObjectTypeSelector
+        strategy for selecting data object types to consider when matching.
 
     """
 
@@ -310,22 +355,26 @@ class IngredientLabelByProcessAndName(Serializable['IngredientLabelByProcessAndN
     process_template = properties.Object(LinkByUID, 'process_template')
     ingredient_name = properties.String('ingredient_name')
     label = properties.String('label')
+    type_selector = properties.Enumeration(DataObjectTypeSelector, "type_selector")
     typ = properties.String('type', default="ing_label_by_process_and_name", deserializable=False)
 
     def _attrs(self) -> List[str]:
-        return ["name", "headers", "process_template", "ingredient_name", "label", "typ"]
+        return ["name", "headers", "process_template", "ingredient_name", "label",
+                "type_selector", "typ"]
 
     def __init__(self, *,
                  name: str,
                  headers: List[str],
                  process_template: LinkByUID,
                  ingredient_name: str,
-                 label: str):
+                 label: str,
+                 type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
         self.name = name
         self.headers = headers
         self.process_template = process_template
         self.ingredient_name = ingredient_name
         self.label = label
+        self.type_selector = type_selector
 
 
 class IngredientQuantityByProcessAndName(
@@ -345,6 +394,8 @@ class IngredientQuantityByProcessAndName(
     quantity_dimension: IngredientQuantityDimension
         dimension of the ingredient quantity: absolute quantity, number, mass, or volume fraction.
         valid options are defined by :class:`~citrine.ara.variables.IngredientQuantityDimension`
+    type_selector: DataObjectTypeSelector
+        strategy for selecting data object types to consider when matching.
 
     """
 
@@ -353,24 +404,27 @@ class IngredientQuantityByProcessAndName(
     process_template = properties.Object(LinkByUID, 'process_template')
     ingredient_name = properties.String('ingredient_name')
     quantity_dimension = properties.Enumeration(IngredientQuantityDimension, 'quantity_dimension')
+    type_selector = properties.Enumeration(DataObjectTypeSelector, "type_selector")
     typ = properties.String('type', default="ing_quantity_by_process_and_name",
                             deserializable=False)
 
     def _attrs(self) -> List[str]:
         return ["name", "headers", "process_template", "ingredient_name", "quantity_dimension",
-                "typ"]
+                "type_selector", "typ"]
 
     def __init__(self, *,
                  name: str,
                  headers: List[str],
                  process_template: LinkByUID,
                  ingredient_name: str,
-                 quantity_dimension: IngredientQuantityDimension):
+                 quantity_dimension: IngredientQuantityDimension,
+                 type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
         self.name = name
         self.headers = headers
         self.process_template = process_template
         self.ingredient_name = ingredient_name
         self.quantity_dimension = quantity_dimension
+        self.type_selector = type_selector
 
 
 class RootIdentifier(Serializable['RootIdentifier'], Variable):
@@ -440,6 +494,8 @@ class AttributeInOutput(Serializable['AttributeInOutput'], Variable):
         constraints on object attributes in the target object that must be satisfied. Constraints
         are expressed as Bounds.  Attributes are expressed with links. The attribute that the
         variable is being set to may be the target of a constraint as well.
+    type_selector: DataObjectTypeSelector
+        strategy for selecting data object types to consider when matching.
 
     """
 
@@ -453,23 +509,26 @@ class AttributeInOutput(Serializable['AttributeInOutput'], Variable):
                 [properties.Object(LinkByUID), properties.Object(BaseBounds)]
             )
         ), 'attribute_constraints')
+    type_selector = properties.Enumeration(DataObjectTypeSelector, "type_selector")
     typ = properties.String('type', default="attribute_in_trunk", deserializable=False)
 
     def _attrs(self) -> List[str]:
         return ["name", "headers", "attribute_template", "process_templates",
-                "attribute_constraints", "typ"]
+                "attribute_constraints", "type_selector", "typ"]
 
     def __init__(self, *,
                  name: str,
                  headers: List[str],
                  attribute_template: LinkByUID,
                  process_templates: List[LinkByUID],
-                 attribute_constraints: Optional[List[List[Union[LinkByUID, BaseBounds]]]] = None):
+                 attribute_constraints: Optional[List[List[Union[LinkByUID, BaseBounds]]]] = None,
+                 type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
         self.name = name
         self.headers = headers
         self.attribute_template = attribute_template
         self.process_templates = process_templates
         self.attribute_constraints = attribute_constraints
+        self.type_selector = type_selector
 
 
 class IngredientIdentifierInOutput(Serializable['IngredientIdentifierInOutput'], Variable):
@@ -512,6 +571,8 @@ class IngredientIdentifierInOutput(Serializable['IngredientIdentifierInOutput'],
         Process templates halt the search for a matching ingredient name.
         These process templates are inclusive.
         The ingredient may be present in these processes but not after.
+    type_selector: DataObjectTypeSelector
+        strategy for selecting data object types to consider when matching.
 
     """
 
@@ -519,20 +580,23 @@ class IngredientIdentifierInOutput(Serializable['IngredientIdentifierInOutput'],
     headers = properties.List(properties.String, 'headers')
     ingredient_name = properties.String('ingredient_name')
     process_templates = properties.List(properties.Object(LinkByUID), 'process_templates')
+    type_selector = properties.Enumeration(DataObjectTypeSelector, "type_selector")
     typ = properties.String('type', default="ing_id_in_output", deserializable=False)
 
     def _attrs(self) -> List[str]:
-        return ["name", "headers", "ingredient_name", "process_templates", "typ"]
+        return ["name", "headers", "ingredient_name", "process_templates", "type_selector", "typ"]
 
     def __init__(self, *,
                  name: str,
                  headers: List[str],
                  ingredient_name: str,
-                 process_templates: List[LinkByUID]):
+                 process_templates: List[LinkByUID],
+                 type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
         self.name = name
         self.headers = headers
         self.ingredient_name = ingredient_name
         self.process_templates = process_templates
+        self.type_selector = type_selector
 
 
 class IngredientQuantityInOutput(Serializable['IngredientQuantityInOutput'], Variable):
@@ -577,6 +641,8 @@ class IngredientQuantityInOutput(Serializable['IngredientQuantityInOutput'], Var
         Process templates halt the search for a matching ingredient name.
         These process templates are inclusive.
         The ingredient may be present in these processes but not after.
+    type_selector: DataObjectTypeSelector
+        strategy for selecting data object types to consider when matching.
 
     """
 
@@ -585,22 +651,25 @@ class IngredientQuantityInOutput(Serializable['IngredientQuantityInOutput'], Var
     ingredient_name = properties.String('ingredient_name')
     quantity_dimension = properties.Enumeration(IngredientQuantityDimension, 'quantity_dimension')
     process_templates = properties.List(properties.Object(LinkByUID), 'process_templates')
+    type_selector = properties.Enumeration(DataObjectTypeSelector, "type_selector")
     typ = properties.String('type', default="ing_quantity_in_output", deserializable=False)
 
     def _attrs(self) -> List[str]:
-        return ["name", "headers", "ingredient_name", "process_templates", "typ"]
+        return ["name", "headers", "ingredient_name", "process_templates", "type_selector", "typ"]
 
     def __init__(self, *,
                  name: str,
                  headers: List[str],
                  ingredient_name: str,
                  quantity_dimension: IngredientQuantityDimension,
-                 process_templates: List[LinkByUID]):
+                 process_templates: List[LinkByUID],
+                 type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
         self.name = name
         self.headers = headers
         self.ingredient_name = ingredient_name
         self.quantity_dimension = quantity_dimension
         self.process_templates = process_templates
+        self.type_selector = type_selector
 
 
 class XOR(Serializable['XOR'], Variable):

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -39,7 +39,8 @@ class DataObjectTypeSelector(BaseEnumeration):
     * SPEC_ONLY only match spec objects
     * PREFER_RUN match either run or spec objects, and if both types match 
                  only return the result for runs
-    * ANY match run and spec objects, ambiguous when both run and spec match
+    * ANY match either run or spec objects, and if both types match
+          return an ambiguous error result
     """
 
     RUN_ONLY = "run_only"

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -30,8 +30,9 @@ class DataObjectTypeSelector(BaseEnumeration):
     """[ALPHA] The strategy for selecting types to consider for variable matching.
 
     Variables can potentially match many objects in a material history, creating
-    ambiguity around the which value should be assigned. In particular, runs and
-    specs can often match the same variable. To enable disambiguation in such
+    ambiguity around the which value should be assigned. In particular, 
+    associated runs and specs often share attributes and thus will often match 
+    the same variable. To enable disambiguation in such
     circumstances, many variables allow specification of a `type_selector`, with
     the following choices:
 

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -37,8 +37,8 @@ class DataObjectTypeSelector(BaseEnumeration):
 
     * RUN_ONLY only match run objects
     * SPEC_ONLY only match spec objects
-    * PREFER_RUN match run objects, but match spec objects if no run is found,
-                 no ambiguity when both run and spec match
+    * PREFER_RUN match either run or spec objects, and if both types match 
+                 only return the result for runs
     * ANY match run and spec objects, ambiguous when both run and spec match
     """
 


### PR DESCRIPTION
# Citrine Python PR

## Description 
Adds `type_selector` to numerous table config variables. Allows the specification of which object type(s) to consider when performing variable matching.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
