### PR TITLE
Add experimental and experimental_reasons fields

### DIFF
--- a/docs/source/workflows/getting_started.rst
+++ b/docs/source/workflows/getting_started.rst
@@ -64,7 +64,6 @@ Modules come `active` by default when created. If you would like to deactivate a
 
 Modules that are not `active` cannot be used in workflows and will not show up when listing.
 
-
 Registration and validation
 ---------------------------
 
@@ -78,3 +77,17 @@ Validation status can be one of the following states:
 -  **Error:** Validation did not complete. An error was raised during the validation process that prevented an invalid or ready status to be determined.
 
 Validation of a workflow and all constituent modules must complete with ready status before the workflow can be executed.
+
+Experimental functionality
+***************************
+
+Both modules and workflows can be used to access experimental functionality on the platform.
+In some cases, the module or workflow type itself may be experimental.
+In other cases, whether a module or workflow represents experimental functionality may depend on the specific configuration of the module or workflow.
+For example, a module might have an experimental option that is turned off by default.
+Another example could be a workflow that contains an experimental module.
+Because the experimental status of a module or workflow may not be known at registration time, it is computed as part
+of the validation process and then returned via two fields:
+
+- `experimental` is a boolean field that is true when the module or workflow is experimental
+- `experimental_reasons` is a list of strings that describe what about the module or workflow makes it experimental

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.39.1',
+      version='0.40.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/informatics/design_spaces.py
+++ b/src/citrine/informatics/design_spaces.py
@@ -60,6 +60,12 @@ class ProductDesignSpace(Resource['ProductDesignSpace'], DesignSpace):
         serializable=False
     )
     active = properties.Boolean('active', default=True)
+    experimental = properties.Boolean("experimental", serializable=False)
+    experimental_reasons = properties.Optional(
+        properties.List(properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = properties.String('module_type', default='DESIGN_SPACE')
@@ -119,6 +125,12 @@ class EnumeratedDesignSpace(Resource['EnumeratedDesignSpace'], DesignSpace):
         serializable=False
     )
     active = properties.Boolean('active', default=True)
+    experimental = properties.Boolean("experimental", serializable=False)
+    experimental_reasons = properties.Optional(
+        properties.List(properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = properties.String('module_type', default='DESIGN_SPACE')

--- a/src/citrine/informatics/design_spaces.py
+++ b/src/citrine/informatics/design_spaces.py
@@ -60,7 +60,7 @@ class ProductDesignSpace(Resource['ProductDesignSpace'], DesignSpace):
         serializable=False
     )
     active = properties.Boolean('active', default=True)
-    experimental = properties.Boolean("experimental", serializable=False)
+    experimental = properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = properties.Optional(
         properties.List(properties.String()),
         'experimental_reasons',
@@ -125,7 +125,7 @@ class EnumeratedDesignSpace(Resource['EnumeratedDesignSpace'], DesignSpace):
         serializable=False
     )
     active = properties.Boolean('active', default=True)
-    experimental = properties.Boolean("experimental", serializable=False)
+    experimental = properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = properties.Optional(
         properties.List(properties.String()),
         'experimental_reasons',

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -103,7 +103,7 @@ class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
-    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental = _properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = _properties.Optional(
         _properties.List(_properties.String()),
         'experimental_reasons',
@@ -170,7 +170,7 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
         'status_info',
         serializable=False
     )
-    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental = _properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = _properties.Optional(
         _properties.List(_properties.String()),
         'experimental_reasons',
@@ -257,7 +257,7 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
         'status_info',
         serializable=False
     )
-    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental = _properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = _properties.Optional(
         _properties.List(_properties.String()),
         'experimental_reasons',
@@ -373,7 +373,7 @@ class MolecularStructureFeaturizer(Serializable['MolecularStructureFeaturizer'],
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
-    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental = _properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = _properties.Optional(
         _properties.List(_properties.String()),
         'experimental_reasons',
@@ -448,7 +448,7 @@ class IngredientsToSimpleMixturePredictor(
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
-    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental = _properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = _properties.Optional(
         _properties.List(_properties.String()),
         'experimental_reasons',
@@ -542,7 +542,7 @@ class GeneralizedMeanPropertyPredictor(
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
-    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental = _properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = _properties.Optional(
         _properties.List(_properties.String()),
         'experimental_reasons',
@@ -619,7 +619,7 @@ class SimpleMixturePredictor(Serializable['SimpleMixturePredictor'], Predictor):
                                        'status_info',
                                        serializable=False)
     active = _properties.Boolean('active', default=True)
-    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental = _properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = _properties.Optional(
         _properties.List(_properties.String()),
         'experimental_reasons',
@@ -686,7 +686,7 @@ class LabelFractionsPredictor(Serializable['LabelFractionsPredictor'], Predictor
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
-    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental = _properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = _properties.Optional(
         _properties.List(_properties.String()),
         'experimental_reasons',
@@ -755,7 +755,7 @@ class IngredientFractionsPredictor(Serializable["IngredientFractionsPredictor"],
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
-    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental = _properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = _properties.Optional(
         _properties.List(_properties.String()),
         'experimental_reasons',

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -103,6 +103,12 @@ class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
+    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental_reasons = _properties.Optional(
+        _properties.List(_properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -162,6 +168,12 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
     status_info = _properties.Optional(
         _properties.List(_properties.String()),
         'status_info',
+        serializable=False
+    )
+    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental_reasons = _properties.Optional(
+        _properties.List(_properties.String()),
+        'experimental_reasons',
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
@@ -245,6 +257,13 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
         'status_info',
         serializable=False
     )
+    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental_reasons = _properties.Optional(
+        _properties.List(_properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
+
     active = _properties.Boolean('active', default=True)
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
@@ -354,6 +373,12 @@ class MolecularStructureFeaturizer(Serializable['MolecularStructureFeaturizer'],
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
+    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental_reasons = _properties.Optional(
+        _properties.List(_properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -423,6 +448,12 @@ class IngredientsToSimpleMixturePredictor(
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
+    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental_reasons = _properties.Optional(
+        _properties.List(_properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -511,6 +542,12 @@ class GeneralizedMeanPropertyPredictor(
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
+    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental_reasons = _properties.Optional(
+        _properties.List(_properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -582,6 +619,12 @@ class SimpleMixturePredictor(Serializable['SimpleMixturePredictor'], Predictor):
                                        'status_info',
                                        serializable=False)
     active = _properties.Boolean('active', default=True)
+    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental_reasons = _properties.Optional(
+        _properties.List(_properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -643,6 +686,12 @@ class LabelFractionsPredictor(Serializable['LabelFractionsPredictor'], Predictor
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
+    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental_reasons = _properties.Optional(
+        _properties.List(_properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -706,6 +755,12 @@ class IngredientFractionsPredictor(Serializable["IngredientFractionsPredictor"],
         serializable=False
     )
     active = _properties.Boolean('active', default=True)
+    experimental = _properties.Boolean("experimental", serializable=False)
+    experimental_reasons = _properties.Optional(
+        _properties.List(_properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     def __init__(self,
                  name: str,

--- a/src/citrine/informatics/processors.py
+++ b/src/citrine/informatics/processors.py
@@ -63,6 +63,12 @@ class GridProcessor(Serializable['GridProcessor'], Processor):
         serializable=False
     )
     active = properties.Boolean('active', default=True)
+    experimental = properties.Boolean("experimental", serializable=False)
+    experimental_reasons = properties.Optional(
+        properties.List(properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = properties.String('module_type', default='PROCESSOR')
@@ -114,6 +120,12 @@ class EnumeratedProcessor(Serializable['EnumeratedProcessor'], Processor):
         serializable=False
     )
     active = properties.Boolean('active', default=True)
+    experimental = properties.Boolean("experimental", serializable=False)
+    experimental_reasons = properties.Optional(
+        properties.List(properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = properties.String('module_type', default='PROCESSOR')

--- a/src/citrine/informatics/processors.py
+++ b/src/citrine/informatics/processors.py
@@ -63,7 +63,7 @@ class GridProcessor(Serializable['GridProcessor'], Processor):
         serializable=False
     )
     active = properties.Boolean('active', default=True)
-    experimental = properties.Boolean("experimental", serializable=False)
+    experimental = properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = properties.Optional(
         properties.List(properties.String()),
         'experimental_reasons',
@@ -120,7 +120,7 @@ class EnumeratedProcessor(Serializable['EnumeratedProcessor'], Processor):
         serializable=False
     )
     active = properties.Boolean('active', default=True)
-    experimental = properties.Boolean("experimental", serializable=False)
+    experimental = properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = properties.Optional(
         properties.List(properties.String()),
         'experimental_reasons',

--- a/src/citrine/informatics/workflows.py
+++ b/src/citrine/informatics/workflows.py
@@ -67,6 +67,12 @@ class DesignWorkflow(Resource['DesignWorkflow'], Workflow):
         'status_info',
         serializable=False
     )
+    experimental = properties.Boolean("experimental", serializable=False)
+    experimental_reasons = properties.Optional(
+        properties.List(properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
     active = properties.Boolean('active', default=True)
     created_by = properties.Optional(properties.UUID, 'created_by', serializable=False)
     create_time = properties.Optional(properties.Datetime, 'create_time', serializable=False)
@@ -119,6 +125,12 @@ class PerformanceWorkflow(Resource['PerformanceWorkflow'], Workflow):
     status_info = properties.Optional(
         properties.List(properties.String()),
         'status_info',
+        serializable=False
+    )
+    experimental = properties.Boolean("experimental", serializable=False)
+    experimental_reasons = properties.Optional(
+        properties.List(properties.String()),
+        'experimental_reasons',
         serializable=False
     )
     active = properties.Boolean('active', default=True)

--- a/src/citrine/informatics/workflows.py
+++ b/src/citrine/informatics/workflows.py
@@ -67,7 +67,7 @@ class DesignWorkflow(Resource['DesignWorkflow'], Workflow):
         'status_info',
         serializable=False
     )
-    experimental = properties.Boolean("experimental", serializable=False)
+    experimental = properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = properties.Optional(
         properties.List(properties.String()),
         'experimental_reasons',
@@ -127,7 +127,7 @@ class PerformanceWorkflow(Resource['PerformanceWorkflow'], Workflow):
         'status_info',
         serializable=False
     )
-    experimental = properties.Boolean("experimental", serializable=False)
+    experimental = properties.Boolean("experimental", serializable=False, default=True)
     experimental_reasons = properties.Optional(
         properties.List(properties.String()),
         'experimental_reasons',


### PR DESCRIPTION
# Citrine Python PR

## Description 
These are present on all modules and workflows as type boolean
and list[str].  They are response-only fields populated
by the service.  Because they aren't part of the constructor, they aren't particularly visible
in the autodocs, so I went ahead and added them to the sphinx docs.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
