### PR TITLE
Add pre-register/update validation of enumerated design space size

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.40.2',
+      version='0.40.3',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.40.3',
+      version='0.40.4',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/design_space.py
+++ b/src/citrine/resources/design_space.py
@@ -24,7 +24,7 @@ class DesignSpaceCollection(Collection[DesignSpace]):
     _resource = DesignSpace
     _module_type = 'DESIGN_SPACE'
     _enumerated_descriptor_limit = 10
-    _enumerated_candidate_limit = 5000
+    _enumerated_candidate_limit = 2000
 
     def __init__(self, project_id: UUID, session: Session = Session()):
         self.project_id = project_id

--- a/tests/resources/test_design_space.py
+++ b/tests/resources/test_design_space.py
@@ -56,7 +56,7 @@ def test_design_space_limits():
         "foo",
         "bar",
         descriptors=[RealDescriptor("x", 0, 1)],
-        data=[{"x": random()} for _ in range(11000)]
+        data=[{"x": random()} for _ in range(2001)]
     )
 
     too_wide = EnumeratedDesignSpace(


### PR DESCRIPTION
# Citrine Python PR

## Description 

EnumeratedDesignSpaces can be pretty big, so we want to return a helpful
error message rather than let the POST or PUT call fail because the
request body is too big.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
