### PR TITLE
Added fallback to octet-stream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.40.5',
+      version='0.40.6',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -214,7 +214,7 @@ class FileCollection(Collection[FileLink]):
         """
         path = self._get_path() + "/uploads"
         extension = os.path.splitext(file_path)[1]
-        mime_type = mimetypes.types_map[extension.lower()]
+        mime_type = mimetypes.types_map.get(extension.lower(), "application/octet-stream")
         file_size = os.stat(file_path).st_size
         assert isinstance(file_size, int)
         upload_json = {

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -98,7 +98,7 @@ def test_upload(mock_isfile, mock_stat, mock_open, mock_boto3_client, collection
     # It would be good to test these, but the values assigned are not accessible
     dest_names = {
         'foo.txt': 'text/plain',
-        'foo.TXT': 'text/plain',  # Verify that capitalization in extension is fine
+        'foo.TXT': 'text/plain',  # Capitalization in extension is fine
         'foo.bar': 'application/octet-stream'  # No match == generic binary
     }
     file_id = '12345'

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -95,7 +95,12 @@ def test_upload(mock_isfile, mock_stat, mock_open, mock_boto3_client, collection
     mock_open.return_value.__enter__.return_value = 'Random file contents'
     mock_boto3_client.return_value = FakeS3Client({'VersionId': '3'})
 
-    dest_names = ['foo.txt', 'foo.TXT']  # Verify that capitalization in extension is fine
+    # It would be good to test these, but the values assigned are not accessible
+    dest_names = {
+        'foo.txt': 'text/plain',
+        'foo.TXT': 'text/plain',  # Verify that capitalization in extension is fine
+        'foo.bar': 'application/octet-stream'  # No match == generic binary
+    }
     file_id = '12345'
     version = '13'
 
@@ -130,57 +135,7 @@ def test_upload(mock_isfile, mock_stat, mock_open, mock_boto3_client, collection
             .format(collection.project_id, collection.dataset_id, file_id, version)
         assert file_link.dump() == FileLink(dest_name, url=url).dump()
 
-    assert session.num_calls == 4
-
-
-@pytest.mark.xfail(reason="PLA-4395: MIME type resolution depends on file extension")
-@patch('citrine.resources.file_link.boto3_client')
-@patch('citrine.resources.file_link.open')
-@patch('citrine.resources.file_link.os.stat')
-@patch('citrine.resources.file_link.os.path.isfile')
-def test_upload_fail(mock_isfile, mock_stat, mock_open, mock_boto3_client, collection, session):
-    """Test signaling that an upload has completed and the creation of a FileLink object."""
-    StatStub = namedtuple('StatStub', ['st_size'])
-
-    mock_isfile.return_value = True
-    mock_stat.return_value = StatStub(st_size=22300)
-    mock_open.return_value.__enter__.return_value = 'Random file contents'
-    mock_boto3_client.return_value = FakeS3Client({'VersionId': '3'})
-
-    dest_name = 'foo.bar'
-    file_id = '12345'
-    version = '13'
-
-    # This is the dictionary structure we expect from the upload completion request
-    file_info_response = {
-        'file_info': {
-            'file_id': file_id,
-            'version': version
-        }
-    }
-    uploads_response = {
-        's3_region': 'us-east-1',
-        's3_bucket': 'temp-bucket',
-        'temporary_credentials': {
-            'access_key_id': '1234',
-            'secret_access_key': 'abbb8777',
-            'session_token': 'hefheuhuhhu83772333',
-        },
-        'uploads': [
-            {
-                's3_key': '66377378',
-                'upload_id': '111',
-            }
-        ]
-    }
-
-    session.set_responses(uploads_response, file_info_response)
-    file_link = collection.upload(dest_name)
-    assert session.num_calls == 2
-
-    url = 'projects/{}/datasets/{}/files/{}/versions/{}' \
-        .format(collection.project_id, collection.dataset_id, file_id, version)
-    assert file_link.dump() == FileLink(dest_name, url=url).dump()
+    assert session.num_calls == 2 * len(dest_names)
 
 
 def test_upload_missing_file(collection):


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR modifies the MIME type resolution so that any unrecognized upload is uploaded with MIME type `application/octet-stream` as per [common practice](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).  

Issue was encountered trying to upload a file with an `.xlsx` file extension.  If we instead want to include the [formally correct MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml), we should define a Citrine custom MIME type file, as per [mimetypes](https://docs.python.org/3/library/mimetypes.html#mimetypes.init).  This seems excessive as we will not be acting on them.

https://citrine.atlassian.net/browse/PLA-4395

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
