### PR TITLE
modify file_link to use the mime type library's guess_type method 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.40.6',
+      version='0.40.7',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -127,7 +127,7 @@ class FileCollection(Collection[FileLink]):
         This is necessary because the database resource contains additional information that is
         not in the FileLink object, such as file size and the id of the user who uploaded the file.
 
-        Paramters
+        Parameters
         ---------
         file: dict
             A JSON dictionary corresponding to the file link as it is saved in the database.
@@ -195,9 +195,7 @@ class FileCollection(Collection[FileLink]):
 
     def _make_upload_request(self, file_path: str, dest_name: str):
         """
-        Make a request to the backend to upload a file.
-        Uses mimetypes.guess_type to guess the mime type of the file, including 
-        commonly used but not IANA approved mime types (like .xlsx).
+        Make a request to the backend to upload a file. Uses mimetypes.guess_type.
 
         Parameters
         ----------

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -30,6 +30,18 @@ def valid_data() -> dict:
     return FileLinkDataFactory(url='www.citrine.io', filename='materials.txt')
 
 
+def test_mime_types(collection):
+    expected_xlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    expected_xls = "application/vnd.ms-excel"
+    expected_txt = "text/plain"
+    expected_unk = "application/octet-stream"
+
+    assert collection._mime_type("asdf.xlsx") == expected_xlsx
+    assert collection._mime_type("asdf.XLSX") == expected_xlsx
+    assert collection._mime_type("asdf.xls") == expected_xls
+    assert collection._mime_type("asdf.TXT") == expected_txt
+    assert collection._mime_type("asdf.FAKE") == expected_unk
+
 def test_build_equivalence(collection, valid_data):
     """Test that build() works the same whether called from FileLink or FileCollection."""
     assert collection.build(valid_data).dump() == FileLink.build(valid_data).dump()
@@ -141,7 +153,6 @@ def test_upload(mock_isfile, mock_stat, mock_open, mock_boto3_client, collection
 def test_upload_missing_file(collection):
     with pytest.raises(ValueError):
         collection.upload('this-file-does-not-exist.xls')
-
 
 @patch('citrine.resources.file_link.os.stat')
 def test_upload_request(mock_stat, collection, session, uploader):


### PR DESCRIPTION
First, use mimetypes' [guess_type](https://docs.python.org/2/library/mimetypes.html#mimetypes.guess_type) method, which includes commonly used but non-iana mime types (like xslx) before falling back to `application/octet-stream`

# Citrine Python PR

## Description 
Please briefly explain the goal of the changes/this PR.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
