### PR TITLE
Pla 4204 categorical descriptor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.40.7',
+      version='0.40.8',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -182,7 +182,11 @@ class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):
 
     def __init__(self, key: str, categories: List[str]):
         self.key: str = key
+        for category in categories:
+            if not isinstance(category, str):
+                raise TypeError("All categories must be strings")
         self.categories: List[str] = categories
+
 
     def __str__(self):
         return "<CategoricalDescriptor {!r}>".format(self.key)

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -187,7 +187,6 @@ class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):
                 raise TypeError("All categories must be strings")
         self.categories: List[str] = categories
 
-
     def __str__(self):
         return "<CategoricalDescriptor {!r}>".format(self.key)
 

--- a/tests/informatics/test_descriptors.py
+++ b/tests/informatics/test_descriptors.py
@@ -52,3 +52,10 @@ def test_inorganic_deprecated():
 def test_string_rep(descriptor):
     """String representation of descriptor should contain the descriptor key."""
     assert str(descriptor).__contains__(descriptor.key)
+
+def test_categorical_descriptor_categories_types():
+    """Categories in a categorical descriptor should be of type str, and other types should raise TypeError."""
+    with pytest.raises(TypeError):
+        CategoricalDescriptor("my categorical", ["a", "b", 1])
+    with pytest.raises(TypeError):
+        CategoricalDescriptor("my categorical", ["a", "b", None])


### PR DESCRIPTION
# Citrine Python PR

## Description 
Categorical descriptors should only allow strings in the `categories` field. If a CategoricalDescriptor contains something else, construction should fail. Currently, serialization fails instead, which is confusing to end users.

Note: There's a difference in the way that serialization and construction is handled in the `Property` class which is leading to this error. The serializer is recursively checking the types, and the setter isn't. This PR is a patch to handle one case in which the difference caused confusion, but unless we change the way the setter works in `Property`, we're open to similar confusion in the future.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
