### PR TITLE
coerce path to string before handing it off

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.40.9',
+      version='0.40.10',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.40.10',
+      version='0.41.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -213,7 +213,8 @@ class FileCollection(Collection[FileLink]):
 
         """
         path = self._get_path() + "/uploads"
-        mime_type = self._mime_type(file_path)
+        # This string coersion is for supporting pathlib.Path objects in python 3.6
+        mime_type = self._mime_type(str(file_path))
         file_size = os.stat(file_path).st_size
         assert isinstance(file_size, int)
         upload_json = {

--- a/tests/resources/test_file_link.py
+++ b/tests/resources/test_file_link.py
@@ -35,11 +35,13 @@ def test_mime_types(collection):
     expected_xls = "application/vnd.ms-excel"
     expected_txt = "text/plain"
     expected_unk = "application/octet-stream"
+    expected_csv = "text/csv"
 
     assert collection._mime_type("asdf.xlsx") == expected_xlsx
     assert collection._mime_type("asdf.XLSX") == expected_xlsx
     assert collection._mime_type("asdf.xls") == expected_xls
     assert collection._mime_type("asdf.TXT") == expected_txt
+    assert collection._mime_type("asdf.csv") == expected_csv
     assert collection._mime_type("asdf.FAKE") == expected_unk
 
 def test_build_equivalence(collection, valid_data):


### PR DESCRIPTION
# Citrine Python PR
Should address the following failure mode: We are passing a pathlib.Path, and in python3.6, this appears to not get automatically coerced to a string. The other option is getting rid of pathlib.Path from the devkit tests, but that is less robust to people making the same ~mistake~ choice in the future.



https://jenkins.corp.citrine.io/job/devkit/362/console

> 19:55:11  ______________ ERROR at setup of test_graph_predictor_validation _______________
19:55:11  tests/conftest.py:332: in hcep_small_csv
19:55:11      return get_hcep_csv(hcep_dataset, lock_dataset)
19:55:11  tests/preload/hcep.py:70: in get_hcep_csv
19:55:11      timeout=120,
19:55:11  tests/utils/locks.py:121: in find_or_create_atomic
19:55:11      resource = creator()
19:55:11  tests/preload/hcep.py:69: in <lambda>
19:55:11      creator=lambda: file_dataset.files.upload(file_path, HCEP_LIMITED_CSV_FNAME),
19:55:11  /usr/local/lib/python3.6/site-packages/citrine/resources/file_link.py:192: in upload
19:55:11      uploader = self._make_upload_request(file_path, dest_name)
19:55:11  /usr/local/lib/python3.6/site-packages/citrine/resources/file_link.py:216: in _make_upload_request
19:55:11      mime_type = self._mime_type(file_path)
19:55:11  /usr/local/lib/python3.6/site-packages/citrine/resources/file_link.py:255: in _mime_type
19:55:11      mime_type = mimetypes.guess_type(file_path)[0]
19:55:11  /usr/local/lib/python3.6/mimetypes.py:291: in guess_type
19:55:11      return _db.guess_type(url, strict)
19:55:11  /usr/local/lib/python3.6/mimetypes.py:116: in guess_type
19:55:11      scheme, url = urllib.parse.splittype(url)
19:55:11  /usr/local/lib/python3.6/urllib/parse.py:974: in splittype
19:55:11      match = _typeprog.match(url)
19:55:11  E   TypeError: expected string or bytes-like object

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
