### PR TITLE
Add back design space size limit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.43.0',
+      version='0.43.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/design_space.py
+++ b/src/citrine/resources/design_space.py
@@ -4,7 +4,7 @@ from typing import TypeVar
 
 from citrine._rest.collection import Collection
 from citrine._session import Session
-from citrine.informatics.design_spaces import DesignSpace
+from citrine.informatics.design_spaces import DesignSpace, EnumeratedDesignSpace
 
 CreationType = TypeVar('CreationType', bound=DesignSpace)
 
@@ -23,6 +23,8 @@ class DesignSpaceCollection(Collection[DesignSpace]):
     _individual_key = None
     _resource = DesignSpace
     _module_type = 'DESIGN_SPACE'
+    _enumerated_descriptor_limit = 128
+    _enumerated_candidate_limit = 2000
 
     def __init__(self, project_id: UUID, session: Session = Session()):
         self.project_id = project_id
@@ -33,3 +35,34 @@ class DesignSpaceCollection(Collection[DesignSpace]):
         design_space = DesignSpace.build(data)
         design_space.session = self.session
         return design_space
+
+    def validate_write_request(self, design_space: DesignSpace):
+        """Perform write-time validations of the design space registration or update.
+
+        EnumeratedDesignSpaces can be pretty big, so we want to return a helpful error message
+        rather than let the POST or PUT call fail because the request body is too big.  This
+        validation is performed when the design space is sent to the platform in case a user
+        creates a large intermediate design space but then filters it down before registering it.
+        """
+        if isinstance(design_space, EnumeratedDesignSpace):
+            width = len(design_space.descriptors)
+            length = len(design_space.data)
+            if width > self._enumerated_descriptor_limit:
+                msg = "EnumeratedDesignSpace only supports up to {} descriptors, " \
+                      "but {} were given"
+                raise ValueError(msg.format(self._enumerated_descriptor_limit, width))
+            if length > self._enumerated_candidate_limit:
+                msg = "EnumeratedDesignSpace only supports up to {} candidates, " \
+                      "but {} were given"
+                raise ValueError(msg.format(self._enumerated_candidate_limit, length))
+        return
+
+    def register(self, model: DesignSpace) -> DesignSpace:
+        """Create a new design space."""
+        self.validate_write_request(model)
+        return Collection.register(self, model)
+
+    def update(self, model: DesignSpace) -> DesignSpace:
+        """Update an existing design space by uid."""
+        self.validate_write_request(model)
+        return Collection.update(self, model)

--- a/tests/resources/test_design_space.py
+++ b/tests/resources/test_design_space.py
@@ -76,9 +76,6 @@ def test_design_space_limits():
 
     # create mock post response by setting the status
     mock_response = just_right.dump()
-    mock_response["status"] = "READY"
-    mock_response["experimental"] = True
-    mock_response["experimental_reasons"] = ["This is a test", "That experimental reasons work"]
     session.responses.append(mock_response)
 
     # Then

--- a/tests/resources/test_design_space.py
+++ b/tests/resources/test_design_space.py
@@ -1,6 +1,12 @@
 import uuid
+from random import random
 
+import pytest
+
+from citrine.informatics.descriptors import RealDescriptor
+from citrine.informatics.design_spaces import EnumeratedDesignSpace
 from citrine.resources.design_space import DesignSpaceCollection
+from tests.utils.session import FakeSession
 
 
 def test_design_space_build():
@@ -39,3 +45,54 @@ def test_design_space_build():
     assert design_space.uid == design_space_id
     assert design_space.name == 'My Design Space'
     assert design_space.dimensions[0].descriptor.key == 'foo'
+
+
+def test_design_space_limits():
+    """Test that the validation logic is triggered before post/put-ing enumerated design spaces."""
+    # Given
+    session = FakeSession()
+    collection = DesignSpaceCollection(uuid.uuid4(), session)
+
+    too_long = EnumeratedDesignSpace(
+        "foo",
+        "bar",
+        descriptors=[RealDescriptor("x", 0, 1)],
+        data=[{"x": random()} for _ in range(2001)]
+    )
+
+    too_wide = EnumeratedDesignSpace(
+        "foo",
+        "bar",
+        descriptors=[RealDescriptor("R-{}".format(i), 0, 1) for i in range(11)],
+        data=[]
+    )
+
+    just_right = EnumeratedDesignSpace(
+        "foo",
+        "bar",
+        descriptors=[RealDescriptor("R-{}".format(i), 0, 1) for i in range(10)],
+        data=[{"R-{}".format(i): random() for i in range(10)} for _ in range(1000)]
+    )
+
+    # create mock post response by setting the status
+    mock_response = just_right.dump()
+    mock_response["status"] = "READY"
+    session.responses.append(mock_response)
+
+    # Then
+    with pytest.raises(ValueError) as excinfo:
+        collection.register(too_long)
+    assert "only supports" in str(excinfo.value)
+
+    with pytest.raises(ValueError):
+        collection.update(too_wide)
+    assert "only supports" in str(excinfo.value)
+
+    # test register
+    collection.register(just_right)
+
+    # add back the response for the next test
+    session.responses.append(mock_response)
+
+    # test update
+    collection.update(just_right)

--- a/tests/resources/test_design_space.py
+++ b/tests/resources/test_design_space.py
@@ -63,7 +63,7 @@ def test_design_space_limits():
     too_wide = EnumeratedDesignSpace(
         "foo",
         "bar",
-        descriptors=[RealDescriptor("R-{}".format(i), 0, 1) for i in range(11)],
+        descriptors=[RealDescriptor("R-{}".format(i), 0, 1) for i in range(129)],
         data=[]
     )
 
@@ -71,12 +71,14 @@ def test_design_space_limits():
         "foo",
         "bar",
         descriptors=[RealDescriptor("R-{}".format(i), 0, 1) for i in range(10)],
-        data=[{"R-{}".format(i): random() for i in range(10)} for _ in range(1000)]
+        data=[{"R-{}".format(i): random() for i in range(128)} for _ in range(1000)]
     )
 
     # create mock post response by setting the status
     mock_response = just_right.dump()
     mock_response["status"] = "READY"
+    mock_response["experimental"] = True
+    mock_response["experimental_reasons"] = ["This is a test", "That experimental reasons work"]
     session.responses.append(mock_response)
 
     # Then

--- a/tests/resources/test_design_space.py
+++ b/tests/resources/test_design_space.py
@@ -76,6 +76,7 @@ def test_design_space_limits():
 
     # create mock post response by setting the status
     mock_response = just_right.dump()
+    mock_response["status"] = "READY"
     session.responses.append(mock_response)
 
     # Then


### PR DESCRIPTION
# Citrine Python PR

## Description 
The [first attempt](https://github.com/CitrineInformatics/citrine-python/pull/377) ran into issues with our existing e2e tests.  This increases the limit on the number of columns significantly (which has been checked against the post body limit) and the e2e tests are being thinned a bit.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [x] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
