### PR TITLE
Warn on experimental register and update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.43.1',
+      version='0.43.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -210,7 +210,10 @@ class Collection(Generic[ResourceType]):
 
     def _check_experimental(self, data):
         if data.get("experimental", False):
-            msg = "The resource is experimental because: \n  {}".format(
+            uid = data.get("id")
+            typ = self._resource().__class__.__name__
+            msg = "The {} with id {} is experimental because: \n  {}".format(
+                typ, uid,
                 "\n  ".join(data.get("experimental_reasons") or ["Unknown reason"])
             )
             warnings.warn(msg)

--- a/tests/resources/test_predictor.py
+++ b/tests/resources/test_predictor.py
@@ -59,7 +59,10 @@ def test_register_experimental(valid_simple_ml_predictor_data, basic_predictor_r
     predictor = SimpleMLPredictor.build(valid_simple_ml_predictor_data)
     with pytest.warns(UserWarning) as record:
         pc.register(predictor)
-    assert len(str(record[0].message).split("\n")) == 3
+    msg = str(record[0].message)
+    assert "Predictor" in msg
+    assert "This is a test" in msg
+    assert "Of experimental reasons" in msg
 
 
 def test_graph_register(valid_graph_predictor_data, basic_predictor_report_data):

--- a/tests/resources/test_predictor.py
+++ b/tests/resources/test_predictor.py
@@ -48,6 +48,20 @@ def test_register(valid_simple_ml_predictor_data, basic_predictor_report_data):
     assert registered.name == 'ML predictor'
 
 
+def test_register_experimental(valid_simple_ml_predictor_data, basic_predictor_report_data):
+    session = mock.Mock()
+    post_response = deepcopy(valid_simple_ml_predictor_data)
+    post_response["experimental"] = True
+    post_response["experimental_reasons"] = ["This is a test", "Of experimental reasons"]
+    session.post_resource.return_value = post_response
+    session.get_resource.return_value = basic_predictor_report_data
+    pc = PredictorCollection(uuid.uuid4(), session)
+    predictor = SimpleMLPredictor.build(valid_simple_ml_predictor_data)
+    with pytest.warns(UserWarning) as record:
+        pc.register(predictor)
+    assert len(str(record[0].message).split("\n")) == 3
+
+
 def test_graph_register(valid_graph_predictor_data, basic_predictor_report_data):
     copy_graph_data = deepcopy(valid_graph_predictor_data)
     session = mock.Mock()


### PR DESCRIPTION
# Citrine Python PR

## Description 
Add a warning when a register or update call returns an experimental resource.  This is part of PLA-4581.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
