### PR TITLE
Using new backend path /table-configs instead of /gem-table-configs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.42.0',
+      version='0.42.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/table.py
+++ b/src/citrine/resources/table.py
@@ -130,7 +130,7 @@ class TableCollection(Collection[Table]):
                            per_page: int) -> Tuple[Iterable[dict], str]:
             path_params = {'ara_definition_uid_str': str(ara_definition_uid)}
             path_params.update(self.__dict__)
-            path = 'projects/{project_id}/gem-table-configs/{ara_definition_uid_str}/gem-tables'\
+            path = 'projects/{project_id}/table-configs/{ara_definition_uid_str}/gem-tables'\
                 .format(**path_params)
             data = self.session.get_resource(
                 path,


### PR DESCRIPTION
Using new backend path /table-configs instead of /gem-table-configs

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
