### PR TITLE
Bugfix/add resource fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.43.3',
+      version='0.43.4',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -207,6 +207,7 @@ class AraDefinitionCollection(Collection[AraDefinition]):
 
     _path_template = 'projects/{project_id}/ara-definitions'
     _collection_key = 'definitions'
+    _resource = AraDefinition
 
     # NOTE: This isn't actually an 'individual key' - both parts (version and
     # definition) are necessary

--- a/src/citrine/resources/condition_template.py
+++ b/src/citrine/resources/condition_template.py
@@ -67,6 +67,7 @@ class ConditionTemplateCollection(AttributeTemplateCollection[ConditionTemplate]
     _dataset_agnostic_path_template = 'projects/{project_id}/condition-templates'
     _individual_key = 'condition_template'
     _collection_key = 'condition_templates'
+    _resource = ConditionTemplate
 
     @classmethod
     def get_type(cls) -> Type[ConditionTemplate]:

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -288,6 +288,7 @@ class DatasetCollection(Collection[Dataset]):
     _path_template = 'projects/{project_id}/datasets'
     _individual_key = None
     _collection_key = None
+    _resource = Dataset
 
     def __init__(self, project_id: UUID, session: Session):
         self.project_id = project_id

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -74,6 +74,7 @@ class FileCollection(Collection[FileLink]):
     _path_template = 'projects/{project_id}/datasets/{dataset_id}/files'
     _individual_key = 'file'
     _collection_key = 'files'
+    _resource = FileLink
 
     def __init__(self, project_id: UUID, dataset_id: UUID, session: Session):
         self.project_id = project_id

--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -116,6 +116,7 @@ class IngredientRunCollection(ObjectRunCollection[IngredientRun]):
     _dataset_agnostic_path_template = 'projects/{project_id}/ingredient-runs'
     _individual_key = 'ingredient_run'
     _collection_key = 'ingredient_runs'
+    _resource = IngredientRun
 
     @classmethod
     def get_type(cls) -> Type[IngredientRun]:

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -110,6 +110,7 @@ class IngredientSpecCollection(ObjectSpecCollection[IngredientSpec]):
     _dataset_agnostic_path_template = 'projects/{project_id}/ingredient-specs'
     _individual_key = 'ingredient_spec'
     _collection_key = 'ingredient_specs'
+    _resource = IngredientSpec
 
     @classmethod
     def get_type(cls) -> Type[IngredientSpec]:

--- a/src/citrine/resources/material_run.py
+++ b/src/citrine/resources/material_run.py
@@ -102,6 +102,7 @@ class MaterialRunCollection(ObjectRunCollection[MaterialRun]):
     _dataset_agnostic_path_template = 'projects/{project_id}/material-runs'
     _individual_key = 'material_run'
     _collection_key = 'material_runs'
+    _resource = MaterialRun
 
     @classmethod
     def get_type(cls) -> Type[MaterialRun]:

--- a/src/citrine/resources/material_spec.py
+++ b/src/citrine/resources/material_spec.py
@@ -90,6 +90,7 @@ class MaterialSpecCollection(ObjectSpecCollection[MaterialSpec]):
     _dataset_agnostic_path_template = 'projects/{project_id}/material-specs'
     _individual_key = 'material_spec'
     _collection_key = 'material_specs'
+    _resource = MaterialSpec
 
     @classmethod
     def get_type(cls) -> Type[MaterialSpec]:

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -85,6 +85,7 @@ class MaterialTemplateCollection(ObjectTemplateCollection[MaterialTemplate]):
     _dataset_agnostic_path_template = 'projects/{project_id}/material-templates'
     _individual_key = 'material_template'
     _collection_key = 'material_templates'
+    _resource = MaterialTemplate
 
     @classmethod
     def get_type(cls) -> Type[MaterialTemplate]:

--- a/src/citrine/resources/measurement_run.py
+++ b/src/citrine/resources/measurement_run.py
@@ -102,6 +102,7 @@ class MeasurementRunCollection(ObjectRunCollection[MeasurementRun]):
     _dataset_agnostic_path_template = 'projects/{project_id}/measurement-runs'
     _individual_key = 'measurement_run'
     _collection_key = 'measurement_runs'
+    _resource = MeasurementRun
 
     @classmethod
     def get_type(cls) -> Type[MeasurementRun]:

--- a/src/citrine/resources/measurement_spec.py
+++ b/src/citrine/resources/measurement_spec.py
@@ -85,6 +85,7 @@ class MeasurementSpecCollection(ObjectSpecCollection[MeasurementSpec]):
     _dataset_agnostic_path_template = 'projects/{project_id}/measurement-specs'
     _individual_key = 'measurement_spec'
     _collection_key = 'measurement_specs'
+    _resource = MeasurementSpec
 
     @classmethod
     def get_type(cls) -> Type[MeasurementSpec]:

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -110,6 +110,7 @@ class MeasurementTemplateCollection(ObjectTemplateCollection[MeasurementTemplate
     _dataset_agnostic_path_template = 'projects/{project_id}/measurement-templates'
     _individual_key = 'measurement_template'
     _collection_key = 'measurement_templates'
+    _resource = MeasurementTemplate
 
     @classmethod
     def get_type(cls) -> Type[MeasurementTemplate]:

--- a/src/citrine/resources/parameter_template.py
+++ b/src/citrine/resources/parameter_template.py
@@ -66,6 +66,7 @@ class ParameterTemplateCollection(AttributeTemplateCollection[ParameterTemplate]
     _dataset_agnostic_path_template = 'projects/{project_id}/parameter-templates'
     _individual_key = 'parameter_template'
     _collection_key = 'parameter_templates'
+    _resource = ParameterTemplate
 
     @classmethod
     def get_type(cls) -> Type[ParameterTemplate]:

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -100,6 +100,7 @@ class ProcessRunCollection(ObjectRunCollection[ProcessRun]):
     _dataset_agnostic_path_template = 'projects/{project_id}/process-runs'
     _individual_key = 'process_run'
     _collection_key = 'process_runs'
+    _resource = ProcessRun
 
     @classmethod
     def get_type(cls) -> Type[ProcessRun]:

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -96,6 +96,7 @@ class ProcessSpecCollection(ObjectSpecCollection[ProcessSpec]):
     _dataset_agnostic_path_template = 'projects/{project_id}/process-specs'
     _individual_key = 'process_spec'
     _collection_key = 'process_specs'
+    _resource = ProcessSpec
 
     @classmethod
     def get_type(cls) -> Type[ProcessSpec]:

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -100,6 +100,7 @@ class ProcessTemplateCollection(ObjectTemplateCollection[ProcessTemplate]):
     _dataset_agnostic_path_template = 'projects/{project_id}/process-templates'
     _individual_key = 'process_template'
     _collection_key = 'process_templates'
+    _resource = ProcessTemplate
 
     @classmethod
     def get_type(cls) -> Type[ProcessTemplate]:

--- a/src/citrine/resources/processor.py
+++ b/src/citrine/resources/processor.py
@@ -21,6 +21,7 @@ class ProcessorCollection(Collection[Processor]):
 
     _path_template = '/projects/{project_id}/modules'
     _individual_key = None
+    _resource = Processor
     _module_type = 'PROCESSOR'
 
     def __init__(self, project_id: UUID, session: Session):

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -330,6 +330,7 @@ class ProjectCollection(Collection[Project]):
     _path_template = '/projects'
     _individual_key = 'project'
     _collection_key = 'projects'
+    _resource = Project
 
     def __init__(self, session: Session = Session()):
         self.session = session

--- a/src/citrine/resources/property_template.py
+++ b/src/citrine/resources/property_template.py
@@ -66,6 +66,7 @@ class PropertyTemplateCollection(AttributeTemplateCollection[PropertyTemplate]):
     _dataset_agnostic_path_template = 'projects/{project_id}/property-templates'
     _individual_key = 'property_template'
     _collection_key = 'property_templates'
+    _resource = PropertyTemplate
 
     @classmethod
     def get_type(cls) -> Type[PropertyTemplate]:

--- a/src/citrine/resources/table.py
+++ b/src/citrine/resources/table.py
@@ -73,6 +73,7 @@ class TableCollection(Collection[Table]):
     _path_template = 'projects/{project_id}/display-tables'
     _collection_key: str = 'tables'
     _paginator: Paginator = TableVersionPaginator()
+    _resource = Table
 
     def __init__(self, project_id: UUID, session: Session):
         self.project_id = project_id


### PR DESCRIPTION
# Citrine Python PR

## Description 
The _resource field is missing from many collections, which caused a bug when it was used to throw warnings for experimental modules.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
