### PR TITLE
Change the design space size check to count cells

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.43.5',
+      version='0.43.6',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/design_space.py
+++ b/src/citrine/resources/design_space.py
@@ -23,8 +23,7 @@ class DesignSpaceCollection(Collection[DesignSpace]):
     _individual_key = None
     _resource = DesignSpace
     _module_type = 'DESIGN_SPACE'
-    _enumerated_descriptor_limit = 128
-    _enumerated_candidate_limit = 2000
+    _enumerated_cell_limit = 128 * 2000
 
     def __init__(self, project_id: UUID, session: Session = Session()):
         self.project_id = project_id
@@ -47,14 +46,11 @@ class DesignSpaceCollection(Collection[DesignSpace]):
         if isinstance(design_space, EnumeratedDesignSpace):
             width = len(design_space.descriptors)
             length = len(design_space.data)
-            if width > self._enumerated_descriptor_limit:
-                msg = "EnumeratedDesignSpace only supports up to {} descriptors, " \
-                      "but {} were given"
-                raise ValueError(msg.format(self._enumerated_descriptor_limit, width))
-            if length > self._enumerated_candidate_limit:
-                msg = "EnumeratedDesignSpace only supports up to {} candidates, " \
-                      "but {} were given"
-                raise ValueError(msg.format(self._enumerated_candidate_limit, length))
+            if width * length > self._enumerated_cell_limit:
+                msg = "EnumeratedDesignSpace only supports up to {} descriptor-values, " \
+                      "but {} were given. Please reduce the number of descriptors or candidates " \
+                      "in this EnumeratedDesignSpace"
+                raise ValueError(msg.format(self._enumerated_cell_limit, width * length))
         return
 
     def register(self, model: DesignSpace) -> DesignSpace:

--- a/tests/resources/test_design_space.py
+++ b/tests/resources/test_design_space.py
@@ -53,24 +53,17 @@ def test_design_space_limits():
     session = FakeSession()
     collection = DesignSpaceCollection(uuid.uuid4(), session)
 
-    too_long = EnumeratedDesignSpace(
+    too_big = EnumeratedDesignSpace(
         "foo",
         "bar",
-        descriptors=[RealDescriptor("x", 0, 1)],
-        data=[{"x": random()} for _ in range(2001)]
-    )
-
-    too_wide = EnumeratedDesignSpace(
-        "foo",
-        "bar",
-        descriptors=[RealDescriptor("R-{}".format(i), 0, 1) for i in range(129)],
-        data=[]
+        descriptors=[RealDescriptor("R-{}".format(i), 0, 1) for i in range(128)],
+        data=[{"R-{}".format(i): random() for i in range(128)} for _ in range(2001)]
     )
 
     just_right = EnumeratedDesignSpace(
         "foo",
         "bar",
-        descriptors=[RealDescriptor("R-{}".format(i), 0, 1) for i in range(10)],
+        descriptors=[RealDescriptor("R-{}".format(i), 0, 1) for i in range(128)],
         data=[{"R-{}".format(i): random() for i in range(128)} for _ in range(1000)]
     )
 
@@ -81,11 +74,7 @@ def test_design_space_limits():
 
     # Then
     with pytest.raises(ValueError) as excinfo:
-        collection.register(too_long)
-    assert "only supports" in str(excinfo.value)
-
-    with pytest.raises(ValueError):
-        collection.update(too_wide)
+        collection.register(too_big)
     assert "only supports" in str(excinfo.value)
 
     # test register

--- a/tests/resources/test_design_space.py
+++ b/tests/resources/test_design_space.py
@@ -64,7 +64,7 @@ def test_design_space_limits():
         "foo",
         "bar",
         descriptors=[RealDescriptor("R-{}".format(i), 0, 1) for i in range(128)],
-        data=[{"R-{}".format(i): random() for i in range(128)} for _ in range(1000)]
+        data=[{"R-{}".format(i): random() for i in range(128)} for _ in range(2000)]
     )
 
     # create mock post response by setting the status


### PR DESCRIPTION
## Description 

The client-side design space size limit is meant simply to catch
very large POSTs and PUTs that would cause a 5xx on the backend
because they are too big.  This changes "too big" from either
"too many rows" or "too many columns" to "too many cells", with
the actual number of cells unchanged.

NOTE this does not imply that we can actually handle any
EnumeratedDesignSpace that fits within this limit; simply that it
shoudln't cause a 5xx in the handler on the backend.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
