### PR TITLE
Adding dataset.delete(obj), which calls the specific type's delete

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.43.6',
+      version='0.44.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -271,6 +271,14 @@ class Dataset(Resource['Dataset']):
                     resources.extend(registered)
         return resources
 
+    def delete(self, data_concepts_resource: ResourceType, dry_run=False) -> ResourceType:
+        """Delete a data concepts resource to the appropriate collection."""
+        uid = next(iter(data_concepts_resource.uids.items()), None)
+        if uid is None:
+            raise ValueError("Only objects that contain identifiers can be deleted.")
+        return self._collection_for(data_concepts_resource) \
+            .delete(uid[1], scope=uid[0], dry_run=dry_run)
+
 
 class DatasetCollection(Collection[Dataset]):
     """

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -346,3 +346,24 @@ def test_register_all_object_update(dataset):
 
     assert process.uids == registered_process.uids
     assert material.uids == registered_material.uids
+
+
+def test_delete_data_concepts(dataset):
+    """Check that delete routes to the correct collections"""
+    expected = {
+        MaterialTemplateCollection: MaterialTemplate("foo", uids={"foo": "bar"}),
+        MaterialSpecCollection: MaterialSpec("foo", uids={"foo": "bar"}),
+        MaterialRunCollection: MaterialRun("foo", uids={"foo": "bar"}),
+        ProcessTemplateCollection: ProcessTemplate("foo", uids={"foo": "bar"}),
+    }
+
+    for collection, obj in expected.items():
+        dataset.delete(obj)
+        assert dataset.session.calls[-1].path.split("/")[-3] == basename(collection._path_template)
+
+
+def test_delete_missing_uid(dataset):
+    """Check that delete raises an error when there are no uids"""
+    obj = MaterialTemplate("foo")
+    with pytest.raises(ValueError):
+        dataset.delete(obj)


### PR DESCRIPTION
# Citrine Python PR

## Description 
This is a convenience method that makes it much easier to delete
data objects in loops.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
