### PR TITLE
fix usage of project search in find_collection function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.40.7',
+      version='0.40.8',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -402,7 +402,7 @@ class ProjectCollection(Collection[Project]):
                 },
             }
             The dict can constain any combination of (one or all) search specifications for the
-        name, description, and status fields of a project. For each parameter specified, the
+            name, description, and status fields of a project. For each parameter specified, the
             "value" to match, as well as the "search_method" must be provided. The available
             search_methods are "SUBSTRING" and "EXACT". The example above demonstrates the input
             necessary to list projects with the exact name "Polymer Project," and descriptions

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -392,19 +392,17 @@ class ProjectCollection(Collection[Project]):
             A dict representing the body of the post request that will be sent to the search
             endpoint to filter the results ie.
             {
-                "search_params": {
-                    "name": {
-                        "value": "Polymer Project",
-                        "search_method": "EXACT"
-                    },
-                    "description": {
-                        "value": "polymer chain length",
-                        "search_method": "SUBSTRING"
-                    },
-                }
+                "name": {
+                    "value": "Polymer Project",
+                    "search_method": "EXACT"
+                },
+                "description": {
+                    "value": "polymer chain length",
+                    "search_method": "SUBSTRING"
+                },
             }
             The dict can constain any combination of (one or all) search specifications for the
-            name, description, and status fields of a project. For each parameter specified, the
+        name, description, and status fields of a project. For each parameter specified, the
             "value" to match, as well as the "search_method" must be provided. The available
             search_methods are "SUBSTRING" and "EXACT". The example above demonstrates the input
             necessary to list projects with the exact name "Polymer Project," and descriptions
@@ -454,7 +452,7 @@ class ProjectCollection(Collection[Project]):
             field should be passed as the key for the outermost dict, with its value the request
             body, so that we can easily unpack the keyword argument when it gets passed to
             fetch_func.
-            ie. { 'search_params': {'name': {'value': 'Project', 'search_method': 'SUBSTRING'} } }
+            ie. {'name': {'value': 'Project', 'search_method': 'SUBSTRING'} }
 
         Returns
         -------
@@ -466,7 +464,7 @@ class ProjectCollection(Collection[Project]):
         """
         # Making 'json' the key of the outermost dict, so that search_params can be passed
         # directly to the function making the request with keyword expansion
-        json_body = {} if search_params is None else {'json': search_params}
+        json_body = {} if search_params is None else {'json': {'search_params': search_params}}
 
         path = self._get_path() + "/search"
 

--- a/src/citrine/seeding/find_or_create.py
+++ b/src/citrine/seeding/find_or_create.py
@@ -15,9 +15,11 @@ def find_collection(collection, name):
             # call list() to collapse the iterator, otherwise the NotFound
             # won't show up until collection_list is used
             collection_list = list(collection.search(search_params={
-                "name": {
-                    "value": name,
-                    "search_method": "EXACT"
+                "search_params": {
+                    "name": {
+                        "value": name,
+                        "search_method": "EXACT"
+                    }
                 }
             }))
         except NotFound:

--- a/src/citrine/seeding/find_or_create.py
+++ b/src/citrine/seeding/find_or_create.py
@@ -15,11 +15,9 @@ def find_collection(collection, name):
             # call list() to collapse the iterator, otherwise the NotFound
             # won't show up until collection_list is used
             collection_list = list(collection.search(search_params={
-                "search_params": {
-                    "name": {
-                        "value": name,
-                        "search_method": "EXACT"
-                    }
+                "name": {
+                    "value": name,
+                    "search_method": "EXACT"
                 }
             }))
         except NotFound:

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -298,21 +298,17 @@ def test_search_projects(collection, session):
 
     session.set_response({'projects': expected_response})
 
-    search_params = { 'search_params': { 
-                            'name': { 
-                                'value': project_name_to_match, 
-                                'search_method': 'EXACT' 
-                                } 
-                            } 
-                        }
-    
+    search_params = {'name': {
+        'value': project_name_to_match,
+        'search_method': 'EXACT'}}
+
     # When
     projects = list(collection.search(search_params=search_params))
 
     # Then
     assert 1 == session.num_calls
     expected_call = FakeCall(method='POST', path='/projects/search', 
-                                        params={'per_page': 100}, json=search_params)
+                                        params={'per_page': 100}, json={'search_params': search_params})
     assert expected_call == session.last_call
     assert len(expected_response) == len(projects)
 
@@ -329,13 +325,10 @@ def test_search_projects_with_pagination(paginated_collection, paginated_session
 
     paginated_session.set_response({ 'projects': same_name_projects_data })
 
-    search_params = { 'search_params': { 
-                        'status': { 
-                            'value': common_name, 
-                            'search_method': 'EXACT' 
-                            } 
-                        } 
-                    }
+    search_params = {'status': {
+        'value': common_name,
+        'search_method': 'EXACT'}}
+
 
     # When
     projects = list(paginated_collection.search(per_page=per_page, search_params=search_params))
@@ -343,10 +336,10 @@ def test_search_projects_with_pagination(paginated_collection, paginated_session
     # Then
     assert 4 == paginated_session.num_calls
     expected_first_call = FakeCall(method='POST', path='/projects/search', 
-                                        params={'per_page': per_page}, json=search_params )
+                                        params={'per_page': per_page}, json={'search_params': search_params} )
     expected_last_call = FakeCall(method='POST', path='/projects/search', 
-                                        params={'page': 4, 'per_page': per_page}, json=search_params )
-    
+                                        params={'page': 4, 'per_page': per_page}, json={'search_params': search_params})
+
     assert expected_first_call == paginated_session.calls[0]
     assert expected_last_call == paginated_session.last_call
 


### PR DESCRIPTION
# Citrine Python PR

## Description 
Updates the find_collection function to correctly use search parameters. This should help speed up tests.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
