### PR TITLE
Version requirements bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.44.1',
+      version='0.45.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',
@@ -68,7 +68,7 @@ setup(name='citrine',
           "pyjwt>=1.7.1,<2",
           "arrow>=0.15.4,<0.16",
           "strip-hints>=0.1.8,<0.2",
-          "gemd>=0.9,<0.10",
+          "gemd>=0.10,<0.11",
           "boto3>=1.9.226,<2",
           "botocore>=1.12.226,<2",
           "deprecation>=2.0.7,<3",


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR increases the required version of gemd-python from 0.9 to 0.10 to reflect the latest GEMD release.  This has downstream implications for consumers of the library but is transparent from citrine-python's perspective.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [X] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
