### PR TITLE
[PLA-4021] Forked expression predictor

### DIFF
--- a/docs/source/workflows/code_examples.rst
+++ b/docs/source/workflows/code_examples.rst
@@ -58,10 +58,10 @@ This pattern is also extremely useful for performing optimization over complex o
         expression = '(water + 0.5*starter) / (wheat + rye + 0.5*starter)',
         output = dough_hydration,
         aliases = {
-            'wheat': 'wheat flour mass',
-            'rye': 'rye flour mass',
-            'water': 'water mass',
-            'starter': 'starter mass'
+            'wheat': wheat_flour_quantity,
+            'rye': rye_flour_quantity,
+            'water': water_quantity,
+            'starter': starter_quantity
         }
     )
 
@@ -87,12 +87,12 @@ This pattern is also extremely useful for performing optimization over complex o
         expression = '4*exp(-0.1*pH - 1.3*w^2 + 5*(water+0.5*starter)/(wheat+rye+water+starter))',
         output = shelf_life,
         aliases = {
-            'pH': 'final pH',
-            'w': 'final loaf hydration',
-            'wheat': 'wheat flour mass',
-            'rye': 'rye flour mass',
-            'water': 'water mass',
-            'starter': 'starter mass'
+            'pH': final_ph,
+            'w': final_loaf_hydration,
+            'wheat': wheat_flour_quantity,
+            'rye': rye_flour_quantity,
+            'water': water_quantity,
+            'starter': starter_quantity
         }
     )
 

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -96,13 +96,14 @@ Expression predictor
 --------------------
 
 The :class:`~citrine.informatics.predictors.ExpressionPredictor` defines an analytic (lossless) model that computes one real-valued output descriptor from one or more input descriptors.
-An ExpressionPredictor should be used when the relationship between inputs and outputs is known.
+An ``ExpressionPredictor`` should be used when the relationship between inputs and outputs is known.
 
 A string is used to define the expression, and the corresponding output is defined by a :class:`~citrine.informatics.descriptors.RealDescriptor`.
-The ``aliases`` parameter defines a mapping from expression arguments to descriptor keys.
-Expression arguments with spaces are not supported, so an alias must be created for each input that has a space in its name.
-Aliases are not required for inputs that do not contain spaces, but may be useful to avoid typing out the verbose descriptors in the expression string.
-If an alias isn't defined, the expression argument is expected to match the descriptor key exactly.
+An alias is required for each expression argument.
+The ``aliases`` parameter defines a mapping from expression arguments to their associated input descriptors.
+The expression argument does not need to match its descriptor key.
+This is useful to avoid typing out the verbose descriptor keys in the expression string.
+Note, spaces are not supported in expression arguments, e.g. ``Y`` is a valid argument while ``Young's modulus`` is not.
 
 The syntax is described in the `mXparser documentation <http://mathparser.org/mxparser-math-collection>`_.
 Citrine-python currently supports the following operators and functions:
@@ -123,6 +124,8 @@ The following example demonstrates how to create an :class:`~citrine.informatics
 
    from citrine.informatics.predictors import ExpressionPredictor
 
+   youngs_modulus = RealDescriptor('Property~Young\'s modulus', lower_bound=0, upper_bound=100, units='GPa')
+   poissons_ratio = RealDescriptor('Property~Poisson\'s ratio', lower_bound=-1, upper_bound=0.5, units='')
    shear_modulus = RealDescriptor('Property~Shear modulus', lower_bound=0, upper_bound=100, units='GPa')
 
    shear_modulus_predictor = ExpressionPredictor(
@@ -131,8 +134,8 @@ The following example demonstrates how to create an :class:`~citrine.informatics
        expression = 'Y / (2 * (1 + v))',
        output = shear_modulus,
        aliases = {
-           'Y': "Property~Young's modulus",
-           'v': "Property~Poisson's ratio"
+           'Y': youngs_modulus,
+           'v': poissons_ratio
        }
    )
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.48.0',
+      version='0.49.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -2,7 +2,6 @@
 # flake8: noqa
 from typing import List, Optional, Type, Union, Mapping
 from uuid import UUID
-import warnings
 
 from citrine._serialization import properties as _properties
 from citrine._serialization.serializable import Serializable
@@ -338,10 +337,6 @@ class DeprecatedExpressionPredictor(Serializable['DeprecatedExpressionPredictor'
                  session: Optional[Session] = None,
                  report: Optional[Report] = None,
                  active: bool = True):
-        warnings.warn(
-            f"{self.__class__.__name__} is deprecated. Please use {ExpressionPredictor.__name__} instead.",
-            DeprecationWarning
-        )
         self.name: str = name
         self.description: str = description
         self.expression: str = expression

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -2,6 +2,7 @@
 # flake8: noqa
 from typing import List, Optional, Type, Union, Mapping
 from uuid import UUID
+from warnings import warn
 
 from citrine._serialization import properties as _properties
 from citrine._serialization.serializable import Serializable
@@ -337,6 +338,8 @@ class DeprecatedExpressionPredictor(Serializable['DeprecatedExpressionPredictor'
                  session: Optional[Session] = None,
                  report: Optional[Report] = None,
                  active: bool = True):
+        warn("{this_class} is deprecated. Please use {replacement} instead"
+             .format(this_class=self.__class__.name, replacement=ExpressionPredictor.__name__))
         self.name: str = name
         self.description: str = description
         self.expression: str = expression

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -1,7 +1,8 @@
 """Tools for working with Predictors."""
 # flake8: noqa
-from typing import Dict, List, Optional, Type, Union
+from typing import List, Optional, Type, Union, Mapping
 from uuid import UUID
+import warnings
 
 from citrine._serialization import properties as _properties
 from citrine._serialization.serializable import Serializable
@@ -9,11 +10,12 @@ from citrine._session import Session
 from citrine.informatics.data_sources import DataSource
 from citrine.informatics.descriptors import Descriptor, FormulationDescriptor, RealDescriptor, \
     MolecularStructureDescriptor
+from citrine.informatics.modules import Module
 from citrine.informatics.reports import Report
 from citrine.resources.report import ReportResource
-from citrine.informatics.modules import Module
 
-__all__ = ['ExpressionPredictor',
+__all__ = ['DeprecatedExpressionPredictor',
+           'ExpressionPredictor',
            'GraphPredictor',
            'IngredientsToSimpleMixturePredictor',
            'Predictor',
@@ -45,7 +47,8 @@ class Predictor(Module):
         type_dict = {
             "Simple": SimpleMLPredictor,
             "Graph": GraphPredictor,
-            "Expression": ExpressionPredictor,
+            "Expression": DeprecatedExpressionPredictor,
+            "AnalyticExpression": ExpressionPredictor,
             "MoleculeFeaturizer": MolecularStructureFeaturizer,
             "IngredientsToSimpleMixture": IngredientsToSimpleMixturePredictor,
             "GeneralizedMeanProperty": GeneralizedMeanPropertyPredictor,
@@ -226,8 +229,63 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
         return '<GraphPredictor {!r}>'.format(self.name)
 
 
-class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
-    """[ALPHA] A predictor interface that allows calculator expressions.
+class DeprecatedExpressionPredictor(Serializable['DeprecatedExpressionPredictor'], Predictor):
+    """[DEPRECATED] A predictor that computes an output from an analytic expression.
+
+    This predictor is deprecated. Please use the :class:`~citrine.informatics.predictors.ExpressionPredictor` instead.
+    To migrate to the new predictor:
+
+    1. add an alias for all unknown expression arguments and
+    2. replace descriptor keys in ``aliases`` with the associated descriptor
+
+    These changes allow the expression to respect descriptor bounds when computing the output and avoid potential
+    descriptor mismatches if a descriptor with an identical key and different bounds is present in the graph.
+
+    The following example shows how to migrate a deprecated expression predictor to the new format.
+    In the deprecated format, an expression that computes shear modulus from Young's modulus and Poisson's ratio is given by:
+
+    .. code-block:: python
+
+       from citrine.informatics.predictors import DeprecatedExpressionPredictor
+
+       shear_modulus = RealDescriptor('Property~Shear modulus', lower_bound=0, upper_bound=100, units='GPa')
+
+       shear_modulus_predictor = DeprecatedExpressionPredictor(
+           name = 'Shear modulus predictor',
+           description = "Computes shear modulus from Young's modulus and Poisson's ratio.",
+           expression = 'Y / (2 * (1 + v))',
+           output = shear_modulus,
+           aliases = {
+               'Y': "Young's modulus",
+               'v': "Poisson's ratio"
+           }
+       )
+
+    To create a predictor using the format, we need to create descriptors for the expression inputs: Young's modulus and Poisson's ratio.
+    We also need to replace references to the descriptor keys in ``aliases`` with the new descriptors:
+
+    .. code-block:: python
+
+       from citrine.informatics.predictors import ExpressionPredictor
+
+       # create a descriptor for each input in addition to the output
+       youngs_modulus = RealDescriptor('Property~Young\'s modulus', lower_bound=0, upper_bound=100, units='GPa')
+       poissons_ratio = RealDescriptor('Property~Poisson\'s ratio', lower_bound=-1, upper_bound=0.5, units='')
+       shear_modulus = RealDescriptor('Property~Shear modulus', lower_bound=0, upper_bound=100, units='GPa')
+
+       shear_modulus_predictor = ExpressionPredictor(
+           name = 'Shear modulus predictor',
+           description = "Computes shear modulus from Young's modulus and Poisson's ratio.",
+           expression = 'Y / (2 * (1 + v))',
+           output = shear_modulus,
+           # note, arguments map to descriptors not descriptor keys
+           aliases = {
+               'Y': youngs_modulus,
+               'v': poissons_ratio
+           }
+       )
+
+    .. seealso:: :class:`~citrine.informatics.predictors.ExpressionPredictor`
 
     Parameters
     ----------
@@ -236,11 +294,12 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
     description: str
         the description of the predictor
     expression: str
-        the expression that uses the aliased values
-    output: Descriptor
-        the Descriptor that represents the output relation
-    aliases: dict
-        a mapping from expression argument to descriptor key
+        expression that computes an output from a set of inputs
+    output: RealDescriptor
+        descriptor that represents the output of the expression
+    aliases: Optional[Mapping[str, str]]
+        a mapping from each each argument as it appears in the ``expression`` to its descriptor key.
+        If an unknown argument is not aliased, the argument and descriptor key are assumed to be identical.
 
     """
 
@@ -248,8 +307,8 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
     name = _properties.String('config.name')
     description = _properties.String('config.description')
     expression = _properties.String('config.expression')
-    output = _properties.Object(Descriptor, 'config.output')
-    aliases = _properties.Mapping(_properties.String, _properties.String, 'config.aliases')
+    output = _properties.Object(RealDescriptor, 'config.output')
+    aliases = _properties.Optional(_properties.Mapping(_properties.String, _properties.String), 'config.aliases')
     typ = _properties.String('config.type', default='Expression', deserializable=False)
     status = _properties.Optional(_properties.String(), 'status', serializable=False)
     status_info = _properties.Optional(
@@ -274,8 +333,88 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
                  name: str,
                  description: str,
                  expression: str,
-                 output: Descriptor,
-                 aliases: dict,
+                 output: RealDescriptor,
+                 aliases: Optional[Mapping[str, str]] = None,
+                 session: Optional[Session] = None,
+                 report: Optional[Report] = None,
+                 active: bool = True):
+        warnings.warn(
+            f"{self.__class__.__name__} is deprecated. Please use {ExpressionPredictor.__name__} instead.",
+            DeprecationWarning
+        )
+        self.name: str = name
+        self.description: str = description
+        self.expression: str = expression
+        self.output: RealDescriptor = output
+        self.aliases: Optional[Mapping[str, str]] = aliases
+        self.session: Optional[Session] = session
+        self.report: Optional[Report] = report
+        self.active: bool = active
+
+    def _post_dump(self, data: dict) -> dict:
+        data['display_name'] = data['config']['name']
+        return data
+
+    def __str__(self):
+        return '<DeprecatedExpressionPredictor {!r}>'.format(self.name)
+
+
+class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
+    """[ALPHA] A predictor that computes an output from an expression and set of bounded inputs.
+
+    .. seealso::
+       If you are using the deprecated predictor please see
+       :class:`~citrine.informatics.predictors.DeprecatedExpressionPredictor` for an example that shows how to migrate
+       to the new format.
+
+    Parameters
+    ----------
+    name: str
+        name of the configuration
+    description: str
+        the description of the predictor
+    expression: str
+        expression that computes an output from aliased inputs
+    output: RealDescriptor
+        descriptor that represents the output relation
+    aliases: Mapping[str, RealDescriptor]
+        a mapping from each unknown argument to its descriptor.
+        All unknown arguments must have an associated descriptor.
+
+    """
+
+    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
+    name = _properties.String('config.name')
+    description = _properties.String('config.description')
+    expression = _properties.String('config.expression')
+    output = _properties.Object(RealDescriptor, 'config.output')
+    aliases = _properties.Mapping(_properties.String, _properties.Object(RealDescriptor), 'config.aliases')
+    typ = _properties.String('config.type', default='AnalyticExpression', deserializable=False)
+    status = _properties.Optional(_properties.String(), 'status', serializable=False)
+    status_info = _properties.Optional(
+        _properties.List(_properties.String()),
+        'status_info',
+        serializable=False
+    )
+    experimental = _properties.Boolean("experimental", serializable=False, default=True)
+    experimental_reasons = _properties.Optional(
+        _properties.List(_properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
+
+    active = _properties.Boolean('active', default=True)
+
+    # NOTE: These could go here or in _post_dump - it's unclear which is better right now
+    module_type = _properties.String('module_type', default='PREDICTOR')
+    schema_id = _properties.UUID('schema_id', default=UUID('f1601161-bb98-4fa9-bdd2-a2a673547532'))
+
+    def __init__(self,
+                 name: str,
+                 description: str,
+                 expression: str,
+                 output: RealDescriptor,
+                 aliases: Mapping[str, RealDescriptor],
                  session: Optional[Session] = None,
                  report: Optional[Report] = None,
                  active: bool = True):
@@ -283,7 +422,7 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
         self.description: str = description
         self.expression: str = expression
         self.output: Descriptor = output
-        self.aliases: dict = aliases
+        self.aliases: Mapping[str, RealDescriptor] = aliases
         self.session: Optional[Session] = session
         self.report: Optional[Report] = report
         self.active: bool = active
@@ -422,10 +561,10 @@ class IngredientsToSimpleMixturePredictor(
         description of the predictor
     output: FormulationDescriptor
         descriptor that represents the output formulation
-    id_to_quantity: Dict[str, RealDescriptor]
+    id_to_quantity: Mapping[str, RealDescriptor]
         Map from ingredient identifier to the descriptor that represents its quantity,
         e.g. ``{'water': RealDescriptor('water quantity', 0, 1)}``
-    labels: Dict[str, List[str]]
+    labels: Mapping[str, List[str]]
         Map from each label to all ingredients assigned that label, when present in a mixture,
         e.g. ``{'solvent': ['water']}``
 
@@ -463,16 +602,16 @@ class IngredientsToSimpleMixturePredictor(
                  name: str,
                  description: str,
                  output: FormulationDescriptor,
-                 id_to_quantity: Dict[str, RealDescriptor],
-                 labels: Dict[str, List[str]],
+                 id_to_quantity: Mapping[str, RealDescriptor],
+                 labels: Mapping[str, List[str]],
                  session: Optional[Session] = None,
                  report: Optional[Report] = None,
                  active: bool = True):
         self.name: str = name
         self.description: str = description
         self.output: FormulationDescriptor = output
-        self.id_to_quantity: Dict[str, RealDescriptor] = id_to_quantity
-        self.labels: Dict[str, List[str]] = labels
+        self.id_to_quantity: Mapping[str, RealDescriptor] = id_to_quantity
+        self.labels: Mapping[str, List[str]] = labels
         self.session: Optional[Session] = session
         self.report: Optional[Report] = report
         self.active: bool = active
@@ -512,7 +651,7 @@ class GeneralizedMeanPropertyPredictor(
         Source of the training data, which can be either a CSV or an Ara table
     label: Optional[str]
         Optional label
-    default_properties: Optional[Dict[str, float]]
+    default_properties: Optional[Mapping[str, float]]
         Default values to use for imputed properties.
         Defaults are specified as a map from descriptor key to its default value.
         If not specified and ``impute_properties == True`` the average over the entire dataset
@@ -561,7 +700,7 @@ class GeneralizedMeanPropertyPredictor(
                  p: float,
                  training_data: DataSource,
                  impute_properties: bool,
-                 default_properties: Optional[Dict[str, float]] = None,
+                 default_properties: Optional[Mapping[str, float]] = None,
                  label: Optional[str] = None,
                  session: Optional[Session] = None,
                  report: Optional[Report] = None,
@@ -573,7 +712,7 @@ class GeneralizedMeanPropertyPredictor(
         self.p: float = p
         self.training_data = training_data
         self.impute_properties: bool = impute_properties
-        self.default_properties: Optional[Dict[str, float]] = default_properties
+        self.default_properties: Optional[Mapping[str, float]] = default_properties
         self.label: Optional[str] = label
         self.session: Optional[Session] = session
         self.report: Optional[Report] = report

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,7 +156,7 @@ def valid_graph_predictor_data():
 
 
 @pytest.fixture
-def valid_expression_predictor_data():
+def valid_deprecated_expression_predictor_data():
     """Produce valid data used for tests."""
     from citrine.informatics.descriptors import RealDescriptor
     shear_modulus = RealDescriptor('Property~Shear modulus', lower_bound=0, upper_bound=100, units='GPa')
@@ -166,7 +166,7 @@ def valid_expression_predictor_data():
         status_info=[],
         active=True,
         display_name='Expression predictor',
-        schema_id='e7d79c73-8bf3-4609-887a-7f31b9cef566',
+        schema_id='866e72a6-0a01-4c5f-8c35-146eb2540166',
         id=str(uuid.uuid4()),
         config=dict(
             type='Expression',
@@ -175,8 +175,37 @@ def valid_expression_predictor_data():
             expression='Y / (2 * (1 + v))',
             output=shear_modulus.dump(),
             aliases={
-                "Property~Young's modulus": 'Y',
-                "Property~Poisson's ratio": 'v',
+                'Y': "Property~Young's modulus",
+                'v': "Property~Poisson's ratio",
+            }
+        )
+    )
+
+
+@pytest.fixture
+def valid_expression_predictor_data():
+    """Produce valid data used for tests."""
+    from citrine.informatics.descriptors import RealDescriptor
+    shear_modulus = RealDescriptor('Property~Shear modulus', lower_bound=0, upper_bound=100, units='GPa')
+    youngs_modulus = RealDescriptor('Property~Young\'s modulus', lower_bound=0, upper_bound=100, units='GPa')
+    poissons_ratio = RealDescriptor('Property~Poisson\'s ratio', lower_bound=-1, upper_bound=0.5, units='')
+    return dict(
+        module_type='PREDICTOR',
+        status='VALID',
+        status_info=[],
+        active=True,
+        display_name='Expression predictor',
+        schema_id='f1601161-bb98-4fa9-bdd2-a2a673547532',
+        id=str(uuid.uuid4()),
+        config=dict(
+            type='AnalyticExpression',
+            name='Expression predictor',
+            description='Computes shear modulus from Youngs modulus and Poissons ratio',
+            expression='Y / (2 * (1 + v))',
+            output=shear_modulus.dump(),
+            aliases={
+                'Y': youngs_modulus.dump(),
+                'v': poissons_ratio.dump(),
             }
         )
     )

--- a/tests/informatics/test_predictors.py
+++ b/tests/informatics/test_predictors.py
@@ -7,12 +7,14 @@ from citrine.informatics.data_sources import AraTableDataSource
 from citrine.informatics.descriptors import RealDescriptor, MolecularStructureDescriptor, FormulationDescriptor
 from citrine.informatics.predictors import ExpressionPredictor, GraphPredictor, SimpleMLPredictor, \
     MolecularStructureFeaturizer, GeneralizedMeanPropertyPredictor, IngredientsToSimpleMixturePredictor, \
-    SimpleMixturePredictor, LabelFractionsPredictor, IngredientFractionsPredictor
+    SimpleMixturePredictor, LabelFractionsPredictor, IngredientFractionsPredictor, DeprecatedExpressionPredictor
 
 x = RealDescriptor("x", 0, 100, "")
 y = RealDescriptor("y", 0, 100, "")
 z = RealDescriptor("z", 0, 100, "")
 shear_modulus = RealDescriptor('Property~Shear modulus', lower_bound=0, upper_bound=100, units='GPa')
+youngs_modulus = RealDescriptor('Property~Young\'s modulus', lower_bound=0, upper_bound=100, units='GPa')
+poissons_ratio = RealDescriptor('Property~Poisson\'s ratio', lower_bound=-1, upper_bound=0.5, units='')
 formulation = FormulationDescriptor('formulation')
 formulation_output = FormulationDescriptor('output formulation')
 water_quantity = RealDescriptor('water quantity', 0, 1)
@@ -49,6 +51,20 @@ def graph_predictor() -> GraphPredictor:
 
 
 @pytest.fixture
+def deprecated_expression_predictor() -> DeprecatedExpressionPredictor:
+    """Build a DeprecatedExpressionPredictor for testing."""
+    return DeprecatedExpressionPredictor(
+        name='Expression predictor',
+        description='Computes shear modulus from Youngs modulus and Poissons ratio',
+        expression='Y / (2 * (1 + v))',
+        output=shear_modulus,
+        aliases={
+            'Y': "Property~Young's modulus",
+            'v': "Property~Poisson's ratio"
+        })
+
+
+@pytest.fixture
 def expression_predictor() -> ExpressionPredictor:
     """Build an ExpressionPredictor for testing."""
     return ExpressionPredictor(
@@ -57,8 +73,8 @@ def expression_predictor() -> ExpressionPredictor:
         expression='Y / (2 * (1 + v))',
         output=shear_modulus,
         aliases={
-            'Y': "Property~Young's modulus",
-            'v': "Property~Poisson's ratio"
+            'Y': youngs_modulus,
+            'v': poissons_ratio
         })
 
 
@@ -177,12 +193,33 @@ def test_graph_post_build(graph_predictor):
     assert graph_predictor.report.status == 'OK'
 
 
+def test_deprecated_expression_initialization(deprecated_expression_predictor):
+    """Make sure the correct fields go to the correct places for a deprecated expression predictor."""
+    assert deprecated_expression_predictor.name == 'Expression predictor'
+    assert deprecated_expression_predictor.output.key == 'Property~Shear modulus'
+    assert deprecated_expression_predictor.expression == 'Y / (2 * (1 + v))'
+    assert deprecated_expression_predictor.aliases == {'Y': "Property~Young's modulus", 'v': "Property~Poisson's ratio"}
+    assert str(deprecated_expression_predictor) == '<DeprecatedExpressionPredictor \'Expression predictor\'>'
+
+
+def test_deprecated_expression_post_build(deprecated_expression_predictor):
+    """Ensures we get a report from a deprecated expression predictor post_build call."""
+    assert deprecated_expression_predictor.report is None
+    session = mock.Mock()
+    session.get_resource.return_value = dict(status='OK', report=dict(descriptors=[], models=[]), uid=str(uuid.uuid4()))
+    deprecated_expression_predictor.session = session
+    deprecated_expression_predictor.post_build(uuid.uuid4(), dict(id=uuid.uuid4()))
+    assert session.get_resource.call_count == 1
+    assert deprecated_expression_predictor.report is not None
+    assert deprecated_expression_predictor.report.status == 'OK'
+
+
 def test_expression_initialization(expression_predictor):
     """Make sure the correct fields go to the correct places for an expression predictor."""
     assert expression_predictor.name == 'Expression predictor'
     assert expression_predictor.output.key == 'Property~Shear modulus'
     assert expression_predictor.expression == 'Y / (2 * (1 + v))'
-    assert expression_predictor.aliases == {'Y': "Property~Young's modulus", 'v': "Property~Poisson's ratio"}
+    assert expression_predictor.aliases == {'Y': youngs_modulus, 'v': poissons_ratio}
     assert str(expression_predictor) == '<ExpressionPredictor \'Expression predictor\'>'
 
 

--- a/tests/serialization/test_predictors.py
+++ b/tests/serialization/test_predictors.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 from citrine.informatics.predictors import ExpressionPredictor, GeneralizedMeanPropertyPredictor, \
     GraphPredictor, Predictor, SimpleMLPredictor, IngredientsToSimpleMixturePredictor, \
-    LabelFractionsPredictor, SimpleMixturePredictor, IngredientFractionsPredictor
+    LabelFractionsPredictor, SimpleMixturePredictor, IngredientFractionsPredictor, DeprecatedExpressionPredictor
 from citrine.informatics.descriptors import RealDescriptor
 
 
@@ -58,6 +58,14 @@ def test_graph_serialization(valid_graph_predictor_data):
     serialized['id'] = graph_data_copy['id']
     assert serialized['config']['predictors'] == graph_data_copy['config']['predictors']
     assert serialized == valid_serialization_output(graph_data_copy)
+
+
+def test_deprecated_expression_serialization(valid_deprecated_expression_predictor_data):
+    """Ensure that a serialized DeprecatedExpressionPredictor looks sane."""
+    predictor = DeprecatedExpressionPredictor.build(valid_deprecated_expression_predictor_data)
+    serialized = predictor.dump()
+    serialized['id'] = valid_deprecated_expression_predictor_data['id']
+    assert serialized == valid_serialization_output(valid_deprecated_expression_predictor_data)
 
 
 def test_expression_serialization(valid_expression_predictor_data):


### PR DESCRIPTION
This PR renames the current `ExpressionPredictor` to `DeprecatedExpressionPredictor` and defines a new `ExpressionPredictor` with an updated API. The new expression predictor requires aliases for all unknown expression arguments, and keys in `aliases` map to descriptors instead of descriptor keys.

I updated all docs that referenced the previous expression predictor and included details on how to migrate from the deprecated predictor the deprecated class's docstring.

### PR Type:
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
