### PR TITLE
Add finer control for table build and deprecate old methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.50.0',
+      version='0.51.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/ara_definition.py
+++ b/src/citrine/resources/ara_definition.py
@@ -3,6 +3,7 @@ from logging import getLogger
 from typing import List, Union, Optional, Tuple
 from uuid import UUID
 
+from deprecation import deprecated
 from gemd.entity.object import MaterialRun
 
 from citrine.resources.ara_job import JobSubmissionResponse, JobStatusResponse
@@ -304,6 +305,8 @@ class AraDefinitionCollection(Collection[AraDefinition]):
         ambiguous = [(Variable.build(v), Column.build(c)) for v, c in data['ambiguous']]
         return config, ambiguous
 
+    @deprecated(details='Please use TableCollection.build_from config or '
+                        'TableCollection.initiate_build')
     def build_ara_table(self, ara_def: AraDefinition) -> JobSubmissionResponse:
         """[ALPHA] submit an ara table construction job.
 
@@ -312,16 +315,16 @@ class AraDefinitionCollection(Collection[AraDefinition]):
 
         Parameters
         ----------
-        project: Project
-            The project on behalf of which the job executes.
         ara_def: AraDefinition
             the ara definition describing the new table
 
         """
         from citrine.resources.table import TableCollection
         table_collection = TableCollection(self.project_id, self.session)
-        return table_collection._initiate_build_from_config(ara_def, None)
+        return table_collection.initiate_build(ara_def, None)
 
+    @deprecated(details='Table build job status does not have a stable format. Please use '
+                        'TableCollection.build_from_config or TableCollection.get_by_build_job')
     def get_job_status(self, job_id: str):
         """[ALPHA] get status of a running job.
 
@@ -329,8 +332,6 @@ class AraDefinitionCollection(Collection[AraDefinition]):
 
         Parameters
         ----------
-        project: Project
-            The project on behalf of which we retrieve a job status
         job_id: str
             The job we retrieve the status for
 

--- a/src/citrine/resources/table.py
+++ b/src/citrine/resources/table.py
@@ -153,7 +153,7 @@ class TableCollection(Collection[Table]):
         return self._paginator.paginate(fetch_versions, build_versions, page, per_page)
 
     def initiate_build(self, config: Union[AraDefinition, str, UUID],
-                       version: Optional[Union[str, UUID]]) -> JobSubmissionResponse:
+                       version: Union[str, UUID] = None) -> JobSubmissionResponse:
         """
         [ALPHA] Initiates tables build with provided config.
 


### PR DESCRIPTION
# Citrine Python PR

## Description 
Exposes finer-grain control of table build in new methods and deprecates old build methods.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
