### PR TITLE
expression predictors docs

### DIFF
--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -118,6 +118,8 @@ Citrine-python currently supports the following operators and functions:
 
 - constants: `pi`, `e`
 
+ExpressionPredictors do not support complex numbers.
+
 The following example demonstrates how to create an :class:`~citrine.informatics.predictors.ExpressionPredictor`.
 
 .. code:: python

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.51.0',
+      version='0.51.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.51.1',
+      version='0.51.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',


### PR DESCRIPTION
Added that expression predictors do not support complex numbers

# Citrine Python PR

## Description 
Please briefly explain the goal of the changes/this PR.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
