### PR TITLE
Add gemdjson dump to fix incorrect link serialization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.52.0',
+      version='0.52.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/data_objects.py
+++ b/src/citrine/resources/data_objects.py
@@ -2,10 +2,12 @@
 from abc import ABC
 from typing import Dict, Union, Optional, Iterator, List, TypeVar
 
+from gemd.json import GEMDJson
+
 from citrine._utils.functions import get_object_id, replace_objects_with_links, scrub_none
 from citrine.exceptions import BadRequest
 from citrine.resources.api_error import ValidationError
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
+from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection, CITRINE_SCOPE
 from citrine.resources.object_templates import ObjectTemplateResourceType
 from citrine.resources.process_template import ProcessTemplate
 from gemd.entity.bounds.base_bounds import BaseBounds
@@ -161,6 +163,7 @@ class DataObjectCollection(DataConceptsCollection[DataObjectResourceType], ABC):
         :return: List[ValidationError] of validation errors encountered. Empty if successful.
         """
         path = self._get_path(ignore_dataset=True) + "/validate-templates"
+        GEMDJson(scope=CITRINE_SCOPE).dumps(model)  # This apparent no-op populates uids
         dumped_data = replace_objects_with_links(scrub_none(model.dump()))
         request_data = {"dataObject": dumped_data}
         if object_template is not None:


### PR DESCRIPTION
# Citrine Python PR

## Description 
Serialize object with gemd json before sending off for validation so links are serialized correctly.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
