### PR TITLE
Raise a helpful error message when trying to get a resource with uid=None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.52.1',
+      version='0.52.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -40,6 +40,8 @@ class Collection(Generic[ResourceType]):
 
     def get(self, uid: Union[UUID, str]) -> ResourceType:
         """Get a particular element of the collection."""
+        if uid is None:
+            raise ValueError("Cannot get when uid=None.  Are you using a registered resource?")
         path = self._get_path(uid)
         data = self.session.get_resource(path)
         data = data[self._individual_key] if self._individual_key else data

--- a/tests/resources/test_predictor.py
+++ b/tests/resources/test_predictor.py
@@ -129,3 +129,15 @@ def test_list_predictors(valid_simple_ml_predictor_data, valid_expression_predic
     assert 3 == session.num_calls, session.calls  # This is a little strange, the report is fetched eagerly
     assert expected_call == session.calls[0]
     assert len(predictors) == 2
+
+
+def test_get_none():
+    """Test that trying to get a predictor with uid=None results in an informative error."""
+    session = mock.Mock()
+    session.get_resource.return_value = basic_predictor_report_data
+    pc = PredictorCollection(uuid.uuid4(), session)
+
+    with pytest.raises(ValueError) as excinfo:
+        pc.get(uid=None)
+
+    assert "uid=None" in str(excinfo.value)


### PR DESCRIPTION
# Citrine Python PR

## Description 
Raise a helpful error message when trying to get a resource with uid=None

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
