### PR TITLE
Feature/ingredient identifier in output scope

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.53.1',
+      version='0.54.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -581,22 +581,26 @@ class IngredientIdentifierInOutput(Serializable['IngredientIdentifierInOutput'],
     headers = properties.List(properties.String, 'headers')
     ingredient_name = properties.String('ingredient_name')
     process_templates = properties.List(properties.Object(LinkByUID), 'process_templates')
+    scope = properties.String('scope')
     type_selector = properties.Enumeration(DataObjectTypeSelector, "type_selector")
     typ = properties.String('type', default="ing_id_in_output", deserializable=False)
 
     def _attrs(self) -> List[str]:
-        return ["name", "headers", "ingredient_name", "process_templates", "type_selector", "typ"]
+        return ["name", "headers", "ingredient_name", "process_templates", "scope",
+                "type_selector", "typ"]
 
     def __init__(self, *,
                  name: str,
                  headers: List[str],
                  ingredient_name: str,
                  process_templates: List[LinkByUID],
+                 scope: str,
                  type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
         self.name = name
         self.headers = headers
         self.ingredient_name = ingredient_name
         self.process_templates = process_templates
+        self.scope = scope
         self.type_selector = type_selector
 
 

--- a/src/citrine/ara/variables.py
+++ b/src/citrine/ara/variables.py
@@ -594,7 +594,7 @@ class IngredientIdentifierInOutput(Serializable['IngredientIdentifierInOutput'],
                  headers: List[str],
                  ingredient_name: str,
                  process_templates: List[LinkByUID],
-                 scope: str,
+                 scope: str = 'id',
                  type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
         self.name = name
         self.headers = headers

--- a/tests/ara/test_variables.py
+++ b/tests/ara/test_variables.py
@@ -14,7 +14,7 @@ from gemd.entity.link_by_uid import LinkByUID
     AttributeByTemplateAndObjectTemplate(name="density", headers=["density"], attribute_template=LinkByUID(scope="template", id="density"), object_template=LinkByUID(scope="template", id="object")),
     AttributeInOutput(name="density", headers=["density"], attribute_template=LinkByUID(scope="template", id="density"), process_templates=[LinkByUID(scope="template", id="object")]),
     IngredientIdentifierByProcessTemplateAndName(name="ingredient id", headers=["density"], process_template=LinkByUID(scope="template", id="process"), ingredient_name="ingredient", scope="scope"),
-    IngredientIdentifierInOutput(name="ingredient id", headers=["ingredient id"], ingredient_name="ingredient", process_templates=[LinkByUID(scope="template", id="object")]),
+    IngredientIdentifierInOutput(name="ingredient id", headers=["ingredient id"], ingredient_name="ingredient", process_templates=[LinkByUID(scope="template", id="object")], scope="scope"),
     IngredientLabelByProcessAndName(name="ingredient label", headers=["label"], process_template=LinkByUID(scope="template", id="process"), ingredient_name="ingredient", label="label"),
     IngredientQuantityByProcessAndName(name="ingredient quantity dimension", headers=["quantity"], process_template=LinkByUID(scope="template", id="process"), ingredient_name="ingredient", quantity_dimension=IngredientQuantityDimension.ABSOLUTE),
     IngredientQuantityInOutput(name="ingredient quantity", headers=["ingredient quantity"], ingredient_name="ingredient", quantity_dimension=IngredientQuantityDimension.MASS, process_templates=[LinkByUID(scope="template", id="object")]),


### PR DESCRIPTION
# Citrine Python PR

## Description 
`scope` is missing from `IngredientIdentifierInOutput`, but it can be handled by the backend. This PR adds that in.

cc'ing: @sdedkins for tracking visibility

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
