### PR TITLE
PLA-5251: explicitly return 'TABLE' as the resource type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.54.1',
+      version='0.54.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/gemtables.py
+++ b/src/citrine/resources/gemtables.py
@@ -54,6 +54,10 @@ class GemTable(Resource['Table']):
     def __str__(self):
         return '<GEM Table {!r}, version {}>'.format(self.uid, self.version)
 
+    def resource_type(self) -> str:
+        """Get the access control resource type of this resource."""
+        return 'TABLE'
+
     @deprecation.deprecated(deprecated_in="0.16.0", details="Use TableCollection.read() instead")
     def read(self, local_path):
         """[DEPRECATED] Use TableCollection.read() instead."""  # noqa: D402

--- a/tests/resources/test_gem_table.py
+++ b/tests/resources/test_gem_table.py
@@ -242,3 +242,12 @@ def test_get_and_read_table_from_collection(mock_write_files_locally, table, ses
         assert mock_get.call_count == 1
         assert mock_write_files_locally.call_count == 1
         assert mock_write_files_locally.call_args == call(b'stuff', "table4.csv")
+
+def test_gem_table_entity_dict():
+    table = GemTable.build(GemTableDataFactory())
+    entity = table.as_entity_dict()
+
+    assert entity == {
+        'id': str(table.uid),
+        'type': 'TABLE'
+    }


### PR DESCRIPTION
# Citrine Python PR

As part of a recent refactoring, we changed the resource type to 'GEMTABLE' via an implicit method that just takes the class name. The Shire can no longer grant access. This change explicitly returns 'TABLE' as the resource type.
