### PR TITLE
[PLA-5163] Added formulation descriptor to gem table data source.

### DIFF
--- a/docs/source/workflows/data_sources.rst
+++ b/docs/source/workflows/data_sources.rst
@@ -145,7 +145,9 @@ GEM Table Data Source
 
 An :class:`~citrine.informatics.data_sources.GemTableDataSource` references a GEM Table.
 As explained more in the :doc:`documentation <../data_extraction>`, GEM Tables provide a structured version of on-platform data.
-GEM Tables are specified by the display table uuid and version number.
+GEM Tables are specified by the display table uuid, version number and optional formulation descriptor.
+A formulation descriptor must be specified if formulations should be built from the data source.
+If specified, any formulations emitted by the data source are stored using the provided descriptor.
 The example below assumes that the uuid and the version of the desired GEM Table are known.
 
 .. code:: python
@@ -172,6 +174,6 @@ The example below assumes that the uuid and the version of the desired GEM Table
         training_data = data_source
     )
 
-  Note that the descriptor keys above are the headers of the *variable* not the column in the table.
-  The last term in the column header is a suffix associated with the specific column definition rather than the variable.
-  It should be omitted from the descriptor key.
+Note that the descriptor keys above are the headers of the *variable* not the column in the table.
+The last term in the column header is a suffix associated with the specific column definition rather than the variable.
+It should be omitted from the descriptor key.

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -150,6 +150,10 @@ Ingredients to simple mixture predictor
 ---------------------------------------
 
 The :class:`~citrine.informatics.predictors.IngredientsToSimpleMixturePredictor` constructs a simple mixture from a list of ingredients.
+This predictor is only required to construct simple mixtures from CSV data sources.
+Formulations are constructed automatically by GEM Tables when a ``formulation_descriptor`` is specified by the data source, so
+an :class:`~citrine.informatics.predictors.IngredientsToSimpleMixturePredictor` in not required in those cases.
+
 Ingredients are specified by a map from ingredient id to the descriptor that contains the ingredient's quantity.
 For example, ``{'water': RealDescriptor('water quantity', 0, 1}`` defines an ingredient ``water`` with quantity held by the descriptor ``water quantity``.
 There must be a corresponding (id, quantity) pair in the map for all possible ingredients.
@@ -200,15 +204,27 @@ The following example illustrates how an :class:`~citrine.informatics.predictors
     from citrine.informatics.descriptors import FormulationDescriptor, RealDescriptor
     from citrine.informatics.predictors import IngredientsToSimpleMixturePredictor
 
-    # create a descriptor to hold simple mixtures
-    formulation = FormulationDescriptor('simple mixture')
+    file_link = dataset.files.upload("./saline_solutions.csv", "saline_solutions.csv")
 
     # create descriptors for each ingredient quantity
     water_quantity = RealDescriptor('water quantity', 0, 1)
     salt_quantity = RealDescriptor('salt quantity', 0, 1)
 
-    # table with simple mixtures and their ingredients
-    data_source = GemTableDataSource(table_uid, 0)
+    # create a descriptor to hold density data
+    density = RealDescriptor('density', lower_bound=0, upper_bound=1000, units='g/cc')
+
+    data_source = CSVDataSource(
+        file_link = file_link,
+        column_definitions = {
+            'water quantity': water_quantity,
+            'salt quantity': salt_quantity,
+            'density': density
+        },
+        identifiers=['Ingredient id']
+    )
+
+    # create a descriptor to hold simple mixtures
+    formulation = FormulationDescriptor('simple mixture')
 
     IngredientsToSimpleMixturePredictor(
         name='Ingredients to simple mixture predictor',
@@ -250,7 +266,7 @@ The following example illustrates how a :class:`~citrine.informatics.predictors.
     output_formulation = FormulationDescriptor('diluted saline (flattened)')
 
     # table with simple mixtures and their ingredients
-    data_source = GemTableDataSource(table_uid, 0)
+    data_source = GemTableDataSource(table_uid, 0, input_descriptor)
 
     SimpleMixturePredictor(
         name='Simple mixture predictor',
@@ -324,7 +340,7 @@ The example below show how to configure a mean property predictor to compute mea
     formulation = FormulationDescriptor('simple mixture')
 
     # table with simple mixtures and their ingredients
-    data_source = GemTableDataSource(table_uid, 0)
+    data_source = GemTableDataSource(table_uid, 0, formulation)
 
     GeneralizedMeanPropertyPredictor(
         name='Mean property predictor',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.54.3',
+      version='0.55.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.55.0',
+      version='0.56.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/informatics/data_sources.py
+++ b/src/citrine/informatics/data_sources.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from citrine._serialization.serializable import Serializable
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
 from citrine._serialization import properties
-from citrine.informatics.descriptors import Descriptor
+from citrine.informatics.descriptors import Descriptor, FormulationDescriptor
 from citrine.resources.file_link import FileLink
 
 
@@ -87,23 +87,28 @@ class GemTableDataSource(Serializable['GemTableDataSource'], DataSource):
     table_id: UUID
         Unique identifier for the GEM Table
     table_version: Union[str,int]
-        Version number for the GEM Table, which starts at 1 rather than 0.  Strings
-        are cast to ints
+        Version number for the GEM Table, which starts at 1 rather than 0.
+        Strings are cast to ints.
+    formulation_descriptor: Optional[FormulationDescriptor]
+        Optional descriptor used to store formulations emitted by the data source.
 
     """
 
     typ = properties.String('type', default='hosted_table_data_source', deserializable=False)
     table_id = properties.UUID("table_id")
     table_version = properties.Integer("table_version")
+    formulation_descriptor = properties.Optional(properties.Object(FormulationDescriptor), "formulation_descriptor")
 
     def _attrs(self) -> List[str]:
         return ["table_id", "table_version", "typ"]
 
     def __init__(self,
                  table_id: UUID,
-                 table_version: Union[int, str]):
-        self.table_id = table_id
-        self.table_version = table_version
+                 table_version: Union[int, str],
+                 formulation_descriptor: Optional[FormulationDescriptor] = None):
+        self.table_id: UUID = table_id
+        self.table_version: Union[int, str] = table_version
+        self.formulation_descriptor: Optional[FormulationDescriptor] = formulation_descriptor
 
 
 def AraTableDataSource(*args, **kwargs):  # pragma: no cover

--- a/src/citrine/informatics/data_sources.py
+++ b/src/citrine/informatics/data_sources.py
@@ -3,9 +3,9 @@ from abc import abstractmethod
 from typing import Type, List, Mapping, Optional, Union  # noqa: F401
 from uuid import UUID
 
-from citrine._serialization.serializable import Serializable
-from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
 from citrine._serialization import properties
+from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
+from citrine._serialization.serializable import Serializable
 from citrine.informatics.descriptors import Descriptor, FormulationDescriptor
 from citrine.resources.file_link import FileLink
 
@@ -97,7 +97,10 @@ class GemTableDataSource(Serializable['GemTableDataSource'], DataSource):
     typ = properties.String('type', default='hosted_table_data_source', deserializable=False)
     table_id = properties.UUID("table_id")
     table_version = properties.Integer("table_version")
-    formulation_descriptor = properties.Optional(properties.Object(FormulationDescriptor), "formulation_descriptor")
+    formulation_descriptor = properties.Optional(
+        properties.Object(FormulationDescriptor),
+        "formulation_descriptor"
+    )
 
     def _attrs(self) -> List[str]:
         return ["table_id", "table_version", "typ"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,10 +91,15 @@ def valid_enumerated_design_space_data():
 @pytest.fixture
 def valid_simple_ml_predictor_data():
     """Produce valid data used for tests."""
+    from citrine.informatics.data_sources import GemTableDataSource
     from citrine.informatics.descriptors import RealDescriptor
     x = RealDescriptor("x", 0, 100, "")
     y = RealDescriptor("y", 0, 100, "")
     z = RealDescriptor("z", 0, 100, "")
+    data_source = GemTableDataSource(
+        table_id=uuid.UUID('e5c51369-8e71-4ec6-b027-1f92bdc14762'),
+        table_version=2
+    )
     return dict(
         module_type='PREDICTOR',
         status='VALID',
@@ -110,11 +115,7 @@ def valid_simple_ml_predictor_data():
             inputs=[x.dump()],
             outputs=[z.dump()],
             latent_variables=[y.dump()],
-            training_data=dict(
-                table_id='e5c51369-8e71-4ec6-b027-1f92bdc14762',
-                table_version=2,
-                type="hosted_table_data_source"
-            )
+            training_data=data_source.dump()
         )
     )
 
@@ -309,6 +310,7 @@ def valid_generalized_mean_property_predictor_data():
     """Produce valid data used for tests."""
     from citrine.informatics.descriptors import FormulationDescriptor
     from citrine.informatics.data_sources import GemTableDataSource
+    formulation_descriptor = FormulationDescriptor('simple mixture')
     return dict(
         module_type='PREDICTOR',
         status='VALID',
@@ -321,10 +323,10 @@ def valid_generalized_mean_property_predictor_data():
             type='GeneralizedMeanProperty',
             name='Mean property predictor',
             description='Computes mean ingredient properties',
-            input=FormulationDescriptor('simple mixture').dump(),
+            input=formulation_descriptor.dump(),
             properties=['density'],
             p=2,
-            training_data=GemTableDataSource(uuid.uuid4(), 0).dump(),
+            training_data=GemTableDataSource(uuid.uuid4(), 0, formulation_descriptor).dump(),
             impute_properties=True,
             default_properties={'density': 1.0},
             label='solvent'
@@ -443,7 +445,9 @@ def valid_enumerated_processor_data():
 def valid_simple_mixture_predictor_data():
     """Produce valid data used for tests."""
     from citrine.informatics.data_sources import GemTableDataSource
-    from citrine.informatics.descriptors import RealDescriptor
+    from citrine.informatics.descriptors import FormulationDescriptor
+    input_formulation = FormulationDescriptor('input formulation')
+    output_formulation = FormulationDescriptor('output formulation')
     return dict(
         module_type='PREDICTOR',
         status='VALID',
@@ -456,14 +460,8 @@ def valid_simple_mixture_predictor_data():
             type='SimpleMixture',
             name='Simple mixture predictor',
             description='simple mixture description',
-            input=dict(
-                type='Formulation',
-                descriptor_key='input formulation',
-            ),
-            output=dict(
-                type='Formulation',
-                descriptor_key='output formulation',
-            ),
-            training_data=GemTableDataSource(uuid.uuid4(), 0).dump(),
+            input=input_formulation.dump(),
+            output=output_formulation.dump(),
+            training_data=GemTableDataSource(uuid.uuid4(), 0, input_formulation).dump(),
         ),
     )

--- a/tests/informatics/test_data_source.py
+++ b/tests/informatics/test_data_source.py
@@ -4,7 +4,7 @@ import uuid
 import pytest
 
 from citrine.informatics.data_sources import DataSource, CSVDataSource, GemTableDataSource
-from citrine.informatics.descriptors import RealDescriptor
+from citrine.informatics.descriptors import RealDescriptor, FormulationDescriptor
 from citrine.resources.file_link import FileLink
 
 
@@ -12,6 +12,7 @@ from citrine.resources.file_link import FileLink
     CSVDataSource(FileLink("foo.spam", "http://example.com"), {"spam": RealDescriptor("eggs", lower_bound=0, upper_bound=1.0)}, ["identifier"]),
     GemTableDataSource(uuid.uuid4(), 1),
     GemTableDataSource(uuid.uuid4(), "2"),
+    GemTableDataSource(uuid.uuid4(), "2", FormulationDescriptor("formulation")),
 ])
 def data_source(request):
     return request.param

--- a/tests/informatics/test_predictors.py
+++ b/tests/informatics/test_predictors.py
@@ -20,6 +20,7 @@ formulation_output = FormulationDescriptor('output formulation')
 water_quantity = RealDescriptor('water quantity', 0, 1)
 salt_quantity = RealDescriptor('salt quantity', 0, 1)
 data_source = GemTableDataSource(uuid.UUID('e5c51369-8e71-4ec6-b027-1f92bdc14762'), 0)
+formulation_data_source = GemTableDataSource(uuid.UUID('6894a181-81d2-4304-9dfa-a6c5b114d8bc'), 0, formulation)
 
 
 @pytest.fixture
@@ -105,7 +106,7 @@ def generalized_mean_property_predictor() -> GeneralizedMeanPropertyPredictor:
         input_descriptor=formulation,
         properties=['density'],
         p=2,
-        training_data=data_source,
+        training_data=formulation_data_source,
         impute_properties=True,
         default_properties={'density': 1.0},
         label='solvent'
@@ -120,7 +121,7 @@ def simple_mixture_predictor() -> SimpleMixturePredictor:
         description='Computes mean ingredient properties',
         input_descriptor=formulation,
         output_descriptor=formulation_output,
-        training_data=data_source
+        training_data=formulation_data_source
     )
 
 
@@ -301,7 +302,7 @@ def test_generalized_mean_property_initialization(generalized_mean_property_pred
     assert generalized_mean_property_predictor.properties == ['density']
     assert generalized_mean_property_predictor.p == 2
     assert generalized_mean_property_predictor.impute_properties == True
-    assert generalized_mean_property_predictor.training_data == data_source
+    assert generalized_mean_property_predictor.training_data == formulation_data_source
     assert generalized_mean_property_predictor.default_properties == {'density': 1.0}
     assert generalized_mean_property_predictor.label == 'solvent'
     expected_str = '<GeneralizedMeanPropertyPredictor \'Mean property predictor\'>'
@@ -346,7 +347,7 @@ def test_simple_mixture_predictor_initialization(simple_mixture_predictor):
     assert simple_mixture_predictor.name == 'Simple mixture predictor'
     assert simple_mixture_predictor.input_descriptor.key == 'formulation'
     assert simple_mixture_predictor.output_descriptor.key == 'output formulation'
-    assert simple_mixture_predictor.training_data == data_source
+    assert simple_mixture_predictor.training_data == formulation_data_source
     expected_str = '<SimpleMixturePredictor \'Simple mixture predictor\'>'
     assert str(simple_mixture_predictor) == expected_str
 


### PR DESCRIPTION
This PR adds an optional formulation descriptor to GEM table data sources. This descriptor should be provided when formulations should be emitted from the data source. This descriptor is used to store the formulation constructed from the table.

This PR should be merged after the corresponding backend change: [#1379](https://github.com/CitrineInformatics/platform-backend/pull/1379)

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [x] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
