### PR TITLE
Sketch PlatformVocabularies to use the data platform to store descriptors

### DIFF
--- a/docs/source/workflows/descriptors.rst
+++ b/docs/source/workflows/descriptors.rst
@@ -17,7 +17,7 @@ Real Descriptor
 -----------------------------------
 :class:`~citrine.informatics.descriptors.RealDescriptor` is used to represent continuous variables.
 Each Real Descriptor must provide a lower and upper bound, which is used to both validate input data and as a prior when making predictions.
-If you are not sure what to use bounds, you may want to look at the attribute templates to see if another user has defined bounds for you.
+If you are not sure what bounds to use, you may want to look at the attribute templates to see if another user has defined bounds for you.
 It is better to err on the side of broader bounds rather than narrower ones.
 
 Additionally, each Real Descriptor defines the units of every variable associated with that descriptor.

--- a/docs/source/workflows/descriptors.rst
+++ b/docs/source/workflows/descriptors.rst
@@ -1,0 +1,105 @@
+Descriptors
+==========
+
+Descriptors allow users to define a controlled vocabulary with which to describe the physical context of an AI task.
+Each descriptor defines a term in that vocabulary, which is comprised of a name, a datatype, and bounds on that data type.
+If you are familiar with the GEMD data model, descriptors are roughly equivalent to `AttributeTemplate`s.
+
+The AI Engine currently supports _ kinds of descriptors:
+
+-  `Real Descriptors <#real-descriptor>`__
+-  `Categorical Descriptor <#categorical-descriptor>`__
+-  `Chemical Formula Descriptor <#chemical-formula-descriptor>`__
+-  `Molecular Structure Descriptor <#molecular-structure-descriptor>`__
+-  `Formulation Descriptor <#formulation-descriptor>`__
+
+Real Descriptor
+-----------------------------------
+:class:`~citrine.informatics.descriptors.RealDescriptor` is used to represent continuous variables.
+Each Real Descriptor must provide a lower and upper bound, which is used to both validate input data and as a prior when making predictions.
+If you are not sure what to use bounds, you may want to look at the attribute templates to see if another user has defined bounds for you.
+It is better to err on the side of broader bounds rather than narrower ones.
+
+Additionally, each Real Descriptor defines the units of every variable associated with that descriptor.
+Any `GEMD-compatible <https://citrineinformatics.github.io/gemd-python/depth/unit_parsing.html>`__ unit string may be used.
+If a variable is dimensionless, you can use an empty string.
+
+Categorical Descriptor
+-----------------------------------
+:class:`~citrine.informatics.descriptors.CategoricalDescriptor` is used to represent variables that can take one of
+a set of values, i.e. categories.
+All of the possible categories must be known ahead of time and specified in the Categorical Descriptor.
+
+Chemical Formula Descriptor
+-----------------------------------
+:class:`~citrine.informatics.descriptors.ChemicalFormulaDescriptor` is used to represent variables that should be
+interpreted as chemical formulas.
+The Chemical Formula Descriptor has no parameters other than a name.
+
+Molecular Structure Descriptor
+-----------------------------------
+:class:`~citrine.informatics.descriptors.MolecularStructureDescriptor` is used to represent variables that should be
+interpreted as molecular structures.
+Both `SMILES <https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system>`__
+and `InChI <https://en.wikipedia.org/wiki/International_Chemical_Identifier>`__ are supported.
+The Molecular Structure Descriptor has no parameters other than a name.
+
+Formulation Descriptor
+-----------------------------------
+:class:`~citrine.informatics.descriptors.FormulationDescriptor` is used to represent variables that contain information
+about mixtures of other materials.
+The Formulation Descriptor has no parameters other than a name.
+
+
+Platform Vocabularies
+==================================
+
+A set of descriptors defines a controlled vocabulary with which to describe AI tasks.
+The :class:`~citrine.builders.descriptors.PlatformVocabulary` class is provided to collect a set of descriptors,
+associate them with short convenient names, and provide them via a familiar dictionary interface.
+
+While descriptors cannot be independently saved on the platform for reuse, AttributeTemplates can be.
+Therefore, common descriptors can be saved as AttributeTemplates to the data platform, effectively sharing them with
+other users.
+The `PlatformVocabulary.from_templates` method facilitates this pattern by automatically downloading AttributeTemplates
+and converting them into descriptors.
+AttributeTemplates must be associated with a namespace via Alternative Identifiers (the `uids` field).
+When calling `from_templates`, a scope is provided to select one of those namespaces.
+The descriptors can then be associated with the names from that namespace.
+
+.. code:: python
+
+   from citrine import Citrine
+   from citrine.resources.property_template import PropertyTemplate
+   from citrine.builders.descriptors import PlatformVocabulary
+
+   # create a session with citrine using your API key
+   session = Citrine(api_key = API_KEY)
+
+   # create project
+   project = session.projects.register('Example project')
+
+   # create an property template for density
+   project.property_templates.register(PropertyTemplate(
+       name="density",
+       uids={"my_templates": "rho"},
+       bounds=RealBounds(lower_bound=0, upper_bound=100, default_units="g/cm^3")
+   ))
+
+   # create a condition template for temperature
+   project.property_templates.register(PropertyTemplate(
+       name="temperature",
+       uids={"my_templates": "T"},
+       bounds=RealBounds(lower_bound=0, upper_bound=1000000, default_units="kelvin")
+   ))
+
+   # create a PlatformVocabulary from the templates
+   pv = PlatformVocabulary.from_templates(project, "my_templates")
+
+   # see the terms in the platform vocabulary
+   print(list(pv))
+   # returns ["rho", "T"]
+
+   # access a descriptor from the platform vocabulary
+   print(pv["T"])
+   # returns RealDescriptor(key="temperature", lower_bound=0, upper_bound=1000000, units="K")

--- a/docs/source/workflows/index.rst
+++ b/docs/source/workflows/index.rst
@@ -8,6 +8,7 @@
     :maxdepth: 2
 
     getting_started
+    descriptors
     predictors
     design_spaces
     processors

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.57.0',
+      version='0.58.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/builders/descriptors.py
+++ b/src/citrine/builders/descriptors.py
@@ -1,0 +1,125 @@
+from itertools import chain
+from typing import Iterator, Mapping
+
+from gemd.entity.bounds import RealBounds, CategoricalBounds, MolecularStructureBounds, \
+    IntegerBounds, CompositionBounds
+from gemd.entity.template.attribute_template import AttributeTemplate
+from gemd.entity.value import EmpiricalFormula
+
+from citrine.informatics.descriptors import RealDescriptor, CategoricalDescriptor, \
+    MolecularStructureDescriptor, Descriptor, ChemicalFormulaDescriptor
+from citrine.resources.data_concepts import DataConceptsCollection
+from citrine.resources.project import Project
+
+
+def template_to_descriptor(template: AttributeTemplate) -> Descriptor:
+    """
+    Convert a GEMD attribute template into an AI Engine Descriptor.
+
+    IntBounds cannot be converted because they have no matching descriptor type.
+    CompositionBounds cannot be converted because they may correspond to Formulations or
+    ChemicalFormulas.
+
+    Parameters
+    ----------
+    template: AttributeTemplate
+        Template to convert into a descriptor
+
+    Returns
+    -------
+    Descriptor
+        Descriptor with a key matching the template name and type corresponding to the bounds
+
+    """
+    bounds = template.bounds
+    if isinstance(bounds, RealBounds):
+        return RealDescriptor(
+            key=template.name,
+            lower_bound=bounds.lower_bound,
+            upper_bound=bounds.upper_bound,
+            units=bounds.default_units
+        )
+    if isinstance(bounds, CategoricalBounds):
+        return CategoricalDescriptor(
+            key=template.name,
+            categories=bounds.categories
+        )
+    if isinstance(bounds, MolecularStructureBounds):
+        return MolecularStructureDescriptor(
+            key=template.name
+        )
+    if isinstance(bounds, CompositionBounds):
+        if set(bounds.components).issubset(EmpiricalFormula.all_elements()):
+            return ChemicalFormulaDescriptor(
+                key=template.name
+            )
+        else:
+            msg = "Cannot create descriptor for CompositionBounds with non-atomic components"
+            raise ValueError(msg)
+    if isinstance(bounds, IntegerBounds):
+        raise ValueError("Cannot create a descriptor for integer-valued data")
+    raise ValueError("Template has unrecognized bounds: {}".format(type(bounds)))
+
+
+class PlatformVocabulary(Mapping[str, Descriptor]):
+    """
+    Dictionary of descriptors that define a controlled vocabulary for the AI Engine.
+
+    Parameters
+    ----------
+    entries: Mapping[str, Descriptor]
+        Entries in the dictionary, indexed by a convenient name.
+        To build from templates, use PlatformVocabulary.from_templates
+
+    """
+
+    def __init__(self, entries: Mapping[str, Descriptor]):
+        self.entries = entries
+
+    def __getitem__(self, k: str) -> Descriptor:
+        return self.entries[k]
+
+    def __len__(self):
+        return len(self.entries)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.entries)
+
+    @staticmethod
+    def from_templates(project: Project, scope: str):
+        """
+        Build a PlatformVocabulary from the templates visible to a project.
+
+        All of the templates with the given scope are downloaded and converted into descriptors.
+        The uid values associated with that scope are used as the index into the dictionary.
+        For example, using scope "my_templates" with a template with
+        uids={"my_templates": "density"} would be indexed into the dictionary as "density".
+
+        Parameters
+        ----------
+        project: Project
+            Project on the Citrine Platform to read templates from
+        scope: str
+            Unique ID scope from which to pull the template names
+
+        Returns
+        -------
+        PlatformVocabulary
+
+        """
+        def _from_collection(collection: DataConceptsCollection):
+            return {x.uids[scope]: x for x in collection.list_all() if scope in x.uids}
+
+        properties = _from_collection(project.property_templates)
+        parameters = _from_collection(project.parameter_templates)
+        conditions = _from_collection(project.condition_templates)
+
+        res = {}
+        for k, v in chain(properties.items(), parameters.items(), conditions.items()):
+            try:
+                desc = template_to_descriptor(v)
+                res[k] = desc
+            except ValueError:
+                continue
+
+        return PlatformVocabulary(res)

--- a/src/citrine/builders/descriptors.py
+++ b/src/citrine/builders/descriptors.py
@@ -74,16 +74,16 @@ class PlatformVocabulary(Mapping[str, Descriptor]):
     """
 
     def __init__(self, entries: Mapping[str, Descriptor]):
-        self.entries = entries
+        self._entries = entries
 
     def __getitem__(self, k: str) -> Descriptor:
-        return self.entries[k]
+        return self._entries[k]
 
     def __len__(self):
-        return len(self.entries)
+        return len(self._entries)
 
     def __iter__(self) -> Iterator[str]:
-        return iter(self.entries)
+        return iter(self._entries)
 
     @staticmethod
     def from_templates(project: Project, scope: str):

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -116,6 +116,9 @@ class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descr
     def __str__(self):
         return "<ChemicalFormulaDescriptor {!r}>".format(self.key)
 
+    def __repr__(self):
+        return "ChemicalFormulaDescriptor(key={})".format(self.key)
+
 
 def InorganicDescriptor(key: str, threshold: Optional[float] = 1.0):
     """[DEPRECATED] Use ChemicalFormulaDescriptor instead."""
@@ -156,6 +159,9 @@ class MolecularStructureDescriptor(Serializable['MolecularStructureDescriptor'],
     def __str__(self):
         return "<MolecularStructureDescriptor {!r}>".format(self.key)
 
+    def __repr__(self):
+        return "MolecularStructureDescriptor(key={})".format(self.key)
+
 
 class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):
     """[ALPHA] A descriptor to hold categorical variables.
@@ -194,6 +200,9 @@ class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):
     def __str__(self):
         return "<CategoricalDescriptor {!r}>".format(self.key)
 
+    def __repr__(self):
+        return "CategoricalDescriptor(key={}, categories={})".format(self.key, self.categories)
+
 
 class FormulationDescriptor(Serializable['FormulationDescriptor'], Descriptor):
     """[ALPHA] A descriptor to hold formulations.
@@ -222,3 +231,6 @@ class FormulationDescriptor(Serializable['FormulationDescriptor'], Descriptor):
 
     def __str__(self):
         return "<FormulationDescriptor {!r}>".format(self.key)
+
+    def __repr__(self):
+        return "FormulationDescriptor(key={})".format(self.key)

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -1,5 +1,5 @@
 """Tools for working with Descriptors."""
-from typing import Type, Optional, List  # noqa: F401
+from typing import Type, Optional, List, Iterable, Set  # noqa: F401
 
 from citrine._serialization.serializable import Serializable
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
@@ -79,6 +79,10 @@ class RealDescriptor(Serializable['RealDescriptor'], Descriptor):
 
     def __str__(self):
         return "<RealDescriptor {!r}>".format(self.key)
+
+    def __repr__(self):
+        return "RealDescriptor({}, {}, {}, {})".format(
+            self.key, self.lower_bound, self.upper_bound, self.units)
 
 
 class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descriptor):
@@ -169,23 +173,23 @@ class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):
 
     key = properties.String('descriptor_key')
     typ = properties.String('type', default='Categorical', deserializable=False)
-    categories = properties.List(properties.String, 'descriptor_values')
+    categories = properties.Set(properties.String, 'descriptor_values')
 
     def __eq__(self, other):
         try:
             attrs = ["key", "categories", "typ"]
             return all([
                 self.__getattribute__(key) == other.__getattribute__(key) for key in attrs
-            ]) and set(self.categories) == set(self.categories + other.categories)
+            ])
         except AttributeError:
             return False
 
-    def __init__(self, key: str, categories: List[str]):
+    def __init__(self, key: str, categories: Iterable[str]):
         self.key: str = key
         for category in categories:
             if not isinstance(category, str):
                 raise TypeError("All categories must be strings")
-        self.categories: List[str] = categories
+        self.categories: Set[str] = set(categories)
 
     def __str__(self):
         return "<CategoricalDescriptor {!r}>".format(self.key)

--- a/tests/builders/test_descriptors.py
+++ b/tests/builders/test_descriptors.py
@@ -1,15 +1,71 @@
+from typing import Iterator
+
 import pytest
 from gemd.entity.bounds import RealBounds, CategoricalBounds, MolecularStructureBounds, \
     CompositionBounds, IntegerBounds
+from gemd.entity.bounds.base_bounds import BaseBounds
 from gemd.entity.template import PropertyTemplate, ConditionTemplate, ParameterTemplate
 from gemd.entity.value import EmpiricalFormula
 
 from citrine.builders.descriptors import PlatformVocabulary, template_to_descriptor
 from citrine.informatics.descriptors import RealDescriptor, CategoricalDescriptor, \
     MolecularStructureDescriptor, ChemicalFormulaDescriptor
+from citrine.resources.condition_template import ConditionTemplateCollection
+from citrine.resources.parameter_template import ParameterTemplateCollection
+from citrine.resources.project import Project
+from citrine.resources.property_template import PropertyTemplateCollection
 
 density_desc = RealDescriptor("density", lower_bound=0, upper_bound=100, units="gram / centimeter ** 3")
 pressure_desc = RealDescriptor("pressure", lower_bound=0, upper_bound=10000, units="GPa")
+
+
+@pytest.fixture()
+def fake_project():
+    """Fake project that serves templates from template collection's list_all method."""
+    templates = [
+        PropertyTemplate("density", bounds=RealBounds(lower_bound=0, upper_bound=100, default_units="g / cm^3"), uids={"my_scope": "density"}),
+        ConditionTemplate("volume", bounds=IntegerBounds(lower_bound=0, upper_bound=11), uids={"my_scope": "volume"}),
+        ParameterTemplate("speed", bounds=CategoricalBounds(categories=["slow", "fast"]), uids={})
+    ]
+
+    class FakePropertyTemplateCollection(PropertyTemplateCollection):
+        def __init__(self):
+            pass
+
+        def list_all(self, forward: bool = True, per_page: int = 100) -> Iterator[PropertyTemplate]:
+            return iter([x for x in templates if isinstance(x, PropertyTemplate)])
+
+    class FakeConditionTemplateCollection(ConditionTemplateCollection):
+        def __init__(self):
+            pass
+
+        def list_all(self, forward: bool = True, per_page: int = 100) -> Iterator[ConditionTemplate]:
+            return iter([x for x in templates if isinstance(x, ConditionTemplate)])
+
+    class FakeParameterTemplateCollection(ParameterTemplateCollection):
+        def __init__(self):
+            pass
+
+        def list_all(self, forward: bool = True, per_page: int = 100) -> Iterator[ParameterTemplate]:
+            return iter([x for x in templates if isinstance(x, ParameterTemplate)])
+
+    class FakeProject(Project):
+        def __init__(self):
+            pass
+
+        @property
+        def property_templates(self) -> PropertyTemplateCollection:
+            return FakePropertyTemplateCollection()
+
+        @property
+        def condition_templates(self) -> ConditionTemplateCollection:
+            return FakeConditionTemplateCollection()
+
+        @property
+        def parameter_templates(self) -> ParameterTemplateCollection:
+            return FakeParameterTemplateCollection()
+
+    return FakeProject()
 
 
 def test_valid_template_conversions():
@@ -47,6 +103,17 @@ def test_invalid_template_conversions():
             PropertyTemplate("mixture", bounds=CompositionBounds(components=["sugar", "spice"]))
         )
 
+    class DummyBounds(BaseBounds):
+        """Fake bounds to test unrecognized bounds."""
+
+        def contains(self, bounds):
+            return False
+
+    with pytest.raises(ValueError):
+        template_to_descriptor(
+            ParameterTemplate("dummy", bounds=DummyBounds())
+        )
+
 
 def test_dict_behavior():
     entries = {
@@ -60,3 +127,11 @@ def test_dict_behavior():
     assert list(v) == ["density", "pressure"]
     assert v["density"] == entries["density"]
     assert v["pressure"] == entries["pressure"]
+
+
+def test_from_template(fake_project: Project):
+    """Test that only correct scopes and bounds are loaded from templates."""
+    v = PlatformVocabulary.from_templates(fake_project, scope="my_scope")
+    assert len(v) == 1
+    assert list(v) == ["density"]
+    assert v["density"] == density_desc

--- a/tests/builders/test_descriptors.py
+++ b/tests/builders/test_descriptors.py
@@ -124,7 +124,7 @@ def test_dict_behavior():
     v = PlatformVocabulary(entries)
 
     assert len(v) == 2
-    assert list(v) == ["density", "pressure"]
+    assert set(v) == {"density", "pressure"}
     assert v["density"] == entries["density"]
     assert v["pressure"] == entries["pressure"]
 

--- a/tests/builders/test_descriptors.py
+++ b/tests/builders/test_descriptors.py
@@ -7,7 +7,8 @@ from gemd.entity.bounds.base_bounds import BaseBounds
 from gemd.entity.template import PropertyTemplate, ConditionTemplate, ParameterTemplate
 from gemd.entity.value import EmpiricalFormula
 
-from citrine.builders.descriptors import PlatformVocabulary, template_to_descriptor
+from citrine.builders.descriptors import PlatformVocabulary, template_to_descriptor, \
+    NoEquivalentDescriptorError
 from citrine.informatics.descriptors import RealDescriptor, CategoricalDescriptor, \
     MolecularStructureDescriptor, ChemicalFormulaDescriptor
 from citrine.resources.condition_template import ConditionTemplateCollection
@@ -93,12 +94,12 @@ def test_valid_template_conversions():
 
 
 def test_invalid_template_conversions():
-    with pytest.raises(ValueError):
+    with pytest.raises(NoEquivalentDescriptorError):
         template_to_descriptor(
             ConditionTemplate("foo", bounds=IntegerBounds(lower_bound=0, upper_bound=1))
         )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NoEquivalentDescriptorError):
         template_to_descriptor(
             PropertyTemplate("mixture", bounds=CompositionBounds(components=["sugar", "spice"]))
         )
@@ -132,6 +133,8 @@ def test_dict_behavior():
 def test_from_template(fake_project: Project):
     """Test that only correct scopes and bounds are loaded from templates."""
     v = PlatformVocabulary.from_templates(fake_project, scope="my_scope")
+
+    # no volume since it is an integer, no speed since it doesn't have the right scope
     assert len(v) == 1
     assert list(v) == ["density"]
     assert v["density"] == density_desc

--- a/tests/builders/test_descriptors.py
+++ b/tests/builders/test_descriptors.py
@@ -1,0 +1,62 @@
+import pytest
+from gemd.entity.bounds import RealBounds, CategoricalBounds, MolecularStructureBounds, \
+    CompositionBounds, IntegerBounds
+from gemd.entity.template import PropertyTemplate, ConditionTemplate, ParameterTemplate
+from gemd.entity.value import EmpiricalFormula
+
+from citrine.builders.descriptors import PlatformVocabulary, template_to_descriptor
+from citrine.informatics.descriptors import RealDescriptor, CategoricalDescriptor, \
+    MolecularStructureDescriptor, ChemicalFormulaDescriptor
+
+density_desc = RealDescriptor("density", lower_bound=0, upper_bound=100, units="gram / centimeter ** 3")
+pressure_desc = RealDescriptor("pressure", lower_bound=0, upper_bound=10000, units="GPa")
+
+
+def test_valid_template_conversions():
+    expected = [
+        (
+            PropertyTemplate(name="density", bounds=RealBounds(lower_bound=0, upper_bound=100, default_units="g/cm^3")),
+            density_desc
+        ),
+        (
+            ConditionTemplate(name="speed", bounds=CategoricalBounds(categories=["low", "high"])),
+            CategoricalDescriptor(key="speed", categories=["low", "high"])
+        ),
+        (
+            ParameterTemplate(name="solvent", bounds=MolecularStructureBounds()),
+            MolecularStructureDescriptor(key="solvent")
+        ),
+        (
+            PropertyTemplate(name="formula", bounds=CompositionBounds(components=EmpiricalFormula.all_elements())),
+            ChemicalFormulaDescriptor(key="formula")
+        )
+    ]
+
+    for tmpl, desc in expected:
+        assert template_to_descriptor(tmpl) == desc
+
+
+def test_invalid_template_conversions():
+    with pytest.raises(ValueError):
+        template_to_descriptor(
+            ConditionTemplate("foo", bounds=IntegerBounds(lower_bound=0, upper_bound=1))
+        )
+
+    with pytest.raises(ValueError):
+        template_to_descriptor(
+            PropertyTemplate("mixture", bounds=CompositionBounds(components=["sugar", "spice"]))
+        )
+
+
+def test_dict_behavior():
+    entries = {
+        "density": RealDescriptor("density", lower_bound=0, upper_bound=100, units="g/cm^3"),
+        "pressure": RealDescriptor("pressure", lower_bound=0, upper_bound=10000, units="GPa")
+    }
+
+    v = PlatformVocabulary(entries)
+
+    assert len(v) == 2
+    assert list(v) == ["density", "pressure"]
+    assert v["density"] == entries["density"]
+    assert v["pressure"] == entries["pressure"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def valid_product_design_space_data():
                     descriptor=dict(
                         type='Categorical',
                         descriptor_key='color',
-                        descriptor_values=['red', 'green', 'blue'],
+                        descriptor_values={'red', 'green', 'blue'},
                     ),
                     list=['red']
                 )
@@ -72,7 +72,7 @@ def valid_enumerated_design_space_data():
                 dict(
                     type='Categorical',
                     descriptor_key='color',
-                    descriptor_values=['red', 'green', 'blue'],
+                    descriptor_values={'red', 'green', 'blue'},
                 ),
                 dict(
                     type='Inorganic',

--- a/tests/informatics/test_descriptors.py
+++ b/tests/informatics/test_descriptors.py
@@ -52,6 +52,8 @@ def test_inorganic_deprecated():
 def test_string_rep(descriptor):
     """String representation of descriptor should contain the descriptor key."""
     assert str(descriptor).__contains__(descriptor.key)
+    assert repr(descriptor).__contains__(descriptor.key)
+
 
 def test_categorical_descriptor_categories_types():
     """Categories in a categorical descriptor should be of type str, and other types should raise TypeError."""

--- a/tests/informatics/test_dimensions.py
+++ b/tests/informatics/test_dimensions.py
@@ -15,7 +15,7 @@ def continuous_dimension() -> ContinuousDimension:
 @pytest.fixture
 def enumerated_dimension() -> EnumeratedDimension:
     """Build an EnumeratedDimension."""
-    color = CategoricalDescriptor('color', categories=['red', 'green', 'blue'])
+    color = CategoricalDescriptor('color', categories={'red', 'green', 'blue'})
     return EnumeratedDimension(color, values=['red', 'red', 'blue'])
 
 
@@ -41,5 +41,5 @@ def test_continuous_bounds():
 def test_enumerated_initialization(enumerated_dimension):
     """Make sure the correct fields go to the correct places."""
     assert enumerated_dimension.descriptor.key == 'color'
-    assert enumerated_dimension.descriptor.categories == ['red', 'green', 'blue']
+    assert enumerated_dimension.descriptor.categories == {'red', 'green', 'blue'}
     assert enumerated_dimension.values == ['red', 'red', 'blue']

--- a/tests/serialization/test_design_spaces.py
+++ b/tests/serialization/test_design_spaces.py
@@ -60,7 +60,7 @@ def test_simple_enumerated_deserialization(valid_enumerated_design_space_data):
 
         assert type(categorical) == CategoricalDescriptor
         assert categorical.key == 'color'
-        assert categorical.categories == ['red', 'green', 'blue']
+        assert categorical.categories == {'red', 'green', 'blue'}
 
         assert type(formula) == ChemicalFormulaDescriptor
         assert formula.key == 'formula'

--- a/tests/serialization/test_dimensions.py
+++ b/tests/serialization/test_dimensions.py
@@ -34,7 +34,7 @@ def valid_enumerated_data():
         descriptor=dict(
             type='Categorical',
             descriptor_key='color',
-            descriptor_values=['red', 'green', 'blue'],
+            descriptor_values={'red', 'green', 'blue'},
         ),
         list=['red']
     )


### PR DESCRIPTION
# Citrine Python PR

## Description 

The PlatformVocabulary is a dict interface into a set of descriptors.
It can be conveniently loaded from the data platform by reading
and then converting templates into descriptors.

Also changed categories to a set.
### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
