### PR TITLE
Scrubbing spurious ids in validation routes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.55.0',
+      version='0.55.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/data_objects.py
+++ b/src/citrine/resources/data_objects.py
@@ -1,13 +1,15 @@
 """Top-level class for all data object (i.e. spec and run) objects and collections thereof."""
 from abc import ABC
 from typing import Dict, Union, Optional, Iterator, List, TypeVar
+from uuid import uuid4
 
 from gemd.json import GEMDJson
+from gemd.util import recursive_foreach
 
 from citrine._utils.functions import get_object_id, replace_objects_with_links, scrub_none
 from citrine.exceptions import BadRequest
 from citrine.resources.api_error import ValidationError
-from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection, CITRINE_SCOPE
+from citrine.resources.data_concepts import DataConcepts, DataConceptsCollection
 from citrine.resources.object_templates import ObjectTemplateResourceType
 from citrine.resources.process_template import ProcessTemplate
 from gemd.entity.bounds.base_bounds import BaseBounds
@@ -163,8 +165,12 @@ class DataObjectCollection(DataConceptsCollection[DataObjectResourceType], ABC):
         :return: List[ValidationError] of validation errors encountered. Empty if successful.
         """
         path = self._get_path(ignore_dataset=True) + "/validate-templates"
-        GEMDJson(scope=CITRINE_SCOPE).dumps(model)  # This apparent no-op populates uids
+
+        temp_scope = str(uuid4())
+        GEMDJson(scope=temp_scope).dumps(model)  # This apparent no-op populates uids
         dumped_data = replace_objects_with_links(scrub_none(model.dump()))
+        recursive_foreach(model, lambda x: x.uids.pop(temp_scope, None))  # Strip temp uids
+
         request_data = {"dataObject": dumped_data}
         if object_template is not None:
             request_data["objectTemplate"] = \


### PR DESCRIPTION
# Citrine Python PR

## Description 
Following feedback in primary ticket, this wraps `dry_run` registrations and template_validations in code to first autogenerate a scope and then scrub ids in the resulting scope from objects that have not been written.  This addresses the immediate concern, but has two flaws at present:
* If a user tries to register objects and it fails, there are still CITRINE_SCOPE ids in the objects.  This runs counter to specification but seemed like a much more expensive feature to implement.
* The new features do not have proper test coverage

https://citrine.atlassian.net/browse/PLA-4551

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
