### PR TITLE
Feature/ds builders user warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.57.0',
+      version='0.57.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -200,8 +200,8 @@ def cartesian_join_design_spaces(
         raise ValueError('Duplicate keys are not allowed across design spaces')
 
     # Check that the grid size is small enough to not cause memory issues
-    grid_size = np.prod([len(ds.data[0]) for ds in subspaces]) \
-        * np.sum([len(ds.data) for ds in subspaces])
+    grid_size = np.prod([len(ds.data) for ds in subspaces]) \
+        * np.sum([len(ds.data[0]) for ds in subspaces])
     if grid_size > 2e8:
         warn("Product design grid contains {n} grid points. This may cause memory issues "
              "downstream.".format(n=grid_size))

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -44,7 +44,7 @@ def enumerate_cartesian_product(
     # Check that the grid size is small enough to not cause memory issues
     grid_size = np.prod(
         [len(grid_points) for grid_points in design_grid.values()]
-    )
+    ) * len(design_grid)
     if grid_size > 2E8:
         warn("Product design grid contains {n} grid points. This may cause memory issues "
              "downstream.".format(n=grid_size))

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -200,11 +200,11 @@ def cartesian_join_design_spaces(
         raise ValueError('Duplicate keys are not allowed across design spaces')
 
     # Check that the grid size is small enough to not cause memory issues
-    grid_size = np.prod([len(ds.data) * len(ds.data[0]) for ds in subspaces])
+    grid_size = np.prod([len(ds.data[0]) for ds in subspaces]) \
+        * np.sum([len(ds.data) for ds in subspaces])
     if grid_size > 2e8:
         warn("Product design grid contains {n} grid points. This may cause memory issues "
-             "downstream."
-             .format(n=grid_size))
+             "downstream.".format(n=grid_size))
 
     # Convert data fields of EDS into DataFrames to prep for join
     ds_list = [pd.DataFrame(ds.data) for ds in subspaces]

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -131,14 +131,6 @@ def enumerate_formulation_grid(
         if k in non_balance_ingrs
     }
 
-    # Check that the grid size is small enough to not cause memory issues
-    non_balance_grid_size = np.prod(
-        [len(grid_points) for grid_points in non_balance_grids.values()]
-    )
-    if non_balance_grid_size > 2E8:
-        warn("Non-balance formulation grid contains {n} grid points. This may cause memory "
-             "issues downstream.".format(n=non_balance_grid_size))
-
     # Start by making a naive product design space of non-balance ingredients
     form_ds = pd.DataFrame(
         enumerate_cartesian_product(

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -45,7 +45,7 @@ def enumerate_cartesian_product(
     grid_size = np.prod(
         [len(grid_points) for grid_points in design_grid.values()]
     )
-    if grid_size > 2:
+    if grid_size > 2E8:
         warn("Product design grid contains {n} grid points. This may cause memory issues "
              "downstream.".format(n=grid_size))
 

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -46,8 +46,10 @@ def enumerate_cartesian_product(
         [len(grid_points) for grid_points in design_grid.values()]
     ) * len(design_grid)
     if grid_size > 2E8:
-        warn("Product design grid contains {n} grid points. This may cause memory issues "
-             "downstream.".format(n=grid_size))
+        warn(
+            "Product design grid contains {n} grid points. This may cause memory issues "
+            "downstream.".format(n=grid_size)
+        )
 
     design_space_tuples = list(product(*design_grid.values()))
     design_space_cols = list(design_grid.keys())
@@ -202,9 +204,11 @@ def cartesian_join_design_spaces(
     # Check that the grid size is small enough to not cause memory issues
     grid_size = np.prod([len(ds.data) for ds in subspaces]) \
         * np.sum([len(ds.data[0]) for ds in subspaces])
-    if grid_size > 2e8:
-        warn("Product design grid contains {n} grid points. This may cause memory issues "
-             "downstream.".format(n=grid_size))
+    if grid_size > 2E8:
+        warn(
+            "Product design grid contains {n} grid points. This may cause memory issues "
+            "downstream.".format(n=grid_size)
+        )
 
     # Convert data fields of EDS into DataFrames to prep for join
     ds_list = [pd.DataFrame(ds.data) for ds in subspaces]

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -41,14 +41,13 @@ def enumerate_cartesian_product(
         description for the EnumeratedDesignSpace
 
     """
-
     # Check that the grid size is small enough to not cause memory issues
     grid_size = np.prod(
         [len(grid_points) for grid_points in design_grid.values()]
     )
-    if grid_size > 2E8:
-        warn("Product design grid contains {n} grid points. This may cause memory issues downstream."
-             .format(n=grid_size))
+    if grid_size > 2:
+        warn("Product design grid contains {n} grid points. This may cause memory issues "
+             "downstream.".format(n=grid_size))
 
     design_space_tuples = list(product(*design_grid.values()))
     design_space_cols = list(design_grid.keys())
@@ -137,8 +136,8 @@ def enumerate_formulation_grid(
         [len(grid_points) for grid_points in non_balance_grids.values()]
     )
     if non_balance_grid_size > 2E8:
-        warn("Non-balance formulation grid contains {n} grid points. This may cause memory issues downstream."
-             .format(n=non_balance_grid_size))
+        warn("Non-balance formulation grid contains {n} grid points. This may cause memory "
+             "issues downstream.".format(n=non_balance_grid_size))
 
     # Start by making a naive product design space of non-balance ingredients
     form_ds = pd.DataFrame(
@@ -209,9 +208,10 @@ def cartesian_join_design_spaces(
         raise ValueError('Duplicate keys are not allowed across design spaces')
 
     # Check that the grid size is small enough to not cause memory issues
-    grid_size = np.prod([len(ds.data)*len(ds.data[0]) for ds in subspaces])
+    grid_size = np.prod([len(ds.data) * len(ds.data[0]) for ds in subspaces])
     if grid_size > 2e8:
-        warn("Product design grid contains {n} grid points. This may cause memory issues downstream."
+        warn("Product design grid contains {n} grid points. This may cause memory issues "
+             "downstream."
              .format(n=grid_size))
 
     # Convert data fields of EDS into DataFrames to prep for join

--- a/tests/builders/test_design_spaces.py
+++ b/tests/builders/test_design_spaces.py
@@ -195,11 +195,13 @@ def test_exceptions(basic_cartesian_space, simple_mixture_space):
         )
 
 
-def test_warnings():
+def test_oversize_warnings(large_joint_design_space):
     """Test that warnings are raised"""
-    with warnings.catch_warnings():
-        warnings.simplefilter('error')
-        with pytest.warns(UserWarning):
+    # Test oversized formulation grid
+    with pytest.raises(UserWarning):
+        # Fail on error (so code stops running)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
             too_big_formulation_grid = {
                 'ing_F': np.linspace(0, 1),
                 'ing_G': np.linspace(0, 1),
@@ -208,10 +210,90 @@ def test_warnings():
                 'ing_J': np.linspace(0, 1),
                 'ing_K': np.linspace(0, 1)
             }
-            too__big_mixture_space = enumerate_formulation_grid(
+            enumerate_formulation_grid(
                 formulation_grid=too_big_formulation_grid,
                 balance_ingredient='ing_K',
                 name='too big mixture space',
                 description=''
             )
 
+    # Test oversized enumerated space
+    with pytest.raises(UserWarning):
+        # Fail on error (so code stops running)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            delta = RealDescriptor('delta', 0, 100)
+            epsilon = RealDescriptor('epsilon', 0, 100)
+            zeta = RealDescriptor('zeta', 0, 100)
+            too_big_enumerated_grid = {
+                'delta': np.linspace(0, 100, 600),
+                'epsilon': np.linspace(0, 100, 600),
+                'zeta': np.linspace(0, 100, 600),
+            }
+            enumerate_cartesian_product(
+                design_grid=too_big_enumerated_grid,
+                descriptors=[delta, epsilon, zeta],
+                name='too big space',
+                description=''
+            )
+
+    # Test oversized joined spaces
+    with pytest.raises(UserWarning):
+        # Fail on error (so code stops running)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+
+            delta = RealDescriptor('delta', 0, 100)
+            epsilon = RealDescriptor('epsilon', 0, 100)
+            zeta = CategoricalDescriptor('zeta', ['a', 'b', 'c'])
+            design_grid = {
+                'delta': [0, 50, 100],
+                'epsilon': [0, 25, 50, 75, 100],
+                'zeta': ['a', 'b', 'c']
+            }
+            basic_space_2 = enumerate_cartesian_product(
+                design_grid=design_grid,
+                descriptors=[delta, epsilon, zeta],
+                name='basic space 2',
+                description=''
+            )
+
+            eta = RealDescriptor('eta', 0, 100)
+            theta = RealDescriptor('theta', 0, 100)
+            iota = CategoricalDescriptor('iota', ['a', 'b', 'c'])
+            design_grid = {
+                'eta': [0, 50, 100],
+                'theta': [0, 25, 50, 75, 100],
+                'iota': ['a', 'b', 'c']
+            }
+            basic_space_3 = enumerate_cartesian_product(
+                design_grid=design_grid,
+                descriptors=[eta, theta, iota],
+                name='basic space 3',
+                description=''
+            )
+
+            kappa = RealDescriptor('kappa', 0, 100)
+            mu = RealDescriptor('mu', 0, 100)
+            nu = CategoricalDescriptor('nu', ['a', 'b', 'c'])
+            design_grid = {
+                'kappa': [0, 50, 100],
+                'mu': [0, 25, 50, 75, 100],
+                'nu': ['a', 'b', 'c']
+            }
+            basic_space_4 = enumerate_cartesian_product(
+                design_grid=design_grid,
+                descriptors=[kappa, mu, nu],
+                name='basic space 4',
+                description=''
+            )
+            cartesian_join_design_spaces(
+                subspaces=[
+                    basic_space_2,
+                    basic_space_3,
+                    basic_space_4,
+                    large_joint_design_space
+                ],
+                name='too big join space',
+                description=''
+            )

--- a/tests/builders/test_design_spaces.py
+++ b/tests/builders/test_design_spaces.py
@@ -195,11 +195,10 @@ def test_exceptions(basic_cartesian_space, simple_mixture_space):
         )
 
 
-def test_oversize_warnings(large_joint_design_space):
-    """Test that warnings are raised"""
-    # Test oversized formulation grid
+def test_formulation_oversize_warnings():
+    """Test that oversized formulation grid warnings are raised"""
     with pytest.raises(UserWarning, match="1562500000"):
-        # Fail on error (so code stops running)
+        # Fail on warning (so code stops running)
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             too_big_formulation_grid = {
@@ -217,9 +216,11 @@ def test_oversize_warnings(large_joint_design_space):
                 description=''
             )
 
-    # Test oversized enumerated space
+
+def test_enumerated_oversize_warnings():
+    """Test that oversized enumerated space warnings are raised"""
     with pytest.raises(UserWarning, match="648000000"):
-        # Fail on error (so code stops running)
+        # Fail on warning (so code stops running)
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             delta = RealDescriptor('delta', 0, 100)
@@ -237,9 +238,11 @@ def test_oversize_warnings(large_joint_design_space):
                 description=''
             )
 
-    # Test oversized joined spaces
+
+def test_joined_oversize_warnings(large_joint_design_space):
+    """Test that oversized joined space warnings are raised"""
     with pytest.raises(UserWarning, match="239203125"):
-        # Fail on error (so code stops running)
+        # Fail on warning (so code stops running)
         with warnings.catch_warnings():
             warnings.simplefilter('error')
 

--- a/tests/builders/test_design_spaces.py
+++ b/tests/builders/test_design_spaces.py
@@ -1,5 +1,7 @@
 """Tests for citrine.builders.design_spaces."""
 import pytest
+import warnings
+import numpy as np
 
 from citrine.informatics.descriptors import RealDescriptor, CategoricalDescriptor
 from citrine.informatics.design_spaces import EnumeratedDesignSpace
@@ -191,3 +193,25 @@ def test_exceptions(basic_cartesian_space, simple_mixture_space):
             name='invalid join space 2',
             description=''
         )
+
+
+def test_warnings():
+    """Test that warnings are raised"""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        with pytest.warns(UserWarning):
+            too_big_formulation_grid = {
+                'ing_F': np.linspace(0, 1),
+                'ing_G': np.linspace(0, 1),
+                'ing_H': np.linspace(0, 1),
+                'ing_I': np.linspace(0, 1),
+                'ing_J': np.linspace(0, 1),
+                'ing_K': np.linspace(0, 1)
+            }
+            too__big_mixture_space = enumerate_formulation_grid(
+                formulation_grid=too_big_formulation_grid,
+                balance_ingredient='ing_K',
+                name='too big mixture space',
+                description=''
+            )
+

--- a/tests/builders/test_design_spaces.py
+++ b/tests/builders/test_design_spaces.py
@@ -198,7 +198,9 @@ def test_exceptions(basic_cartesian_space, simple_mixture_space):
 def test_oversize_warnings(large_joint_design_space):
     """Test that warnings are raised"""
     # Test oversized formulation grid
-    with pytest.raises(UserWarning):
+    with pytest.raises(UserWarning,
+                       match="Product design grid contains 1562500000 grid points. "
+                             "This may cause memory issues downstream."):
         # Fail on error (so code stops running)
         with warnings.catch_warnings():
             warnings.simplefilter('error')
@@ -218,7 +220,10 @@ def test_oversize_warnings(large_joint_design_space):
             )
 
     # Test oversized enumerated space
-    with pytest.raises(UserWarning):
+    with pytest.raises(UserWarning,
+                       match="Product design grid contains 648000000 grid points. "
+                             "This may cause memory issues downstream."
+                       ):
         # Fail on error (so code stops running)
         with warnings.catch_warnings():
             warnings.simplefilter('error')
@@ -238,7 +243,9 @@ def test_oversize_warnings(large_joint_design_space):
             )
 
     # Test oversized joined spaces
-    with pytest.raises(UserWarning):
+    with pytest.raises(UserWarning,
+                       match="Product design grid contains 239203125 grid points. "
+                             "This may cause memory issues downstream."):
         # Fail on error (so code stops running)
         with warnings.catch_warnings():
             warnings.simplefilter('error')

--- a/tests/builders/test_design_spaces.py
+++ b/tests/builders/test_design_spaces.py
@@ -205,12 +205,12 @@ def test_oversize_warnings(large_joint_design_space):
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             too_big_formulation_grid = {
-                'ing_F': np.linspace(0, 1),
-                'ing_G': np.linspace(0, 1),
-                'ing_H': np.linspace(0, 1),
-                'ing_I': np.linspace(0, 1),
-                'ing_J': np.linspace(0, 1),
-                'ing_K': np.linspace(0, 1)
+                'ing_F': np.linspace(0, 1, 50),
+                'ing_G': np.linspace(0, 1, 50),
+                'ing_H': np.linspace(0, 1, 50),
+                'ing_I': np.linspace(0, 1, 50),
+                'ing_J': np.linspace(0, 1, 50),
+                'ing_K': np.linspace(0, 1, 50)
             }
             enumerate_formulation_grid(
                 formulation_grid=too_big_formulation_grid,

--- a/tests/builders/test_design_spaces.py
+++ b/tests/builders/test_design_spaces.py
@@ -273,25 +273,10 @@ def test_oversize_warnings(large_joint_design_space):
                 description=''
             )
 
-            kappa = RealDescriptor('kappa', 0, 100)
-            mu = RealDescriptor('mu', 0, 100)
-            nu = CategoricalDescriptor('nu', ['a', 'b', 'c'])
-            design_grid = {
-                'kappa': [0, 50, 100],
-                'mu': [0, 25, 50, 75, 100],
-                'nu': ['a', 'b', 'c']
-            }
-            basic_space_4 = enumerate_cartesian_product(
-                design_grid=design_grid,
-                descriptors=[kappa, mu, nu],
-                name='basic space 4',
-                description=''
-            )
             cartesian_join_design_spaces(
                 subspaces=[
                     basic_space_2,
                     basic_space_3,
-                    basic_space_4,
                     large_joint_design_space
                 ],
                 name='too big join space',

--- a/tests/builders/test_design_spaces.py
+++ b/tests/builders/test_design_spaces.py
@@ -198,9 +198,7 @@ def test_exceptions(basic_cartesian_space, simple_mixture_space):
 def test_oversize_warnings(large_joint_design_space):
     """Test that warnings are raised"""
     # Test oversized formulation grid
-    with pytest.raises(UserWarning,
-                       match="Product design grid contains 1562500000 grid points. "
-                             "This may cause memory issues downstream."):
+    with pytest.raises(UserWarning, match="1562500000"):
         # Fail on error (so code stops running)
         with warnings.catch_warnings():
             warnings.simplefilter('error')
@@ -220,10 +218,7 @@ def test_oversize_warnings(large_joint_design_space):
             )
 
     # Test oversized enumerated space
-    with pytest.raises(UserWarning,
-                       match="Product design grid contains 648000000 grid points. "
-                             "This may cause memory issues downstream."
-                       ):
+    with pytest.raises(UserWarning, match="648000000"):
         # Fail on error (so code stops running)
         with warnings.catch_warnings():
             warnings.simplefilter('error')
@@ -243,9 +238,7 @@ def test_oversize_warnings(large_joint_design_space):
             )
 
     # Test oversized joined spaces
-    with pytest.raises(UserWarning,
-                       match="Product design grid contains 239203125 grid points. "
-                             "This may cause memory issues downstream."):
+    with pytest.raises(UserWarning, match="239203125"):
         # Fail on error (so code stops running)
         with warnings.catch_warnings():
             warnings.simplefilter('error')


### PR DESCRIPTION
# Citrine Python PR

## Description 
Raise warnings to users of the design space builders when attempting to build design spaces that are of a size to likely cause memory issues. This provides the user insight into why they may receive a MemoryError downstream. (Initiated by user feedback.)

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [N/A] I have written Numpy-style docstrings for every method and class.
- [x] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
