### PR TITLE
Fix/tableconfig missing kwargs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.62.1',
+      version='0.62.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/table_config.py
+++ b/src/citrine/resources/table_config.py
@@ -156,7 +156,11 @@ class TableConfig(Resource["TableConfig"]):
             datasets=copy(self.datasets),
             rows=copy(self.rows),
             variables=copy(self.variables) + [variable],
-            columns=copy(self.columns) + columns
+            columns=copy(self.columns) + columns,
+            config_uid=copy(self.config_uid),
+            version_uid=copy(self.version_uid),
+            version_number=self.version_number,
+            definition_uid=copy(self.definition_uid)
         )
 
     def add_all_ingredients(self, *,
@@ -228,7 +232,11 @@ class TableConfig(Resource["TableConfig"]):
             datasets=copy(self.datasets),
             rows=copy(self.rows),
             variables=copy(self.variables) + new_variables,
-            columns=copy(self.columns) + new_columns
+            columns=copy(self.columns) + new_columns,
+            config_uid=copy(self.config_uid),
+            version_uid=copy(self.version_uid),
+            version_number=self.version_number,
+            definition_uid=copy(self.definition_uid)
         )
 
 

--- a/src/citrine/resources/table_config.py
+++ b/src/citrine/resources/table_config.py
@@ -158,8 +158,6 @@ class TableConfig(Resource["TableConfig"]):
             variables=copy(self.variables) + [variable],
             columns=copy(self.columns) + columns,
             config_uid=copy(self.config_uid),
-            version_uid=copy(self.version_uid),
-            version_number=self.version_number,
             definition_uid=copy(self.definition_uid)
         )
 
@@ -234,8 +232,6 @@ class TableConfig(Resource["TableConfig"]):
             variables=copy(self.variables) + new_variables,
             columns=copy(self.columns) + new_columns,
             config_uid=copy(self.config_uid),
-            version_uid=copy(self.version_uid),
-            version_number=self.version_number,
             definition_uid=copy(self.definition_uid)
         )
 

--- a/src/citrine/resources/table_config.py
+++ b/src/citrine/resources/table_config.py
@@ -157,8 +157,7 @@ class TableConfig(Resource["TableConfig"]):
             rows=copy(self.rows),
             variables=copy(self.variables) + [variable],
             columns=copy(self.columns) + columns,
-            config_uid=copy(self.config_uid),
-            definition_uid=copy(self.definition_uid)
+            config_uid=copy(self.config_uid)
         )
 
     def add_all_ingredients(self, *,
@@ -231,8 +230,7 @@ class TableConfig(Resource["TableConfig"]):
             rows=copy(self.rows),
             variables=copy(self.variables) + new_variables,
             columns=copy(self.columns) + new_columns,
-            config_uid=copy(self.config_uid),
-            definition_uid=copy(self.definition_uid)
+            config_uid=copy(self.config_uid)
         )
 
 

--- a/tests/resources/test_table_config.py
+++ b/tests/resources/test_table_config.py
@@ -46,8 +46,8 @@ def table_config() -> AraDefinition:
 
 
 def empty_defn() -> AraDefinition:
-    return TableConfig(name="empty", description="empty",
-                         datasets=[], rows=[], variables=[], columns=[])
+    return TableConfig(name="empty", description="empty", datasets=[], rows=[], variables=[],
+                       columns=[], config_uid=UUID("6b608f78-e341-422c-8076-35adc8828545"))
 
 
 def test_get_table_config_metadata(collection, session):
@@ -258,6 +258,7 @@ def test_add_columns():
     )
     assert with_name_col.variables == [RootInfo(name="name", headers=["bar"], field="name")]
     assert with_name_col.columns == [IdentityColumn(data_source="name")]
+    assert with_name_col.config_uid == UUID('6b608f78-e341-422c-8076-35adc8828545')
 
     # Check duplicate variable name error
     with pytest.raises(ValueError) as excinfo:
@@ -304,6 +305,7 @@ def test_add_all_ingredients(session, project):
     new_columns = def2.columns[len(def1.columns):]
     assert len(new_variables) == len(allowed_names)
     assert len(new_columns) == len(allowed_names) * 2
+    assert def2.config_uid == UUID("6b608f78-e341-422c-8076-35adc8828545")
     for name in allowed_names:
         assert next((var for var in new_variables if name in var.headers
                      and isinstance(var, IngredientQuantityByProcessAndName)), None) is not None


### PR DESCRIPTION
# Citrine Python PR

## Description 
add_columns and add_all_ingredients do not return all of the TableConfig kwargs. This fix adds the missing kwargs in.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
