### PR TITLE
Feature/pla 5184 optional dataset unique name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.63.3',
+      version='0.63.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.62.3',
+      version='0.63.3',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -48,7 +48,8 @@ class Session(requests.Session):
         self.s3_use_ssl = True
         self.s3_addressing_style = 'auto'
 
-        # Feature flag for enabling the use of Dataset idempotent PUT. Will be removed in a future release.
+        # Feature flag for enabling the use of Dataset idempotent PUT. Will be removed
+        # in a future release.
         self.use_idempotent_dataset_put = False
 
         # Custom adapter so we can use custom retry parameters. The default HTTP status

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -48,6 +48,9 @@ class Session(requests.Session):
         self.s3_use_ssl = True
         self.s3_addressing_style = 'auto'
 
+        # Feature flag for enabling the use of Dataset idempotent PUT. Will be removed in a future release.
+        self.use_idempotent_dataset_put = False
+
         # Custom adapter so we can use custom retry parameters. The default HTTP status
         # codes for retries are [503, 413, 429]. We're using status_force list to add
         # additional codes to retry on, focusing on specific CloudFlare 5XX errors.

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -8,6 +8,7 @@ from citrine._rest.resource import Resource
 from citrine._serialization import properties
 from citrine._session import Session
 from citrine._utils.functions import scrub_none
+from citrine.exceptions import NotFound
 from citrine.resources.condition_template import ConditionTemplateCollection
 from citrine.resources.file_link import FileCollection
 from citrine.resources.ingredient_run import IngredientRunCollection
@@ -360,3 +361,17 @@ class DatasetCollection(Collection[Dataset]):
         full_model = self.build(data)
         full_model.project_id = self.project_id
         return full_model
+
+    def get_with_unique_name(self, unique_name: str) -> ResourceType:
+        """Get a Dataset with the given unique name."""
+        if unique_name is None:
+            raise ValueError("You must supply a unique_name")
+        path = self._get_path() + "?unique_name=" + unique_name
+        data = self.session.get_resource(path)
+
+        if len(data) == 1:
+            return self.build( data[0])
+        elif len(data) > 1:
+            raise RuntimeError("Received multiple results when requesting a unique dataset")
+        else:
+            raise NotFound(path)

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -349,20 +349,21 @@ class DatasetCollection(Collection[Dataset]):
         dumped_dataset = model.dump()
         dumped_dataset["deleted"] = None
 
-        # Only use the idempotent put approach if a) a unique name is provided, and b) the session is configured to use
-        # it (default to False for backwards compatibility).
+        # Only use the idempotent put approach if a) a unique name is provided, and b)
+        # the session is configured to use it (default to False for backwards compatibility).
         if model.unique_name is not None and self.session.use_idempotent_dataset_put:
             # Leverage the create-or-update endpoint if we've got a unique name
             data = self.session.put_resource(path, scrub_none(dumped_dataset))
         else:
-            # Otherwise fall back to using the POST approach (which may fail if the resource already exists)
+            # Otherwise fall back to using the POST approach (which may fail if the
+            # resource already exists)
             data = self.session.post_resource(path, scrub_none(dumped_dataset))
 
         full_model = self.build(data)
         full_model.project_id = self.project_id
         return full_model
 
-    def get_with_unique_name(self, unique_name: str) -> ResourceType:
+    def get_by_unique_name(self, unique_name: str) -> ResourceType:
         """Get a Dataset with the given unique name."""
         if unique_name is None:
             raise ValueError("You must supply a unique_name")
@@ -370,7 +371,7 @@ class DatasetCollection(Collection[Dataset]):
         data = self.session.get_resource(path)
 
         if len(data) == 1:
-            return self.build( data[0])
+            return self.build(data[0])
         elif len(data) > 1:
             raise RuntimeError("Received multiple results when requesting a unique dataset")
         else:

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -81,6 +81,7 @@ class Dataset(Resource['Dataset']):
 
     uid = properties.Optional(properties.UUID(), 'id')
     name = properties.String('name')
+    unique_name = properties.Optional(properties.String(), 'unique_name')
     summary = properties.String('summary')
     description = properties.String('description')
     deleted = properties.Optional(properties.Boolean(), 'deleted')
@@ -92,10 +93,11 @@ class Dataset(Resource['Dataset']):
     delete_time = properties.Optional(properties.Datetime(), 'delete_time')
     public = properties.Optional(properties.Boolean(), 'public')
 
-    def __init__(self, name: str, summary: str, description: str):
+    def __init__(self, name: str, summary: str, description: str, unique_name: str = None):
         self.name: str = name
         self.summary: str = summary
         self.description: str = description
+        self.unique_name = unique_name
 
         # The attributes below should not be set by the user. Instead they will be updated as the
         # dataset interacts with the backend data service

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -2,6 +2,8 @@ from os.path import basename
 from uuid import UUID, uuid4
 
 import pytest
+
+from citrine.exceptions import NotFound
 from citrine.resources.condition_template import ConditionTemplateCollection, ConditionTemplate
 from citrine.resources.dataset import DatasetCollection
 from citrine.resources.ingredient_run import IngredientRun, IngredientRunCollection
@@ -80,6 +82,74 @@ def test_register_dataset(collection, session):
     assert session.num_calls == 1
     assert expected_call == session.last_call
     assert name == dataset.name
+
+
+def test_register_dataset_with_idempotent_put(collection, session):
+    # Given
+    name = 'Test Dataset'
+    summary = 'testing summary'
+    description = 'testing description'
+    unique_name = 'foo'
+    session.set_response(DatasetDataFactory(name=name, summary=summary, description=description, unique_name=unique_name))
+
+    # When
+    session.use_idempotent_dataset_put = True
+    dataset = collection.register(DatasetFactory(name=name, summary=summary, description=description, unique_name=unique_name))
+
+    expected_call = FakeCall(
+        method='PUT',
+        path='projects/{}/datasets'.format(collection.project_id),
+        json={'name': name, 'summary': summary, 'description': description, 'unique_name': unique_name}
+    )
+    assert session.num_calls == 1
+    assert expected_call == session.last_call
+    assert name == dataset.name
+
+
+def test_get_by_unique_name_with_single_result(collection, session):
+    # Given
+    name = 'Test Dataset'
+    unique_name = "foo"
+    session.set_response([DatasetDataFactory(name=name, unique_name=unique_name)])
+
+    # When
+    result_ds = collection.get_by_unique_name(unique_name)
+
+    # Then
+    expected_call = FakeCall(
+        method='GET',
+        path='projects/{}/datasets?unique_name={}'.format(collection.project_id, unique_name)
+    )
+    assert session.num_calls == 1
+    assert expected_call == session.last_call
+    assert result_ds.name == name
+    assert result_ds.unique_name == unique_name
+
+
+def test_get_by_unique_name_with_no_result(collection, session):
+    # Given
+    session.set_response([])
+
+    # When
+    with pytest.raises(NotFound):
+        collection.get_by_unique_name("unimportant")
+
+
+def test_get_by_unique_name_no_unique_name_present(collection, session):
+    # When
+    with pytest.raises(ValueError):
+        collection.get_by_unique_name(None)
+
+def test_get_by_unique_name_multiple_results(collection, session):
+
+    # This really shouldn't happen
+
+    # Given
+    session.set_response([DatasetDataFactory(), DatasetDataFactory()])
+
+    # When
+    with pytest.raises(RuntimeError):
+        collection.get_by_unique_name("blah")
 
 
 def test_list_datasets(paginated_collection, paginated_session):

--- a/tests/serialization/test_dataset.py
+++ b/tests/serialization/test_dataset.py
@@ -11,6 +11,7 @@ def valid_data():
     return dict(
         id=str(uuid4()),
         name='Dataset 1',
+        unique_name=None,
         summary='The first dataset',
         description='A dummy dataset for performing unit tests',
         deleted=True,

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -75,6 +75,7 @@ class DatasetDataFactory(factory.DictFactory):
     created_by = factory.Faker('uuid4')
     updated_by = factory.Faker('uuid4')
     deleted_by = factory.Faker('uuid4')
+    unique_name = None
     create_time = None
     update_time = None
     delete_time = None
@@ -138,6 +139,7 @@ class DatasetFactory(factory.Factory):
     name = factory.Faker('company')
     summary = factory.Faker('catch_phrase')
     description = factory.Faker('bs')
+    unique_name = None
 
 
 class _UploaderFactory(factory.Factory):

--- a/tests/utils/session.py
+++ b/tests/utils/session.py
@@ -43,6 +43,7 @@ class FakeSession:
         self.s3_endpoint_url = None
         self.s3_use_ssl = True
         self.s3_addressing_style = 'auto'
+        self.use_idempotent_dataset_put = False
 
     def set_response(self, resp):
         self.responses = [resp]


### PR DESCRIPTION
# Added an optional unique_name to datasets

This is dependent on backend PR: https://github.com/CitrineInformatics/platform-backend/pull/1427

This adds backwards-compatible support for the optional unique_name property. This allows us to have atomic create-or-update sematics for a dataset by supplying a unique name.

Provided the ability to use this in the Dataset collection's .register() call, but it's disabled by default (you can enable it by turning on a flag in the session). This is so we don't break when talking to old backends.

Also added a get_with_unique_name() method (please help with naming) which allows us to directly look up a dataset. This should help make testing (seeding?) and similar operations much faster and reliable, and reduce our reliance on locks.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
