### PR TITLE
Bugfix/deprecate filter by and fix data object list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gemd==0.13.0
+gemd==0.13.2
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.15.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gemd==0.12.1
+gemd==0.13.0
 requests==2.22.0
 pyjwt==1.7.1
 arrow==0.15.4

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.64.1',
+      version='0.64.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',
@@ -68,7 +68,7 @@ setup(name='citrine',
           "pyjwt>=1.7.1,<2",
           "arrow>=0.15.4,<0.16",
           "strip-hints>=0.1.8,<0.2",
-          "gemd>=0.12,<0.13",
+          "gemd>=0.13,<0.14",
           "boto3>=1.9.226,<2",
           "botocore>=1.12.226,<2",
           "deprecation>=2.0.7,<3",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.63.1',
+      version='0.64.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -266,16 +266,18 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         """
         List all visible elements of the collection.
 
-        page and per_page parameters of this method are deprecated and ignored. This method will as default values will return a list of all elements
-        in the collection, paginating over all available pages.
+        page and per_page parameters of this method are deprecated and ignored.
+        This method will will return a list of all elements in the collection.
 
         Parameters
         ---------
         page: int, optional
-            [DEPRECATED][IGNORED] This parameter is ignored. To load individual pages lazily, use the list_all method. 
+            [DEPRECATED][IGNORED] This parameter is ignored. To load individual
+            pages lazily, use the list_all method.
         per_page: int, optional
-            Max number of results to return per page. It is very unlikely that setting this parameters to something
-            other than the default is useful. It exists for rare situations where the client is bandwidth constrained
+            Max number of results to return per page. It is very unlikely that
+            setting this parameter to something other than the default is useful.
+            It exists for rare situations where the client is bandwidth constrained
             or experiencing latency from large payload sizes.
 
         Returns

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -260,24 +260,6 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         data_concepts_object = self.get_type().build(data)
         return data_concepts_object
 
-    def _build_collection_elements(self,
-                                   collection: Iterable[dict]) -> Iterable[ResourceType]:
-        """
-        For each element in the collection, build the appropriate resource type.
-
-        Parameters
-        ---------
-        collection: Iterable[dict]
-            collection containing the elements to be built
-
-        Returns
-        -------
-        Iterable[ResourceType]
-            Resources in this collection.
-
-        """
-        return collection
-
     def list(self,
              page: Optional[int] = None,
              per_page: Optional[int] = 100) -> List[ResourceType]:

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -266,18 +266,17 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         """
         List all visible elements of the collection.
 
-        Leaving page and per_page as default values will return a list of all elements
+        page and per_page parameters of this method are deprecated and ignored. This method will as default values will return a list of all elements
         in the collection, paginating over all available pages.
 
         Parameters
         ---------
         page: int, optional
-            The "page" of results to list. Default is to read all pages and return
-            all results.  This option is deprecated.
+            [DEPRECATED][IGNORED] This parameter is ignored. To load individual pages lazily, use the list_all method. 
         per_page: int, optional
-            Max number of results to return per page.  This parameter is used when
-            making requests to the backend service.  If the page parameter is
-            specified it limits the maximum number of elements in the response.
+            Max number of results to return per page. It is very unlikely that setting this parameters to something
+            other than the default is useful. It exists for rare situations where the client is bandwidth constrained
+            or experiencing latency from large payload sizes.
 
         Returns
         -------
@@ -286,7 +285,7 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
 
         """
         # Convert the iterator to a list to avoid breaking existing client relying on lists
-        return [x for x in self.list_all()]
+        return [x for x in self.list_all(per_page=per_page)]
 
     def register(self, model: ResourceType, dry_run=False):
         """

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -2,6 +2,7 @@
 from abc import abstractmethod, ABC
 from typing import TypeVar, Type, List, Union, Optional, Iterator, Iterable
 from uuid import UUID, uuid4
+import deprecation
 
 from citrine._rest.collection import Collection
 from citrine._serialization import properties
@@ -259,25 +260,6 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         data_concepts_object = self.get_type().build(data)
         return data_concepts_object
 
-    def _fetch_page(self, page: Optional[int] = None, per_page: Optional[int] = None):
-        """
-        List all visible elements of the collection.  Does not handle pagination.
-
-        Parameters
-        ----------
-        page: Optional[int]
-            The page of results to list, 1-indexed (i.e. the first page is page=1)
-        per_page: Optional[int]
-            The number of results to list per page
-
-        Returns
-        -------
-        List[ResourceType]
-            Every object in this collection.
-
-        """
-        return self.filter_by_tags([], page, per_page), ""
-
     def _build_collection_elements(self,
                                    collection: Iterable[dict]) -> Iterable[ResourceType]:
         """
@@ -322,7 +304,7 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
 
         """
         # Convert the iterator to a list to avoid breaking existing client relying on lists
-        return list(super().list(page=page, per_page=per_page))
+        return [x for x in self.list_all()]
 
     def register(self, model: ResourceType, dry_run=False):
         """
@@ -444,6 +426,8 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
         data = self.session.get_resource(path)
         return self.build(data)
 
+    @deprecation.deprecated(details="filter_by_tags is deprecated due to poor "
+                                    "performance. Please use list_by_tag instead.")
     def filter_by_tags(self, tags: List[str],
                        page: Optional[int] = None, per_page: Optional[int] = None):
         """
@@ -483,6 +467,8 @@ class DataConceptsCollection(Collection[ResourceType], ABC):
             params=params)
         return [self.build(content) for content in response["contents"]]
 
+    @deprecation.deprecated(details="filter_by_name is deprecated due to poor "
+                                    "performance. Please use list_by_name instead.")
     def filter_by_name(self, name: str, exact: bool = False,
                        page: Optional[int] = None, per_page: Optional[int] = None):
         """

--- a/src/citrine/resources/data_concepts.py
+++ b/src/citrine/resources/data_concepts.py
@@ -1,6 +1,6 @@
 """Top-level class for all data concepts objects and collections thereof."""
 from abc import abstractmethod, ABC
-from typing import TypeVar, Type, List, Union, Optional, Iterator, Iterable
+from typing import TypeVar, Type, List, Union, Optional, Iterator
 from uuid import UUID, uuid4
 import deprecation
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,4 +9,4 @@ pytest-flake8==1.0.4
 factory-boy==2.12.0
 requests-mock==1.7.0
 strip-hints==0.1.8
-pandas==1.1.1
+pandas==0.25

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,4 +9,4 @@ pytest-flake8==1.0.4
 factory-boy==2.12.0
 requests-mock==1.7.0
 strip-hints==0.1.8
-pandas==0.25
+pandas==1.1.1

--- a/tests/resources/test_material_run.py
+++ b/tests/resources/test_material_run.py
@@ -138,7 +138,8 @@ def test_list_material_runs(collection, session):
         path='projects/{}/material-runs'.format(collection.project_id),
         params={
             'dataset_id': str(collection.dataset_id),
-            'tags': [],
+            'forward': True,
+            'ascending': True,
             'per_page': 100
         }
     )


### PR DESCRIPTION
# Citrine Python PR

## Description 
The Data object "list" and "filter" methods are very slow, and fail with large numbers of data objects in a dataset. This PR:
- Adds deprecation warnings to all remaining "filter_by" methods. 
- replaces the implementation of "list" with a simple call to "list_all" that wraps the iterator in a list comprehension. 

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
