### PR TITLE
Deduplicate list results by their uid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.63.2',
+      version='0.63.3',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.63.1',
+      version='0.63.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_rest/paginator.py
+++ b/src/citrine/_rest/paginator.py
@@ -21,7 +21,7 @@ class Paginator(Generic[ResourceType]):
                  search_params: Optional[dict] = None,
                  deduplicate: bool = True) -> Iterable[ResourceType]:
         """
-        A generic support class to paginate requests into an itcerable of a built object.
+        A generic support class to paginate requests into an iterable of a built object.
 
         Leaving page and per_page as default values will yield all elements in the
         collection, paginating over all available pages.

--- a/src/citrine/_rest/paginator.py
+++ b/src/citrine/_rest/paginator.py
@@ -1,5 +1,6 @@
 import warnings
 from typing import TypeVar, Generic, Callable, Optional, Iterable, Any, Tuple
+from uuid import uuid4
 
 ResourceType = TypeVar('ResourceType')
 
@@ -17,9 +18,10 @@ class Paginator(Generic[ResourceType]):
                  collection_builder: Callable[[Iterable[dict]], Iterable[ResourceType]],
                  page: Optional[int] = None,
                  per_page: int = 100,
-                 search_params: Optional[dict] = None) -> Iterable[ResourceType]:
+                 search_params: Optional[dict] = None,
+                 deduplicate: bool = True) -> Iterable[ResourceType]:
         """
-        A generic support class to paginate requests into an iterable of a built object.
+        A generic support class to paginate requests into an itcerable of a built object.
 
         Leaving page and per_page as default values will yield all elements in the
         collection, paginating over all available pages.
@@ -45,6 +47,9 @@ class Paginator(Generic[ResourceType]):
             page_fetcher function should have a key word argument "search_params" should it
             pass a request body to the target endpoint. If no search_params are supplied,
             no search_params argument will get passed to the page_fetcher function.
+        deduplicate: bool, optional
+            Whether or not to deduplicate the yielded resources by their uid.  The default
+            is true.
 
         Returns
         -------
@@ -62,6 +67,7 @@ class Paginator(Generic[ResourceType]):
 
         first_entity = None
         page_idx = page
+        uids = set()
 
         while True:
             subset_collection, next_uri = page_fetcher(page=page_idx, per_page=per_page,
@@ -80,7 +86,18 @@ class Paginator(Generic[ResourceType]):
                     # TODO: raise an exception once the APIs that ignore pagination are fixed
                     break
 
-                yield element
+                # Only return new uids.  This way, if an element shows up at the end of one page
+                # and then at the beginning of the next one because a new resource in the same
+                # collection was created, it is only returned from the list method once.  uids are
+                # unique, so this should be safe.  If a user is listing enough elements that the
+                # size of uids is too big, there will be other problems first. This could be
+                # replaced by a deque with a fixed size if memory is really an issue, at the cost
+                # of slower lookups.  Or something more complex for both :-)
+                # If no uid is available, create one, which will never deduplicate
+                uid = getattr(element, "uid", uuid4())
+                if not deduplicate or uid not in uids:
+                    uids.add(uid)
+                    yield element
 
                 if first_entity is None:
                     first_entity = current_entity

--- a/src/citrine/resources/gemtables.py
+++ b/src/citrine/resources/gemtables.py
@@ -122,7 +122,9 @@ class GemTableCollection(Collection[GemTable]):
             for item in collection:
                 yield self.build(item)
 
-        return self._paginator.paginate(fetch_versions, build_versions, page, per_page)
+        return self._paginator.paginate(
+            # Don't deduplicate on uid since uids are shared between versions
+            fetch_versions, build_versions, page, per_page, deduplicate=False)
 
     def list_by_config(self,
                        table_config_uid: UUID,
@@ -154,7 +156,9 @@ class GemTableCollection(Collection[GemTable]):
             for item in collection:
                 yield self.build(item)
 
-        return self._paginator.paginate(fetch_versions, build_versions, page, per_page)
+        return self._paginator.paginate(
+            # Don't deduplicate on uid since uids are shared between versions
+            fetch_versions, build_versions, page, per_page, deduplicate=False)
 
     def initiate_build(self, config: Union[TableConfig, str, UUID],
                        version: Union[str, UUID] = None) -> JobSubmissionResponse:

--- a/tests/rest/test_paginator.py
+++ b/tests/rest/test_paginator.py
@@ -1,4 +1,6 @@
 """Test the Paginator"""
+from uuid import uuid4
+
 from mock import Mock
 
 from citrine._rest.paginator import Paginator
@@ -6,29 +8,32 @@ from citrine._rest.paginator import Paginator
 
 def test_validate_mock_fetcher():
     """Just ensure our mock fetcher method does the right thing for what the paginator expects"""
-    mock_fetcher = mocked_fetcher("a", "b")
+    mock_fetcher = mocked_fetcher(DummyResource("a"), DummyResource("b"))
 
     # Make calls (and ignore arguments on the callable), and ensure we get back the above elements, each wrapped in a
     # list, and the final call should be an empty list.
-    assert mock_fetcher("a", "b") == (["a"], "next_uri")
-    assert mock_fetcher() == (["b"], "next_uri")
+    assert mock_fetcher(DummyResource("a"), DummyResource("b")) == ([DummyResource("a")], "next_uri")
+    assert mock_fetcher() == ([DummyResource("b")], "next_uri")
     assert mock_fetcher() == ([], "")
 
 
-def test_paginator_fetches_single_page():
-    # Return a single page with 2 elements
-    result = Paginator().paginate(mocked_fetcher(["a", "b"]), lambda x: x, per_page=2)
-    assert list(result) == ["a", "b"]
-
-
 def test_pagination_across_two_pages():
-    result = Paginator().paginate(mocked_fetcher("a", "b"), lambda x: x, per_page=1)
-    assert list(result) == ["a", "b"]
+    result = Paginator().paginate(mocked_fetcher(DummyResource("a"), DummyResource("b")), lambda x: x, per_page=1)
+    assert list(result) == [DummyResource("a"), DummyResource("b")]
 
 
 def test_pagination_stops_when_initial_item_repeated():
-    result = Paginator().paginate(mocked_fetcher("a", "b", "a"), lambda x: x, per_page=1)
-    assert list(result) == ["a", "b"]
+    a = DummyResource("a")
+    result = Paginator().paginate(mocked_fetcher(a, DummyResource("b"), a), lambda x: x, per_page=1)
+    assert list(result) == [a, DummyResource("b")]
+
+
+def test_pagination_deduplicates_repeated_intermediate_values():
+    a = DummyResource("a")
+    b = DummyResource("b")
+    c = DummyResource("c")
+    result = Paginator().paginate(mocked_fetcher(a, b, b, b, b, b, b, c, c), lambda x: x, per_page=1)
+    assert list(result) == [a, b, c]
 
 
 def mocked_fetcher(*args):
@@ -39,8 +44,21 @@ def mocked_fetcher(*args):
     This lets us mock a fetcher easily.
     """
     mock_fetcher = Mock()
-    args_in_lists = [list(a) for a in args]
+    args_in_lists = [[a] for a in args]
     args_in_lists = [(a, "next_uri") for a in args_in_lists]
     args_in_lists.append(([], ""))
     mock_fetcher.side_effect = list(args_in_lists)
     return mock_fetcher
+
+
+class DummyResource(object):
+    """
+    Dummy resource that stores a string val
+    """
+
+    def __init__(self, val: str):
+        self.val = val
+        self.uid = uuid4()
+
+    def __eq__(self, other):
+        return self.val == other.val

--- a/tests/rest/test_paginator.py
+++ b/tests/rest/test_paginator.py
@@ -6,32 +6,46 @@ from mock import Mock
 from citrine._rest.paginator import Paginator
 
 
+class DummyResource:
+    """
+    Dummy resource that stores a string val
+    """
+
+    def __init__(self, val: str):
+        self.val = val
+        self.uid = uuid4()
+
+    def __eq__(self, other):
+        return self.val == other.val
+
+
+a = DummyResource("a")
+b = DummyResource("b")
+c = DummyResource("c")
+
+
 def test_validate_mock_fetcher():
     """Just ensure our mock fetcher method does the right thing for what the paginator expects"""
     mock_fetcher = mocked_fetcher(DummyResource("a"), DummyResource("b"))
 
     # Make calls (and ignore arguments on the callable), and ensure we get back the above elements, each wrapped in a
     # list, and the final call should be an empty list.
-    assert mock_fetcher(DummyResource("a"), DummyResource("b")) == ([DummyResource("a")], "next_uri")
-    assert mock_fetcher() == ([DummyResource("b")], "next_uri")
+    assert mock_fetcher(a, b) == ([a], "next_uri")
+    assert mock_fetcher() == ([b], "next_uri")
     assert mock_fetcher() == ([], "")
 
 
 def test_pagination_across_two_pages():
-    result = Paginator().paginate(mocked_fetcher(DummyResource("a"), DummyResource("b")), lambda x: x, per_page=1)
-    assert list(result) == [DummyResource("a"), DummyResource("b")]
+    result = Paginator().paginate(mocked_fetcher(a, b), lambda x: x, per_page=1)
+    assert list(result) == [a, b]
 
 
 def test_pagination_stops_when_initial_item_repeated():
-    a = DummyResource("a")
-    result = Paginator().paginate(mocked_fetcher(a, DummyResource("b"), a), lambda x: x, per_page=1)
-    assert list(result) == [a, DummyResource("b")]
+    result = Paginator().paginate(mocked_fetcher(a, b, a), lambda x: x, per_page=1)
+    assert list(result) == [a, b]
 
 
 def test_pagination_deduplicates_repeated_intermediate_values():
-    a = DummyResource("a")
-    b = DummyResource("b")
-    c = DummyResource("c")
     result = Paginator().paginate(mocked_fetcher(a, b, b, b, b, b, b, c, c), lambda x: x, per_page=1)
     assert list(result) == [a, b, c]
 
@@ -44,21 +58,8 @@ def mocked_fetcher(*args):
     This lets us mock a fetcher easily.
     """
     mock_fetcher = Mock()
-    args_in_lists = [[a] for a in args]
-    args_in_lists = [(a, "next_uri") for a in args_in_lists]
+    args_in_lists = [[x] for x in args]
+    args_in_lists = [(x, "next_uri") for x in args_in_lists]
     args_in_lists.append(([], ""))
     mock_fetcher.side_effect = list(args_in_lists)
     return mock_fetcher
-
-
-class DummyResource(object):
-    """
-    Dummy resource that stores a string val
-    """
-
-    def __init__(self, val: str):
-        self.val = val
-        self.uid = uuid4()
-
-    def __eq__(self, other):
-        return self.val == other.val


### PR DESCRIPTION
# Citrine Python PR

## Description 

Since we're doing pagination-based listing, creates and deletes
to the collection being listed can result in index movement during
a multi-request list operation.  In particular, the repetition of
a list element from the end of one page to the beginning of the next
has been observed to occur when items are added to the list.  This
change keeps a list of the uids that have been encountered and skips
returning duplicates. If the listed object isn't a resource and
therefore doesn't have a uid, then no deduplication is performed.

This behavior can be toggled via a flag to assist future developers.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
