### PR TITLE
Removing ALPHA from basic predictors

### DIFF
--- a/docs/source/workflows/descriptors.rst
+++ b/docs/source/workflows/descriptors.rst
@@ -44,7 +44,7 @@ Both `SMILES <https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entr
 and `InChI <https://en.wikipedia.org/wiki/International_Chemical_Identifier>`__ are supported.
 The Molecular Structure Descriptor has no parameters other than a name.
 
-Formulation Descriptor
+Formulation Descriptor (ALPHA)
 -----------------------------------
 :class:`~citrine.informatics.descriptors.FormulationDescriptor` is used to represent variables that contain information
 about mixtures of other materials.

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -191,8 +191,8 @@ The following example demonstrates how to create an :class:`~citrine.informatics
 
 For an example of expression predictors used in a graph predictor, see :ref:`AI Engine Code Examples <graph_predictor_example>`.
 
-Ingredients to simple mixture predictor
----------------------------------------
+Ingredients to simple mixture predictor (ALPHA)
+--------------------------------------------------
 
 The :class:`~citrine.informatics.predictors.IngredientsToSimpleMixturePredictor` constructs a simple mixture from a list of ingredients.
 This predictor is only required to construct simple mixtures from CSV data sources.
@@ -288,8 +288,8 @@ The following example illustrates how an :class:`~citrine.informatics.predictors
         training_data=[data_source]
     )
 
-Simple mixture predictor
-------------------------
+Simple mixture predictora (ALPHA)
+--------------------------------------
 
 Simple mixtures may contain ingredients that are blends of other simple mixtures.
 Along the lines of the example above, hypertonic saline can be mixed with water to form isotonic saline.
@@ -321,8 +321,8 @@ The following example illustrates how a :class:`~citrine.informatics.predictors.
         training_data=[data_source]
     )
 
-Generalized mean property predictor
------------------------------------
+Generalized mean property predictor (ALPHA)
+---------------------------------------------
 
 Often, properties of a mixture are proportional to the properties of it's ingredients.
 For example, the density of a saline solution can be computed from the densities of water and salt multiplied by their respective amounts:
@@ -413,8 +413,8 @@ This predictor will compute a real descriptor with a key ``mean of property dens
 
 If ``p`` is given a value other than ``1.0``, that value will be included in the key for the feature, e.g. ``2.0-mean of property viscosity``.
 
-Ingredient fractions predictor
-------------------------------
+Ingredient fractions predictor (ALPHA)
+-----------------------------------------
 
 The :class:`~citrine.informatics.predictors.IngredientFractionsPredictor` featurizes ingredient fractions in a simple mixture.
 The predictor is configured by specifying a descriptor that contains simple mixture data and a list of known ingredients to featurize.
@@ -455,8 +455,8 @@ The response descriptors can be retrieved using:
 
 This will return a real descriptor for each featurized ingredient with bounds ``[0, 1]`` and key in the form ``'{ingredient} share in simple mixture'`` where ``{ingredient}`` is either ``water``, ``salt`` or ``boric acid``.
 
-Label fractions predictor
--------------------------
+Label fractions predictor (ALPHA)
+----------------------------------
 
 The :class:`~citrine.informatics.predictors.LabelFractionsPredictor` computes total fraction of ingredients with a given label.
 The predictor is configured by specifying a formulation descriptor that holds simple mixture data (i.e. recipes and ingredient labels) and a list of labels to featurize.

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -288,7 +288,7 @@ The following example illustrates how an :class:`~citrine.informatics.predictors
         training_data=[data_source]
     )
 
-Simple mixture predictora (ALPHA)
+Simple mixture predictor (ALPHA)
 --------------------------------------
 
 Simple mixtures may contain ingredients that are blends of other simple mixtures.

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.67.0',
+      version='0.68.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/informatics/data_sources.py
+++ b/src/citrine/informatics/data_sources.py
@@ -11,7 +11,7 @@ from citrine.resources.file_link import FileLink
 
 
 class DataSource(PolymorphicSerializable['DataSource']):
-    """[ALPHA] A source of data for the AI engine.
+    """A source of data for the AI engine.
 
     Data source provides a polymorphic interface for specifying different kinds of data as the
     training data for predictors and the input data for some design spaces.
@@ -45,7 +45,7 @@ class DataSource(PolymorphicSerializable['DataSource']):
 
 
 class CSVDataSource(Serializable['CSVDataSource'], DataSource):
-    """[ALPHA] A data source based on a CSV file stored on the data platform.
+    """A data source based on a CSV file stored on the data platform.
 
     Parameters
     ----------
@@ -112,11 +112,3 @@ class GemTableDataSource(Serializable['GemTableDataSource'], DataSource):
         self.table_id: UUID = table_id
         self.table_version: Union[int, str] = table_version
         self.formulation_descriptor: Optional[FormulationDescriptor] = formulation_descriptor
-
-
-def AraTableDataSource(*args, **kwargs):  # pragma: no cover
-    """[DEPRECATED] Use GemTableDataSource instead."""
-    from warnings import warn
-    warn("AraTableDataSource is deprecated and will soon be removed. "
-         "Please use GemTableDataSource instead", DeprecationWarning)
-    return GemTableDataSource(*args, **kwargs)

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -8,7 +8,6 @@ from citrine._serialization import properties
 __all__ = ['Descriptor',
            'RealDescriptor',
            'ChemicalFormulaDescriptor',
-           'InorganicDescriptor',
            'MolecularStructureDescriptor',
            'CategoricalDescriptor',
            'FormulationDescriptor']

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -15,7 +15,7 @@ __all__ = ['Descriptor',
 
 
 class Descriptor(PolymorphicSerializable['Descriptor']):
-    """[ALPHA] A Citrine Descriptor describes the range of values that a quantity can take on.
+    """A Citrine Descriptor describes the range of values that a quantity can take on.
 
     Abstract type that returns the proper type given a serialized dict.
     """
@@ -39,7 +39,7 @@ class Descriptor(PolymorphicSerializable['Descriptor']):
 
 
 class RealDescriptor(Serializable['RealDescriptor'], Descriptor):
-    """[ALPHA] A descriptor to hold real-valued numbers.
+    """A descriptor to hold real-valued numbers.
 
     Parameters
     ----------
@@ -86,7 +86,7 @@ class RealDescriptor(Serializable['RealDescriptor'], Descriptor):
 
 
 class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descriptor):
-    """[ALPHA] Captures domain-specific context about a stoichiometric chemical formula.
+    """Captures domain-specific context about a stoichiometric chemical formula.
 
     Parameters
     ----------
@@ -120,17 +120,9 @@ class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descr
         return "ChemicalFormulaDescriptor(key={})".format(self.key)
 
 
-def InorganicDescriptor(key: str, threshold: Optional[float] = 1.0):
-    """[DEPRECATED] Use ChemicalFormulaDescriptor instead."""
-    from warnings import warn
-    warn("InorganicDescriptor is deprecated and will soon be removed. "
-         "Use ChemicalFormulaDescriptor instead.", DeprecationWarning)
-    return ChemicalFormulaDescriptor(key)
-
-
 class MolecularStructureDescriptor(Serializable['MolecularStructureDescriptor'], Descriptor):
     """
-    [ALPHA] Material descriptor for an organic molecule.
+    Material descriptor for an organic molecule.
 
     Accepts SMILES, IUPAC, and InChI String values.
 
@@ -164,7 +156,7 @@ class MolecularStructureDescriptor(Serializable['MolecularStructureDescriptor'],
 
 
 class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):
-    """[ALPHA] A descriptor to hold categorical variables.
+    """A descriptor to hold categorical variables.
 
     An exhaustive list of categorical values may be supplied.
 

--- a/src/citrine/informatics/modules.py
+++ b/src/citrine/informatics/modules.py
@@ -7,7 +7,7 @@ from citrine._serialization.serializable import Serializable
 
 
 class Module(PolymorphicSerializable['Module']):
-    """[ALPHA] A Citrine Module is a reusable computational tool used to construct a workflow.
+    """A Citrine Module is a reusable computational tool used to construct a workflow.
 
     Abstract type that returns the proper type given a serialized dict.
 

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -1,6 +1,5 @@
 """Tools for working with Predictors."""
 # flake8: noqa
-from collections import Iterable
 from typing import List, Optional, Type, Union, Mapping
 from uuid import UUID
 from warnings import warn
@@ -29,7 +28,7 @@ __all__ = ['DeprecatedExpressionPredictor',
 
 
 class Predictor(Module):
-    """[ALPHA] Module that describes the ability to compute/predict properties of materials.
+    """Module that describes the ability to compute/predict properties of materials.
 
     Abstract type that returns the proper type given a serialized dict. subtype
     based on the 'type' value of the passed in dict.
@@ -91,7 +90,7 @@ class Predictor(Module):
 
 
 class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
-    """[ALPHA] A predictor interface that builds a simple graphical model.
+    """A predictor interface that builds a simple graphical model.
 
     The model connects the set of inputs through latent variables to the outputs.
     Supported complex inputs (such as chemical formulas) are auto-featurized and machine learning
@@ -174,7 +173,7 @@ class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
 
 
 class GraphPredictor(Serializable['GraphPredictor'], Predictor):
-    """[ALPHA] A predictor interface that stitches other predictors together.
+    """A predictor interface that stitches other predictors together.
 
     Parameters
     ----------
@@ -396,7 +395,7 @@ class DeprecatedExpressionPredictor(Serializable['DeprecatedExpressionPredictor'
 
 
 class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
-    """[ALPHA] A predictor that computes an output from an expression and set of bounded inputs.
+    """A predictor that computes an output from an expression and set of bounded inputs.
 
     .. seealso::
        If you are using the deprecated predictor please see

--- a/src/citrine/resources/module.py
+++ b/src/citrine/resources/module.py
@@ -7,7 +7,7 @@ from citrine.informatics.modules import Module
 
 
 class ModuleCollection(Collection[Module]):
-    """[ALPHA] Represents the collection of all modules as well as the resources belonging to it.
+    """Represents the collection of all modules as well as the resources belonging to it.
 
     Parameters
     ----------

--- a/src/citrine/resources/predictor.py
+++ b/src/citrine/resources/predictor.py
@@ -10,7 +10,7 @@ CreationType = TypeVar('CreationType', bound=Predictor)
 
 
 class PredictorCollection(Collection[Predictor]):
-    """[ALPHA] Represents the collection of all predictors for a project.
+    """Represents the collection of all predictors for a project.
 
     Parameters
     ----------

--- a/tests/informatics/test_descriptors.py
+++ b/tests/informatics/test_descriptors.py
@@ -4,7 +4,6 @@ import json
 import pytest
 
 from citrine.informatics.descriptors import *
-from citrine.informatics.descriptors import InorganicDescriptor
 
 
 @pytest.fixture(params=[
@@ -43,12 +42,6 @@ def test_buggy_deserialization():
 def test_invalid_eq(descriptor):
     other = None
     assert not descriptor == other
-
-
-def test_inorganic_deprecated():
-    # InorganicDescriptor is still callable but creates a ChemicalFormulaDescriptor
-    old_descriptor = InorganicDescriptor("formula")
-    assert isinstance(old_descriptor, ChemicalFormulaDescriptor)
 
 
 def test_string_rep(descriptor):


### PR DESCRIPTION
# Citrine Python PR

## Description 
The predictor system, graph predictor, expression predictor,
and simple ml predictor are out of alpha.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
