### PR TITLE
Increased the default per_page from 100 to 1000 for project listing and search

### DIFF
--- a/scripts/Dockerfile.pytest
+++ b/scripts/Dockerfile.pytest
@@ -11,5 +11,5 @@ RUN pip install -U -r test_requirements.txt
 COPY . .
 RUN pip install --no-deps -e .
 ENTRYPOINT ["pytest", "--cov=src/", "--cov-report", "term-missing", "--cov-report", "term:skip-covered", \
-    "--cov-fail-under=100", "-s"]
+    "--cov-config=tox.ini", "--cov-fail-under=100", "-s", "-r", "."]
 CMD ["-r", "."]

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.67.0',
+      version='0.68.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.68.0',
+      version='0.69.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -407,8 +407,35 @@ class ProjectCollection(Collection[Project]):
         """
         return super().register(Project(name, description))
 
+    def list(self,
+             page: Optional[int] = None,
+             per_page: int = 1000) -> Iterable[Project]:
+        """
+        List projects using pagination.
+
+        Leaving page and per_page as default values will yield all elements in the
+        collection, paginating over all available pages.
+
+        Parameters
+        ---------
+        page: int, optional
+            The "page" of results to list. Default is to read all pages and yield
+            all results.  This option is deprecated.
+        per_page: int, optional
+            Max number of results to return per page. Default is 1000.  This parameter
+            is used when making requests to the backend service.  If the page parameter
+            is specified it limits the maximum number of elements in the response.
+
+        Returns
+        -------
+        Iterable[Project]
+            Projects in this collection.
+
+        """
+        return super().list(page, per_page)
+
     def search(self, search_params: Optional[dict] = None,
-               per_page: int = 100) -> Iterable[Project]:
+               per_page: int = 1000) -> Iterable[Project]:
         """
         Search for projects matching the desired name or description.
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,4 +9,4 @@ pytest-flake8==1.0.4
 factory-boy==2.12.0
 requests-mock==1.7.0
 strip-hints==0.1.8
-pandas==0.25
+pandas==1.1.2

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,4 +9,4 @@ pytest-flake8==1.0.4
 factory-boy==2.12.0
 requests-mock==1.7.0
 strip-hints==0.1.8
-pandas==1.1.2
+pandas==0.25.3

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -272,7 +272,7 @@ def test_list_projects(collection, session):
 
     # Then
     assert 1 == session.num_calls
-    expected_call = FakeCall(method='GET', path='/projects', params={'per_page': 100})
+    expected_call = FakeCall(method='GET', path='/projects', params={'per_page': 1000})
     assert expected_call == session.last_call
     assert 5 == len(projects)
 
@@ -288,7 +288,7 @@ def test_list_projects_filters_non_projects(collection, session):
 
     # Then
     assert 1 == session.num_calls
-    expected_call = FakeCall(method='GET', path='/projects', params={'per_page': 100})
+    expected_call = FakeCall(method='GET', path='/projects', params={'per_page': 1000})
     assert expected_call == session.last_call
     assert 5 == len(projects)   # The non-project data is filtered out
 
@@ -327,7 +327,7 @@ def test_search_projects(collection, session):
     # Then
     assert 1 == session.num_calls
     expected_call = FakeCall(method='POST', path='/projects/search', 
-                                        params={'per_page': 100}, json={'search_params': search_params})
+                                        params={'per_page': 1000}, json={'search_params': search_params})
     assert expected_call == session.last_call
     assert len(expected_response) == len(projects)
 


### PR DESCRIPTION
# Citrine Python PR

## Description 

This is a simple PR that increases the default per_page value from 100 to 1000.  Load testing the project listing and search endpoints has shown that a value of 100 yields poor performance when listing a large number of projects (> 40K projects).  Using a value of 1000 does not significantly increase query latency and reduces the number of API calls by a factor of 10.  This should result in much better performance and less load on the accounts DB, roughly 10X faster when paginating a large number of projects.

This PR compliments an optimization to the accounts service that increases the performance by roughly 2X, based on local load testing.

This PR leaves the default collection per_page value to avoid unintended impacts on other services.

I updated the version of Pandas used in test_requirements.txt because version 0.25 was not using binary wheel files and the Docker build was failing after more than 10 minutes.  The current version installs in seconds with a binary wheel.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
