### PR TITLE
add support for 403 status code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.71.0',
+      version='0.71.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -149,6 +149,9 @@ class Session(requests.Session):
             elif response.status_code == 401:
                 logger.error('%s %s %s', response.status_code, method, path)
                 raise Unauthorized(path, response)
+            elif response.status_code == 403:
+                logger.error('%s %s %s', response.status_code, method, path)
+                raise Unauthorized(path, response)
             elif response.status_code == 404:
                 logger.error('%s %s %s', response.status_code, method, path)
                 raise NotFound(path, response)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -189,7 +189,7 @@ def test_post_refreshes_token_when_denied(session: Session):
 
 def test_delete_unauthorized_without_json(session: Session):
     with requests_mock.Mocker() as m:
-        m.delete('http://citrine-testing.fake/api/v1/bar/something', status_code=401)
+        m.delete('http://citrine-testing.fake/api/v1/bar/something', status_code=403)
 
         with pytest.raises(Unauthorized):
             session.delete_resource('/bar/something')

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -187,6 +187,15 @@ def test_post_refreshes_token_when_denied(session: Session):
     assert datetime(2019, 3, 14) == session.access_token_expiration
 
 
+# this test exists to provide 100% coverage for the legacy 401 status on Unauthorized responses
+def test_delete_unauthorized_without_json_legacy(session: Session):
+    with requests_mock.Mocker() as m:
+        m.delete('http://citrine-testing.fake/api/v1/bar/something', status_code=401)
+
+        with pytest.raises(Unauthorized):
+            session.delete_resource('/bar/something')
+
+
 def test_delete_unauthorized_without_json(session: Session):
     with requests_mock.Mocker() as m:
         m.delete('http://citrine-testing.fake/api/v1/bar/something', status_code=403)


### PR DESCRIPTION
# Citrine Python PR

## Description 
The backend data service currently returns a 401 for unauthorized access to projects. This is an incorrect status code, as it should be a 403. In preparation for updating the backend, this change adds support for handling a 403 status code.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
