### PR TITLE
Added an optional Unit type to IngredientQuantityByProcessAndName

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.71.1',
+      version='0.72.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.71.0',
+      version='0.71.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/gemtables/variables.py
+++ b/src/citrine/gemtables/variables.py
@@ -410,6 +410,7 @@ class IngredientQuantityByProcessAndName(
     type_selector = properties.Enumeration(DataObjectTypeSelector, "type_selector")
     typ = properties.String('type', default="ing_quantity_by_process_and_name",
                             deserializable=False)
+    unit = properties.Optional(properties.String, "unit")
 
     def _attrs(self) -> List[str]:
         return ["name", "headers", "process_template", "ingredient_name", "quantity_dimension",
@@ -421,13 +422,15 @@ class IngredientQuantityByProcessAndName(
                  process_template: LinkByUID,
                  ingredient_name: str,
                  quantity_dimension: IngredientQuantityDimension,
-                 type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN):
+                 type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN,
+                 unit: str = None):
         self.name = name
         self.headers = headers
         self.process_template = process_template
         self.ingredient_name = ingredient_name
         self.quantity_dimension = quantity_dimension
         self.type_selector = type_selector
+        self.unit = unit
 
 
 class RootIdentifier(Serializable['RootIdentifier'], Variable):

--- a/src/citrine/gemtables/variables.py
+++ b/src/citrine/gemtables/variables.py
@@ -399,6 +399,10 @@ class IngredientQuantityByProcessAndName(
         :class:`~citrine.gemtables.variables.IngredientQuantityDimension`
     type_selector: DataObjectTypeSelector
         strategy for selecting data object types to consider when matching, defaults to PREFER_RUN
+    unit: str
+        an optional unit: only ingredient quantities that are convertable to this unit will be
+        matched. note that this parameter is mandatory when quantity_dimension is
+        IngredientQuantityDimension.ABSOLUTE.
 
     """
 
@@ -423,7 +427,7 @@ class IngredientQuantityByProcessAndName(
                  ingredient_name: str,
                  quantity_dimension: IngredientQuantityDimension,
                  type_selector: DataObjectTypeSelector = DataObjectTypeSelector.PREFER_RUN,
-                 unit: str = None):
+                 unit: Optional[str] = None):
         self.name = name
         self.headers = headers
         self.process_template = process_template

--- a/tests/gemtable/test_variables.py
+++ b/tests/gemtable/test_variables.py
@@ -17,7 +17,7 @@ from gemd.entity.link_by_uid import LinkByUID
     IngredientIdentifierByProcessTemplateAndName(name="ingredient id", headers=["density"], process_template=LinkByUID(scope="template", id="process"), ingredient_name="ingredient", scope="scope"),
     IngredientIdentifierInOutput(name="ingredient id", headers=["ingredient id"], ingredient_name="ingredient", process_templates=[LinkByUID(scope="template", id="object")], scope="scope"),
     IngredientLabelByProcessAndName(name="ingredient label", headers=["label"], process_template=LinkByUID(scope="template", id="process"), ingredient_name="ingredient", label="label"),
-    IngredientQuantityByProcessAndName(name="ingredient quantity dimension", headers=["quantity"], process_template=LinkByUID(scope="template", id="process"), ingredient_name="ingredient", quantity_dimension=IngredientQuantityDimension.ABSOLUTE),
+    IngredientQuantityByProcessAndName(name="ingredient quantity dimension", headers=["quantity"], process_template=LinkByUID(scope="template", id="process"), ingredient_name="ingredient", quantity_dimension=IngredientQuantityDimension.ABSOLUTE, unit='kg'),
     IngredientQuantityInOutput(name="ingredient quantity", headers=["ingredient quantity"], ingredient_name="ingredient", quantity_dimension=IngredientQuantityDimension.MASS, process_templates=[LinkByUID(scope="template", id="object")]),
     RootIdentifier(name="root id", headers=["id"], scope="scope")
 ])


### PR DESCRIPTION
This adds the optional 'unit' to IngredientQuantityByProcessAndName, necessary for a proper filter using absolute quantities.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
