### PR TITLE
Update data_extraction.rst

### DIFF
--- a/docs/source/data_extraction.rst
+++ b/docs/source/data_extraction.rst
@@ -204,7 +204,7 @@ This identifier can be used to get the status of the job via the ``get_job_statu
 The :class:`~citrine.resources.ara_job.JobStatusResponse` contains a ``status`` string describing the state of the job and an ``output`` map that contains the table id and version.
 
 The table id and version can be used to get a :class:`~citrine.resources.table.Table` resource that provides access the table.
-You can also use the :class:`~citrine.resources.ara_job.JobStatusResponse` to return the :class:`~citrine.resources.table.Table` resource directly with the ``get_by_build_job`` method.
+You can also use the :class:`~citrine.resources.job.JobStatusResponse` to return the :class:`~citrine.resources.gemtables.GemTable` resource directly with the ``get_by_build_job`` method.
 Just like the :class:`~citrine.resources.file_link.FileLink` resource, :class:`~citrine.resources.table.Table` does not literally contain the table but does expose a ``read`` method that will download it.
 
 Available Row Definitions

--- a/docs/source/data_extraction.rst
+++ b/docs/source/data_extraction.rst
@@ -241,7 +241,7 @@ There are several ways to define variables that take their values from Attribute
   * :class:`~citrine.gemtables.variables.RootInfo`: for fields defined on the material at the root of the Material History, like the name of the material
   * :class:`~citrine.gemtables.variables.RootIdentifier`: for the id of the Material History, which can be used as a unique identifier for the rows
   * :class:`~citrine.gemtables.variables.IngredientIdentifierByProcessTemplateAndName`: for the id of the material being used in an ingredient, which can be used as a key for looking up that input material
-  * :class:`~citrine.gemtables.variables.IngredientIdentifierInOutput`: for the id the material being used in an ingredient used in multiple processes
+  * :class:`~citrine.gemtables.variables.IngredientIdentifierInOutput`: for the id of the material being used in an ingredient used in multiple processes
   * :class:`~citrine.gemtables.variables.IngredientLabelByProcessAndName`: for a boolean that indicates whether an ingredient is assigned a given label
 
 * Compound Variables

--- a/docs/source/data_extraction.rst
+++ b/docs/source/data_extraction.rst
@@ -234,14 +234,14 @@ There are several ways to define variables that take their values from Attribute
   * :class:`~citrine.gemtables.variables.AttributeByTemplateAfterProcessTemplate`: for when measurements are distinguished by the process that precedes them
   * :class:`~citrine.gemtables.variables.AttributeInOutput`: for when attributes occur both in a process output and one or more of its inputs
   * :class:`~citrine.gemtables.variables.IngredientQuantityByProcessAndName`: for the specific case of the volume fraction, mass fraction, number fraction, or absolute quantity of an ingredient
-  * :class:`~citrine.gemtables.variables.IngredientQuantityInOutput`: for the quantity an ingredient used in multiple processes
+  * :class:`~citrine.gemtables.variables.IngredientQuantityInOutput`: for the quantity of an ingredient between the terminal material and a given set of processes (useful for ingredients used in multiple processes)
 
 * Identifiers
 
   * :class:`~citrine.gemtables.variables.RootInfo`: for fields defined on the material at the root of the Material History, like the name of the material
   * :class:`~citrine.gemtables.variables.RootIdentifier`: for the id of the Material History, which can be used as a unique identifier for the rows
   * :class:`~citrine.gemtables.variables.IngredientIdentifierByProcessTemplateAndName`: for the id of the material being used in an ingredient, which can be used as a key for looking up that input material
-  * :class:`~citrine.gemtables.variables.IngredientIdentifierInOutput`: for the id of the material being used in an ingredient used in multiple processes
+  * :class:`~citrine.gemtables.variables.IngredientIdentifierInOutput`: for the id of a material used in an ingredient between the terminal material and a given set of processes (useful for ingredients used in multiple processes)
   * :class:`~citrine.gemtables.variables.IngredientLabelByProcessAndName`: for a boolean that indicates whether an ingredient is assigned a given label
 
 * Compound Variables

--- a/docs/source/data_extraction.rst
+++ b/docs/source/data_extraction.rst
@@ -171,41 +171,30 @@ Registered Table Configs can be built into GEM Tables. For example:
    
 The above will build a table, wait for the build job to complete, and save the table locally.
    
-However, GEM Tables are sometimes large and time-consuming to build, so the build process can be performed asynchronously.
-The steps are:
-
-1. Submit a GEM Table Build Job
-2. Poll the Job Status until it is a ``Success`` or ``Failure``
-3. (If success) Get the built table resource
-4. (If success) Download the table
-
+However, GEM Tables are sometimes large and time-consuming to build, so the build process can be performed asynchronously with the ``initiate_build`` method.
 For example:
 
 .. code-block:: python
 
-    from time import sleep
-    # 1. Submit the GEM Table build job
     job = project.tables.initiate_build(table_config)
-    # 2. Poll the Job Status every second
-    while True:
-        status = project.table_configs.get_job_status(job.job_id)
-        if status.status in ['Success', 'Failure']:
-            break
-        sleep(1)
-    if status.status == 'Success':
-        # 3. Get the table resource as an object
-        table = project.tables.get_by_build_job(job)
-        # 4. Download the table
-        project.tables.read(table, "./my_table.csv")
 
 The return type of the ``initiate_build`` method is a :class:`~citrine.resources.job.JobSubmissionResponse` that contains a unique identifier for the submitted job.
 
 This identifier can be used to get the status of the job via the ``get_job_status`` method, which returns a :class:`~citrine.resources.ara_job.JobStatusResponse`.
 The :class:`~citrine.resources.ara_job.JobStatusResponse` contains a ``status`` string describing the state of the job and an ``output`` map that contains the table id and version.
-
 The table id and version can be used to get a :class:`~citrine.resources.table.Table` resource that provides access the table.
+
 You can also use the :class:`~citrine.resources.job.JobStatusResponse` to return the :class:`~citrine.resources.gemtables.GemTable` resource directly with the ``get_by_build_job`` method.
 Just like the :class:`~citrine.resources.file_link.FileLink` resource, :class:`~citrine.resources.table.Table` does not literally contain the table but does expose a ``read`` method that will download it.
+
+For example, once the above ``initiate_build`` method has completed:
+
+.. code-block:: python
+
+   # Get the table resource as an object
+   table = project.tables.get_by_build_job(job)
+   # Download the table
+   project.tables.read(table, "./my_table.csv")
 
 Available Row Definitions
 -------------------------

--- a/docs/source/data_extraction.rst
+++ b/docs/source/data_extraction.rst
@@ -198,7 +198,7 @@ For example:
         # 4. Download the table
         project.tables.read(table, "./my_table.csv")
 
-The return type of the ``initiate_build`` method is a :class:`~citrine.resources.ara_job.JobSubmissionResponse` that contains a unique identifier for the submitted job.
+The return type of the ``initiate_build`` method is a :class:`~citrine.resources.job.JobSubmissionResponse` that contains a unique identifier for the submitted job.
 
 This identifier can be used to get the status of the job via the ``get_job_status`` method, which returns a :class:`~citrine.resources.ara_job.JobStatusResponse`.
 The :class:`~citrine.resources.ara_job.JobStatusResponse` contains a ``status`` string describing the state of the job and an ``output`` map that contains the table id and version.

--- a/docs/source/data_extraction.rst
+++ b/docs/source/data_extraction.rst
@@ -180,8 +180,6 @@ For example:
 
 The return type of the ``initiate_build`` method is a :class:`~citrine.resources.job.JobSubmissionResponse` that contains a unique identifier for the submitted job.
 
-This identifier can be used to get the status of the job via the ``get_job_status`` method, which returns a :class:`~citrine.resources.ara_job.JobStatusResponse`.
-The :class:`~citrine.resources.ara_job.JobStatusResponse` contains a ``status`` string describing the state of the job and an ``output`` map that contains the table id and version.
 The table id and version can be used to get a :class:`~citrine.resources.table.Table` resource that provides access the table.
 
 You can also use the :class:`~citrine.resources.job.JobStatusResponse` to return the :class:`~citrine.resources.gemtables.GemTable` resource directly with the ``get_by_build_job`` method.

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.72.2',
+      version='0.72.3',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.71.1',
+      version='0.72.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.71.0',
+      version='0.71.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',


### PR DESCRIPTION
# Citrine Python PR

## Description 
Updates to table documentation to:
* Clarify that Material UIDs are returned by `IngredientIdentifierInOutput`
* Update the build table examples to include `build_from_config`, `initiate_build`, and `get_by_build_job` methods.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [N/A] I have added tests for 100% coverage
- [N/A] I have written Numpy-style docstrings for every method and class.
- [x] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
