### PR TITLE
Make serde base class behavior explicit with "override"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.71.0',
+      version='0.71.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -36,6 +36,9 @@ class Predictor(Module):
     """
 
     _response_key = None
+    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
+    name = _properties.String('config.name')
+    description = _properties.Optional(_properties.String(), 'config.description')
 
     def post_build(self, project_id: UUID, data: dict):
         """Executes after a .build() is called in [[PredictorCollection]]."""
@@ -57,6 +60,7 @@ class Predictor(Module):
             "IngredientFractions": IngredientFractionsPredictor,
         }
         typ = type_dict.get(data['config']['type'])
+        print("Got type {}".format(typ))
 
         if typ is not None:
             return typ
@@ -118,9 +122,6 @@ class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
 
     """
 
-    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
-    name = _properties.String('config.name')
-    description = _properties.Optional(_properties.String(), 'config.description')
     inputs = _properties.List(_properties.Object(Descriptor), 'config.inputs')
     outputs = _properties.List(_properties.Object(Descriptor), 'config.outputs')
     latent_variables = _properties.List(_properties.Object(Descriptor), 'config.latent_variables')
@@ -193,9 +194,6 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
 
     """
 
-    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
-    name = _properties.String('config.name')
-    description = _properties.String('config.description')
     predictors = _properties.List(_properties.Union(
         [_properties.UUID, _properties.Object(Predictor)]), 'config.predictors')
     training_data = _properties.List(_properties.Object(DataSource), 'config.training_data')
@@ -340,9 +338,6 @@ class DeprecatedExpressionPredictor(Serializable['DeprecatedExpressionPredictor'
 
     """
 
-    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
-    name = _properties.String('config.name')
-    description = _properties.String('config.description')
     expression = _properties.String('config.expression')
     output = _properties.Object(RealDescriptor, 'config.output')
     aliases = _properties.Optional(_properties.Mapping(_properties.String, _properties.String), 'config.aliases')
@@ -418,9 +413,6 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
 
     """
 
-    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
-    name = _properties.String('config.name')
-    description = _properties.String('config.description')
     expression = _properties.String('config.expression')
     output = _properties.Object(RealDescriptor, 'config.output')
     aliases = _properties.Mapping(_properties.String, _properties.Object(RealDescriptor), 'config.aliases')
@@ -532,9 +524,6 @@ class MolecularStructureFeaturizer(Serializable['MolecularStructureFeaturizer'],
 
     """
 
-    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
-    name = _properties.String('config.name')
-    description = _properties.String('config.description')
     descriptor = _properties.Object(Descriptor, 'config.descriptor')
     features = _properties.List(_properties.String, 'config.features')
     excludes = _properties.List(_properties.String, 'config.excludes')
@@ -604,9 +593,6 @@ class IngredientsToSimpleMixturePredictor(
 
     """
 
-    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
-    name = _properties.String('config.name')
-    description = _properties.String('config.description')
     output = _properties.Object(FormulationDescriptor, 'config.output')
     id_to_quantity = _properties.Mapping(_properties.String, _properties.Object(RealDescriptor),
                                          'config.id_to_quantity')
@@ -700,9 +686,6 @@ class GeneralizedMeanPropertyPredictor(
 
     """
 
-    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
-    name = _properties.String('config.name')
-    description = _properties.String('config.description')
     input_descriptor = _properties.Object(FormulationDescriptor, 'config.input')
     properties = _properties.List(_properties.String, 'config.properties')
     p = _properties.Float('config.p')
@@ -789,9 +772,6 @@ class SimpleMixturePredictor(Serializable['SimpleMixturePredictor'], Predictor):
 
     """
 
-    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
-    name = _properties.String('config.name')
-    description = _properties.String('config.description')
     input_descriptor = _properties.Object(FormulationDescriptor, 'config.input')
     output_descriptor = _properties.Object(FormulationDescriptor, 'config.output')
     training_data = _properties.List(_properties.Object(DataSource), 'config.training_data')
@@ -855,9 +835,6 @@ class LabelFractionsPredictor(Serializable['LabelFractionsPredictor'], Predictor
 
     """
 
-    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
-    name = _properties.String('config.name')
-    description = _properties.String('config.description')
     input_descriptor = _properties.Object(FormulationDescriptor, 'config.input')
     labels = _properties.List(_properties.String, 'config.labels')
     typ = _properties.String('config.type', default='LabelFractions',
@@ -920,9 +897,6 @@ class IngredientFractionsPredictor(Serializable["IngredientFractionsPredictor"],
         This list should contain all possible ingredients.
         If an unknown ingredient is encountered, an error will be thrown.
     """
-    uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
-    name = _properties.String('config.name')
-    description = _properties.String('config.description')
     input_descriptor = _properties.Object(FormulationDescriptor, 'config.input')
     ingredients = _properties.List(_properties.String, 'config.ingredients')
 

--- a/src/citrine/informatics/predictors.py
+++ b/src/citrine/informatics/predictors.py
@@ -39,6 +39,19 @@ class Predictor(Module):
     uid = _properties.Optional(_properties.UUID, 'id', serializable=False)
     name = _properties.String('config.name')
     description = _properties.Optional(_properties.String(), 'config.description')
+    status = _properties.Optional(_properties.String(), 'status', serializable=False)
+    status_info = _properties.Optional(
+        _properties.List(_properties.String()),
+        'status_info',
+        serializable=False
+    )
+    archived = _properties.Boolean('archived', default=False)
+    experimental = _properties.Boolean("experimental", serializable=False, default=True)
+    experimental_reasons = _properties.Optional(
+        _properties.List(_properties.String()),
+        'experimental_reasons',
+        serializable=False
+    )
 
     def post_build(self, project_id: UUID, data: dict):
         """Executes after a .build() is called in [[PredictorCollection]]."""
@@ -127,19 +140,6 @@ class SimpleMLPredictor(Serializable['SimplePredictor'], Predictor):
     latent_variables = _properties.List(_properties.Object(Descriptor), 'config.latent_variables')
     training_data = _properties.List(_properties.Object(DataSource), 'config.training_data')
     typ = _properties.String('config.type', default='Simple', deserializable=False)
-    status = _properties.Optional(_properties.String(), 'status', serializable=False)
-    status_info = _properties.Optional(
-        _properties.List(_properties.String()),
-        'status_info',
-        serializable=False
-    )
-    archived = _properties.Boolean('archived', default=False)
-    experimental = _properties.Boolean("experimental", serializable=False, default=True)
-    experimental_reasons = _properties.Optional(
-        _properties.List(_properties.String()),
-        'experimental_reasons',
-        serializable=False
-    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -201,18 +201,6 @@ class GraphPredictor(Serializable['GraphPredictor'], Predictor):
     # Graph predictors may not be embedded in other predictors, hence while status is optional
     # for deserializing most predictors, it is required for deserializing a graph
     status = _properties.String('status', serializable=False)
-    status_info = _properties.Optional(
-        _properties.List(_properties.String()),
-        'status_info',
-        serializable=False
-    )
-    experimental = _properties.Boolean("experimental", serializable=False, default=True)
-    experimental_reasons = _properties.Optional(
-        _properties.List(_properties.String()),
-        'experimental_reasons',
-        serializable=False
-    )
-    archived = _properties.Boolean('archived', default=False)
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -342,20 +330,6 @@ class DeprecatedExpressionPredictor(Serializable['DeprecatedExpressionPredictor'
     output = _properties.Object(RealDescriptor, 'config.output')
     aliases = _properties.Optional(_properties.Mapping(_properties.String, _properties.String), 'config.aliases')
     typ = _properties.String('config.type', default='Expression', deserializable=False)
-    status = _properties.Optional(_properties.String(), 'status', serializable=False)
-    status_info = _properties.Optional(
-        _properties.List(_properties.String()),
-        'status_info',
-        serializable=False
-    )
-    experimental = _properties.Boolean("experimental", serializable=False, default=True)
-    experimental_reasons = _properties.Optional(
-        _properties.List(_properties.String()),
-        'experimental_reasons',
-        serializable=False
-    )
-
-    archived = _properties.Boolean('archived', default=False)
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -417,19 +391,6 @@ class ExpressionPredictor(Serializable['ExpressionPredictor'], Predictor):
     output = _properties.Object(RealDescriptor, 'config.output')
     aliases = _properties.Mapping(_properties.String, _properties.Object(RealDescriptor), 'config.aliases')
     typ = _properties.String('config.type', default='AnalyticExpression', deserializable=False)
-    status = _properties.Optional(_properties.String(), 'status', serializable=False)
-    status_info = _properties.Optional(
-        _properties.List(_properties.String()),
-        'status_info',
-        serializable=False
-    )
-    experimental = _properties.Boolean("experimental", serializable=False, default=True)
-    experimental_reasons = _properties.Optional(
-        _properties.List(_properties.String()),
-        'experimental_reasons',
-        serializable=False
-    )
-    archived = _properties.Boolean('archived', default=False)
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -528,19 +489,6 @@ class MolecularStructureFeaturizer(Serializable['MolecularStructureFeaturizer'],
     features = _properties.List(_properties.String, 'config.features')
     excludes = _properties.List(_properties.String, 'config.excludes')
     typ = _properties.String('config.type', default='MoleculeFeaturizer', deserializable=False)
-    status = _properties.Optional(_properties.String, 'status', serializable=False)
-    status_info = _properties.Optional(
-        _properties.List(_properties.String),
-        'status_info',
-        serializable=False
-    )
-    archived = _properties.Boolean('archived', default=False)
-    experimental = _properties.Boolean("experimental", serializable=False, default=True)
-    experimental_reasons = _properties.Optional(
-        _properties.List(_properties.String()),
-        'experimental_reasons',
-        serializable=False
-    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -600,19 +548,6 @@ class IngredientsToSimpleMixturePredictor(
                                  'config.labels')
     typ = _properties.String('config.type', default='IngredientsToSimpleMixture',
                              deserializable=False)
-    status = _properties.Optional(_properties.String(), 'status', serializable=False)
-    status_info = _properties.Optional(
-        _properties.List(_properties.String()),
-        'status_info',
-        serializable=False
-    )
-    archived = _properties.Boolean('archived', default=False)
-    experimental = _properties.Boolean("experimental", serializable=False, default=True)
-    experimental_reasons = _properties.Optional(
-        _properties.List(_properties.String()),
-        'experimental_reasons',
-        serializable=False
-    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -696,19 +631,6 @@ class GeneralizedMeanPropertyPredictor(
     label = _properties.Optional(_properties.String, 'config.label')
     typ = _properties.String('config.type', default='GeneralizedMeanProperty',
                              deserializable=False)
-    status = _properties.Optional(_properties.String, 'status', serializable=False)
-    status_info = _properties.Optional(
-        _properties.List(_properties.String),
-        'status_info',
-        serializable=False
-    )
-    archived = _properties.Boolean('archived', default=False)
-    experimental = _properties.Boolean("experimental", serializable=False, default=True)
-    experimental_reasons = _properties.Optional(
-        _properties.List(_properties.String()),
-        'experimental_reasons',
-        serializable=False
-    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -777,17 +699,6 @@ class SimpleMixturePredictor(Serializable['SimpleMixturePredictor'], Predictor):
     training_data = _properties.List(_properties.Object(DataSource), 'config.training_data')
     typ = _properties.String('config.type', default='SimpleMixture',
                              deserializable=False)
-    status = _properties.Optional(_properties.String, 'status', serializable=False)
-    status_info = _properties.Optional(_properties.List(_properties.String),
-                                       'status_info',
-                                       serializable=False)
-    archived = _properties.Boolean('archived', default=False)
-    experimental = _properties.Boolean("experimental", serializable=False, default=True)
-    experimental_reasons = _properties.Optional(
-        _properties.List(_properties.String()),
-        'experimental_reasons',
-        serializable=False
-    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -839,19 +750,6 @@ class LabelFractionsPredictor(Serializable['LabelFractionsPredictor'], Predictor
     labels = _properties.List(_properties.String, 'config.labels')
     typ = _properties.String('config.type', default='LabelFractions',
                              deserializable=False)
-    status = _properties.Optional(_properties.String, 'status', serializable=False)
-    status_info = _properties.Optional(
-        _properties.List(_properties.String),
-        'status_info',
-        serializable=False
-    )
-    archived = _properties.Boolean('archived', default=False)
-    experimental = _properties.Boolean("experimental", serializable=False, default=True)
-    experimental_reasons = _properties.Optional(
-        _properties.List(_properties.String()),
-        'experimental_reasons',
-        serializable=False
-    )
 
     # NOTE: These could go here or in _post_dump - it's unclear which is better right now
     module_type = _properties.String('module_type', default='PREDICTOR')
@@ -905,19 +803,6 @@ class IngredientFractionsPredictor(Serializable["IngredientFractionsPredictor"],
     schema_id = _properties.UUID('schema_id', default=UUID('eb02a095-8cdc-45d8-bc82-1013b6e8e700'))
     typ = _properties.String('config.type', default='IngredientFractions',
                              deserializable=False)
-    status = _properties.Optional(_properties.String, 'status', serializable=False)
-    status_info = _properties.Optional(
-        _properties.List(_properties.String),
-        'status_info',
-        serializable=False
-    )
-    archived = _properties.Boolean('archived', default=False)
-    experimental = _properties.Boolean("experimental", serializable=False, default=True)
-    experimental_reasons = _properties.Optional(
-        _properties.List(_properties.String()),
-        'experimental_reasons',
-        serializable=False
-    )
 
     def __init__(self,
                  name: str,

--- a/src/citrine/resources/condition_template.py
+++ b/src/citrine/resources/condition_template.py
@@ -36,11 +36,11 @@ class ConditionTemplate(AttributeTemplate, Resource['ConditionTemplate'], GEMDCo
 
     _response_key = GEMDConditionTemplate.typ  # 'condition_template'
 
-    name = String('name')
-    description = PropertyOptional(String(), 'description')
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    bounds = Object(BaseBounds, 'bounds')
+    name = String('name', override=True)
+    description = PropertyOptional(String(), 'description', override=True)
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    bounds = Object(BaseBounds, 'bounds', override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -47,8 +47,8 @@ class FileLink(Resource['FileLink'], GEMDFileLink):
 
     """
 
-    filename = String('filename')
-    url = String('url')
+    filename = String('filename', override=True)
+    url = String('url', override=True)
     typ = String('type')
 
     def __init__(self, filename: str, url: str):

--- a/src/citrine/resources/ingredient_run.py
+++ b/src/citrine/resources/ingredient_run.py
@@ -59,20 +59,20 @@ class IngredientRun(ObjectRun, Resource['IngredientRun'], GEMDIngredientRun):
 
     _response_key = GEMDIngredientRun.typ  # 'ingredient_run'
 
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    notes = PropertyOptional(String(), 'notes')
-    material = PropertyOptional(LinkOrElse(), 'material')
-    process = PropertyOptional(LinkOrElse(), 'process')
-    mass_fraction = PropertyOptional(Object(ContinuousValue), 'mass_fraction')
-    volume_fraction = PropertyOptional(Object(ContinuousValue), 'volume_fraction')
-    number_fraction = PropertyOptional(Object(ContinuousValue), 'number_fraction')
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    notes = PropertyOptional(String(), 'notes', override=True)
+    material = PropertyOptional(LinkOrElse(), 'material', override=True)
+    process = PropertyOptional(LinkOrElse(), 'process', override=True)
+    mass_fraction = PropertyOptional(Object(ContinuousValue), 'mass_fraction', override=True)
+    volume_fraction = PropertyOptional(Object(ContinuousValue), 'volume_fraction', override=True)
+    number_fraction = PropertyOptional(Object(ContinuousValue), 'number_fraction', override=True)
     absolute_quantity = PropertyOptional(
-        Object(ContinuousValue), 'absolute_quantity')
-    name = PropertyOptional(String(), 'name')
-    labels = PropertyOptional(PropertyList(String()), 'labels')
-    spec = PropertyOptional(LinkOrElse(), 'spec')
-    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
+        Object(ContinuousValue), 'absolute_quantity', override=True)
+    name = PropertyOptional(String(), 'name', override=True)
+    labels = PropertyOptional(PropertyList(String()), 'labels', override=True)
+    spec = PropertyOptional(LinkOrElse(), 'spec', override=True)
+    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links', override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/ingredient_spec.py
+++ b/src/citrine/resources/ingredient_spec.py
@@ -60,19 +60,19 @@ class IngredientSpec(ObjectSpec, Resource['IngredientSpec'], GEMDIngredientSpec)
 
     _response_key = GEMDIngredientSpec.typ  # 'ingredient_spec'
 
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    notes = PropertyOptional(String(), 'notes')
-    material = PropertyOptional(LinkOrElse(), 'material')
-    process = PropertyOptional(LinkOrElse(), 'process')
-    mass_fraction = PropertyOptional(Object(ContinuousValue), 'mass_fraction')
-    volume_fraction = PropertyOptional(Object(ContinuousValue), 'volume_fraction')
-    number_fraction = PropertyOptional(Object(ContinuousValue), 'number_fraction')
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    notes = PropertyOptional(String(), 'notes', override=True)
+    material = PropertyOptional(LinkOrElse(), 'material', override=True)
+    process = PropertyOptional(LinkOrElse(), 'process', override=True)
+    mass_fraction = PropertyOptional(Object(ContinuousValue), 'mass_fraction', override=True)
+    volume_fraction = PropertyOptional(Object(ContinuousValue), 'volume_fraction', override=True)
+    number_fraction = PropertyOptional(Object(ContinuousValue), 'number_fraction', override=True)
     absolute_quantity = PropertyOptional(
-        Object(ContinuousValue), 'absolute_quantity')
-    name = String('name')
-    labels = PropertyOptional(PropertyList(String()), 'labels')
-    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
+        Object(ContinuousValue), 'absolute_quantity', override=True)
+    name = String('name', override=True)
+    labels = PropertyOptional(PropertyList(String()), 'labels', override=True)
+    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links', override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/material_run.py
+++ b/src/citrine/resources/material_run.py
@@ -63,14 +63,14 @@ class MaterialRun(ObjectRun, Resource['MaterialRun'], GEMDMaterialRun):
 
     _response_key = GEMDMaterialRun.typ  # 'material_run'
 
-    name = String('name')
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    notes = PropertyOptional(String(), 'notes')
-    process = PropertyOptional(LinkOrElse(), 'process')
-    sample_type = String('sample_type')
-    spec = PropertyOptional(LinkOrElse(), 'spec')
-    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
+    name = String('name', override=True)
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    notes = PropertyOptional(String(), 'notes', override=True)
+    process = PropertyOptional(LinkOrElse(), 'process', override=True)
+    sample_type = String('sample_type', override=True)
+    spec = PropertyOptional(LinkOrElse(), 'spec', override=True)
+    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links', override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/material_spec.py
+++ b/src/citrine/resources/material_spec.py
@@ -52,14 +52,15 @@ class MaterialSpec(ObjectSpec, Resource['MaterialSpec'], GEMDMaterialSpec):
 
     _response_key = GEMDMaterialSpec.typ  # 'material_spec'
 
-    name = String('name')
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    notes = PropertyOptional(String(), 'notes')
-    process = PropertyOptional(LinkOrElse(), 'process')
-    properties = PropertyOptional(PropertyList(Object(PropertyAndConditions)), 'properties')
-    template = PropertyOptional(LinkOrElse(), 'template')
-    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
+    name = String('name', override=True)
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    notes = PropertyOptional(String(), 'notes', override=True)
+    process = PropertyOptional(LinkOrElse(), 'process', override=True)
+    properties = PropertyOptional(
+        PropertyList(Object(PropertyAndConditions)), 'properties', override=True)
+    template = PropertyOptional(LinkOrElse(), 'template', override=True)
+    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links', override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/material_template.py
+++ b/src/citrine/resources/material_template.py
@@ -46,12 +46,12 @@ class MaterialTemplate(ObjectTemplate, Resource['MaterialTemplate'], GEMDMateria
 
     _response_key = GEMDMaterialTemplate.typ  # 'material_template'
 
-    name = String('name')
-    description = PropertyOptional(String(), 'description')
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    properties = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'properties')
+    name = String('name', override=True)
+    description = PropertyOptional(String(), 'description', override=True)
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    properties = PropertyOptional(PropertyList(SpecifiedMixedList(
+        [LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'properties', override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/measurement_run.py
+++ b/src/citrine/resources/measurement_run.py
@@ -57,17 +57,17 @@ class MeasurementRun(ObjectRun, Resource['MeasurementRun'], GEMDMeasurementRun):
 
     _response_key = GEMDMeasurementRun.typ  # 'measurement_run'
 
-    name = String('name')
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    notes = PropertyOptional(String(), 'notes')
-    conditions = PropertyOptional(PropertyList(Object(Condition)), 'conditions')
-    parameters = PropertyOptional(PropertyList(Object(Parameter)), 'parameters')
-    properties = PropertyOptional(PropertyList(Object(Property)), 'properties')
-    spec = PropertyOptional(LinkOrElse(), 'spec')
-    material = PropertyOptional(LinkOrElse(), "material")
-    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
-    source = PropertyOptional(Object(PerformedSource), "source")
+    name = String('name', override=True)
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    notes = PropertyOptional(String(), 'notes', override=True)
+    conditions = PropertyOptional(PropertyList(Object(Condition)), 'conditions', override=True)
+    parameters = PropertyOptional(PropertyList(Object(Parameter)), 'parameters', override=True)
+    properties = PropertyOptional(PropertyList(Object(Property)), 'properties', override=True)
+    spec = PropertyOptional(LinkOrElse(), 'spec', override=True)
+    material = PropertyOptional(LinkOrElse(), "material", override=True)
+    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links', override=True)
+    source = PropertyOptional(Object(PerformedSource), "source", override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/measurement_spec.py
+++ b/src/citrine/resources/measurement_spec.py
@@ -48,14 +48,14 @@ class MeasurementSpec(ObjectSpec, Resource['MeasurementSpec'], GEMDMeasurementSp
 
     _response_key = GEMDMeasurementSpec.typ  # 'measurement_spec'
 
-    name = String('name')
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    notes = PropertyOptional(String(), 'notes')
-    conditions = PropertyOptional(PropertyList(Object(Condition)), 'conditions')
-    parameters = PropertyOptional(PropertyList(Object(Parameter)), 'parameters')
-    template = PropertyOptional(LinkOrElse(), 'template')
-    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
+    name = String('name', override=True)
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    notes = PropertyOptional(String(), 'notes', override=True)
+    conditions = PropertyOptional(PropertyList(Object(Condition)), 'conditions', override=True)
+    parameters = PropertyOptional(PropertyList(Object(Parameter)), 'parameters', override=True)
+    template = PropertyOptional(LinkOrElse(), 'template', override=True)
+    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links', override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/measurement_template.py
+++ b/src/citrine/resources/measurement_template.py
@@ -60,16 +60,16 @@ class MeasurementTemplate(ObjectTemplate,
 
     _response_key = GEMDMeasurementTemplate.typ  # 'measurement_template'
 
-    name = String('name')
-    description = PropertyOptional(String(), 'description')
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    properties = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'properties')
-    conditions = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'conditions')
-    parameters = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'parameters')
+    name = String('name', override=True)
+    description = PropertyOptional(String(), 'description', override=True)
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    properties = PropertyOptional(PropertyList(SpecifiedMixedList(
+        [LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'properties', override=True)
+    conditions = PropertyOptional(PropertyList(SpecifiedMixedList(
+        [LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'conditions', override=True)
+    parameters = PropertyOptional(PropertyList(SpecifiedMixedList(
+        [LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'parameters', override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/parameter_template.py
+++ b/src/citrine/resources/parameter_template.py
@@ -36,11 +36,11 @@ class ParameterTemplate(AttributeTemplate, Resource['ParameterTemplate'], GEMDPa
 
     _response_key = GEMDParameterTemplate.typ  # 'parameter_template'
 
-    name = String('name')
-    description = PropertyOptional(String(), 'description')
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    bounds = Object(BaseBounds, 'bounds')
+    name = String('name', override=True)
+    description = PropertyOptional(String(), 'description', override=True)
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    bounds = Object(BaseBounds, 'bounds', override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/process_run.py
+++ b/src/citrine/resources/process_run.py
@@ -61,15 +61,15 @@ class ProcessRun(ObjectRun, Resource['ProcessRun'], GEMDProcessRun):
 
     _response_key = GEMDProcessRun.typ  # 'process_run'
 
-    name = String('name')
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    notes = PropertyOptional(String(), 'notes')
-    conditions = PropertyOptional(PropertyList(Object(Condition)), 'conditions')
-    parameters = PropertyOptional(PropertyList(Object(Parameter)), 'parameters')
-    spec = PropertyOptional(LinkOrElse(), 'spec')
-    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
-    source = PropertyOptional(Object(PerformedSource), "source")
+    name = String('name', override=True)
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    notes = PropertyOptional(String(), 'notes', override=True)
+    conditions = PropertyOptional(PropertyList(Object(Condition)), 'conditions', override=True)
+    parameters = PropertyOptional(PropertyList(Object(Parameter)), 'parameters', override=True)
+    spec = PropertyOptional(LinkOrElse(), 'spec', override=True)
+    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links', override=True)
+    source = PropertyOptional(Object(PerformedSource), "source", override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/process_spec.py
+++ b/src/citrine/resources/process_spec.py
@@ -58,14 +58,14 @@ class ProcessSpec(ObjectSpec, Resource['ProcessSpec'], GEMDProcessSpec):
 
     _response_key = GEMDProcessSpec.typ  # 'process_spec'
 
-    name = String('name')
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    notes = PropertyOptional(String(), 'notes')
-    conditions = PropertyOptional(PropertyList(Object(Condition)), 'conditions')
-    parameters = PropertyOptional(PropertyList(Object(Parameter)), 'parameters')
-    template = PropertyOptional(LinkOrElse(), 'template')
-    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links')
+    name = String('name', override=True)
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    notes = PropertyOptional(String(), 'notes', override=True)
+    conditions = PropertyOptional(PropertyList(Object(Condition)), 'conditions', override=True)
+    parameters = PropertyOptional(PropertyList(Object(Parameter)), 'parameters', override=True)
+    template = PropertyOptional(LinkOrElse(), 'template', override=True)
+    file_links = PropertyOptional(PropertyList(Object(FileLink)), 'file_links', override=True)
     typ = String('type')
 
     def __init__(self,

--- a/src/citrine/resources/process_template.py
+++ b/src/citrine/resources/process_template.py
@@ -52,16 +52,16 @@ class ProcessTemplate(ObjectTemplate, Resource['ProcessTemplate'], GEMDProcessTe
 
     _response_key = GEMDProcessTemplate.typ  # 'process_template'
 
-    name = String('name')
-    description = PropertyOptional(String(), 'description')
-    uids = Mapping(String('scope'), String('id'), 'uids')
-    tags = PropertyOptional(PropertyList(String()), 'tags')
-    conditions = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'conditions')
-    parameters = PropertyOptional(PropertyList(
-        SpecifiedMixedList([LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'parameters')
-    allowed_labels = PropertyOptional(PropertyList(String()), 'allowed_labels')
-    allowed_names = PropertyOptional(PropertyList(String()), 'allowed_names')
+    name = String('name', override=True)
+    description = PropertyOptional(String(), 'description', override=True)
+    uids = Mapping(String('scope'), String('id'), 'uids', override=True)
+    tags = PropertyOptional(PropertyList(String()), 'tags', override=True)
+    conditions = PropertyOptional(PropertyList(SpecifiedMixedList(
+        [LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'conditions', override=True)
+    parameters = PropertyOptional(PropertyList(SpecifiedMixedList(
+        [LinkOrElse, PropertyOptional(Object(BaseBounds))])), 'parameters', override=True)
+    allowed_labels = PropertyOptional(PropertyList(String()), 'allowed_labels', override=True)
+    allowed_names = PropertyOptional(PropertyList(String()), 'allowed_names', override=True)
     typ = String('type')
 
     def __init__(self,


### PR DESCRIPTION
# Citrine Python PR

## Description 

The behavior for serializing and deserializing properties that were defined in parent classes was tailor made to support overriding members from `gemd` in `DataConcepts` classes.  This behavior is preserved but put behind a flag, which has been applied to all of those cases.

The new default behavior will serialize and deserialize properties that exist in a parent class the same way as in a concrete class, by default.  This allows us to define the serde properties in parent classes, as demonstrated on predictors.  It also allows for the definition of interfaces with the same name as serialized members (to be demonstrated in #441 ).

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
