### PR TITLE
Added archive and restore methods to predictor evaluation workflows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.75.0',
+      version='0.76.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/predictor_evaluation_execution.py
+++ b/src/citrine/resources/predictor_evaluation_execution.py
@@ -142,7 +142,6 @@ class PredictorEvaluationExecutionCollection(Collection["PredictorEvaluationExec
     def restore(self, execution_id: UUID):
         """Restore a predictor evaluation execution.
 
-
         Parameters
         ----------
         execution_id: UUID

--- a/src/citrine/resources/predictor_evaluation_execution.py
+++ b/src/citrine/resources/predictor_evaluation_execution.py
@@ -27,7 +27,7 @@ class PredictorEvaluationExecution(Resource['PredictorEvaluationExecution']):
 
     _response_key = None
 
-    uid = properties.UUID('id', serializable=False)
+    uid: UUID = properties.UUID('id', serializable=False)
     """UUID of the execution."""
 
     evaluator_names = properties.List(properties.String, "evaluator_names", serializable=False)
@@ -127,6 +127,19 @@ class PredictorEvaluationExecutionCollection(Collection["PredictorEvaluationExec
     def update(self, model: PredictorEvaluationExecution) -> PredictorEvaluationExecution:
         """Cannot update an execution."""
         raise NotImplementedError("Cannot update a PredictorEvaluationExecution.")
+
+    def archive(self, execution_id: UUID):
+        """Archive a predictor evaluation execution."""
+        self._put_module_ref('archive', execution_id)
+
+    def restore(self, execution_id: UUID):
+        """Restore a predictor evaluation execution."""
+        self._put_module_ref('restore', execution_id)
+
+    def _put_module_ref(self, subpath: str, execution_id: UUID):
+        url = self._get_path(subpath)
+        ref = ModuleRef(str(execution_id))
+        self.session.put_resource(url, ref.dump())
 
     def list(self,
              page: Optional[int] = None,

--- a/src/citrine/resources/predictor_evaluation_execution.py
+++ b/src/citrine/resources/predictor_evaluation_execution.py
@@ -129,11 +129,26 @@ class PredictorEvaluationExecutionCollection(Collection["PredictorEvaluationExec
         raise NotImplementedError("Cannot update a PredictorEvaluationExecution.")
 
     def archive(self, execution_id: UUID):
-        """Archive a predictor evaluation execution."""
+        """Archive a predictor evaluation execution.
+
+        Parameters
+        ----------
+        execution_id: UUID
+            Unique identifier of the execution to archive
+
+        """
         self._put_module_ref('archive', execution_id)
 
     def restore(self, execution_id: UUID):
-        """Restore a predictor evaluation execution."""
+        """Restore a predictor evaluation execution.
+
+
+        Parameters
+        ----------
+        execution_id: UUID
+            Unique identifier of the execution to restore
+
+        """
         self._put_module_ref('restore', execution_id)
 
     def _put_module_ref(self, subpath: str, execution_id: UUID):

--- a/src/citrine/resources/predictor_evaluation_workflow.py
+++ b/src/citrine/resources/predictor_evaluation_workflow.py
@@ -37,7 +37,7 @@ class PredictorEvaluationWorkflowCollection(Collection[PredictorEvaluationWorkfl
         return self._put_module_ref('archive', workflow_id)
 
     def restore(self, workflow_id: UUID):
-        """Restore a predictor evaluation execution.
+        """Restore a predictor evaluation workflow.
 
         Parameters
         ----------

--- a/src/citrine/resources/predictor_evaluation_workflow.py
+++ b/src/citrine/resources/predictor_evaluation_workflow.py
@@ -39,7 +39,6 @@ class PredictorEvaluationWorkflowCollection(Collection[PredictorEvaluationWorkfl
     def restore(self, workflow_id: UUID):
         """Restore a predictor evaluation execution.
 
-
         Parameters
         ----------
         workflow_id: UUID

--- a/src/citrine/resources/predictor_evaluation_workflow.py
+++ b/src/citrine/resources/predictor_evaluation_workflow.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from citrine._rest.collection import Collection
 from citrine._session import Session
+from citrine.informatics.modules import ModuleRef
 from citrine.informatics.workflows import PredictorEvaluationWorkflow
 
 
@@ -23,3 +24,16 @@ class PredictorEvaluationWorkflowCollection(Collection[PredictorEvaluationWorkfl
         workflow.session = self.session
         workflow.project_id = self.project_id
         return workflow
+
+    def archive(self, workflow_id: UUID):
+        """Archive a predictor evaluation workflow."""
+        return self._put_module_ref('archive', workflow_id)
+
+    def restore(self, workflow_id: UUID):
+        """Restore a predictor evaluation workflow."""
+        return self._put_module_ref('restore', workflow_id)
+
+    def _put_module_ref(self, subpath: str, workflow_id: UUID):
+        url = self._get_path(subpath)
+        ref = ModuleRef(str(workflow_id))
+        return self.session.put_resource(url, ref.dump())

--- a/src/citrine/resources/predictor_evaluation_workflow.py
+++ b/src/citrine/resources/predictor_evaluation_workflow.py
@@ -26,11 +26,26 @@ class PredictorEvaluationWorkflowCollection(Collection[PredictorEvaluationWorkfl
         return workflow
 
     def archive(self, workflow_id: UUID):
-        """Archive a predictor evaluation workflow."""
+        """Archive a predictor evaluation workflow.
+
+        Parameters
+        ----------
+        workflow_id: UUID
+            Unique identifier of the workflow to archive
+
+        """
         return self._put_module_ref('archive', workflow_id)
 
     def restore(self, workflow_id: UUID):
-        """Restore a predictor evaluation workflow."""
+        """Restore a predictor evaluation execution.
+
+
+        Parameters
+        ----------
+        workflow_id: UUID
+            Unique identifier of the workflow to restore
+
+        """
         return self._put_module_ref('restore', workflow_id)
 
     def _put_module_ref(self, subpath: str, workflow_id: UUID):

--- a/tests/resources/test_predictor_evaluation_executions.py
+++ b/tests/resources/test_predictor_evaluation_executions.py
@@ -109,3 +109,15 @@ def test_list(collection: PredictorEvaluationExecutionCollection, session):
         path=expected_path,
         params={"page": 2, "per_page": 4, "predictor_id": str(predictor_id), "workflow_id": str(collection.workflow_id)}
     )
+
+
+def test_archive(workflow_execution, collection):
+    collection.archive(workflow_execution.uid)
+    expected_path = '/projects/{}/predictor-evaluation-executions/archive'.format(collection.project_id)
+    assert collection.session.last_call == FakeCall(method='PUT', path=expected_path, json={"module_uid": str(workflow_execution.uid)})
+
+
+def test_restore(workflow_execution, collection):
+    collection.restore(workflow_execution.uid)
+    expected_path = '/projects/{}/predictor-evaluation-executions/restore'.format(collection.project_id)
+    assert collection.session.last_call == FakeCall(method='PUT', path=expected_path, json={"module_uid": str(workflow_execution.uid)})

--- a/tests/resources/test_predictor_evaluation_workflows.py
+++ b/tests/resources/test_predictor_evaluation_workflows.py
@@ -28,3 +28,16 @@ def workflow(collection: PredictorEvaluationWorkflowCollection, predictor_evalua
 def test_basic_methods(workflow, collection):
     assert "PredictorEvaluationWorkflow" in str(workflow)
     assert workflow.evaluators[0].name == "Example evaluator"
+
+
+def test_archive(workflow, collection):
+    collection.archive(workflow.uid)
+    expected_path = '/projects/{}/predictor-evaluation-workflows/archive'.format(collection.project_id)
+    assert collection.session.last_call == FakeCall(method='PUT', path=expected_path, json={"module_uid": str(workflow.uid)})
+
+
+def test_restore(workflow, collection):
+    collection.restore(workflow.uid)
+    expected_path = '/projects/{}/predictor-evaluation-workflows/restore'.format(collection.project_id)
+    assert collection.session.last_call == FakeCall(method='PUT', path=expected_path, json={"module_uid": str(workflow.uid)})
+


### PR DESCRIPTION
This PR adds archive/restore methods to predictor evaluation workflows and executions.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
