### PR TITLE
Increasing per_page default for DatasetCollection.list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.76.0',
+      version='0.77.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.75.0',
+      version='0.76.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -349,3 +349,30 @@ class DatasetCollection(Collection[Dataset]):
         full_model = self.build(data)
         full_model.project_id = self.project_id
         return full_model
+
+    def list(self,
+             page: Optional[int] = None,
+             per_page: int = 1000) -> Iterable[Dataset]:
+        """
+        List datasets using pagination.
+
+        Leaving page and per_page as default values will yield all elements in the
+        collection, paginating over all available pages.
+
+        Parameters
+        ---------
+        page: int, optional
+            The "page" of results to list. Default is to read all pages and yield
+            all results.  This option is deprecated.
+        per_page: int, optional
+            Max number of results to return per page. Default is 1000.  This parameter
+            is used when making requests to the backend service.  If the page parameter
+            is specified it limits the maximum number of elements in the response.
+
+        Returns
+        -------
+        Iterable[Dataset]
+            Datasets in this collection.
+
+        """
+        return super().list(page, per_page)

--- a/src/citrine/resources/dataset.py
+++ b/src/citrine/resources/dataset.py
@@ -1,6 +1,6 @@
 """Resources that represent both individual and collections of datasets."""
 from collections import defaultdict
-from typing import TypeVar, List
+from typing import TypeVar, List, Optional, Iterable
 from uuid import UUID
 
 from citrine._rest.collection import Collection

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -114,7 +114,7 @@ def test_list_datasets_infinite_loop_detect(paginated_collection, paginated_sess
     paginated_session.set_response(datasets_data)
 
     # When
-    datasets = list(paginated_collection.list())
+    datasets = list(paginated_collection.list(per_page=batch_size))
 
     # Then
     assert 2 == paginated_session.num_calls  # duplicate UID detected on the second call


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR modifies the default value of per_page for the list method on DatasetCollection.  The previous default was resulting in a large number of API calls and a heavy load on the accounts DB.  Increasing this to 1000 increases the payload size per API call, greatly decreasing the number of API calls and db queries.  This should result in much better performance and less load on the accounts db.

This change only impacts dataset collections and can be overridden by specifying the per_page value when listing datasets.  Given that these list methods return an iterable, this should be a transparent change for all clients that either iterate over the results or convert this to a Python list.

The same change was made to project collections and has worked well.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
