### PR TITLE
Fall back to unsorted list on failed set serialization.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.77.0',
+      version='0.77.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_serialization/properties.py
+++ b/src/citrine/_serialization/properties.py
@@ -375,7 +375,10 @@ class Set(Property[set, typing.Iterable]):
         serialized = list()
         for element in value:
             serialized.append(self.element_type.serialize(element))
-        return sorted(serialized)
+        try:
+            return sorted(serialized)
+        except TypeError:
+            return serialized
 
 
 class Union(Property[typing.Any, typing.Any]):


### PR DESCRIPTION
This PR modifies `properties.Set`. `_serialize` will now return the initial (unsorted) list if attempting to sort the list throws an error. This can occur when the serialized elements of the set are not comparable, e.g. `dict`s.