### PR TITLE
Predictor evaluation workflow user docs.

### DIFF
--- a/docs/source/data_extraction.rst
+++ b/docs/source/data_extraction.rst
@@ -200,7 +200,7 @@ Available Row Definitions
 Currently, GEM Tables only provide a single way to define Rows: by the :class:`~gemd.entity.template.material_template.MaterialTemplate` of the roots of the material histories that correspond to each row.
 
 :class:`~citrine.gemtables.rows.MaterialRunByTemplate`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :class:`~citrine.gemtables.rows.MaterialRunByTemplate` class defines Rows through a list of :class:`~gemd.entity.template.material_template.MaterialTemplate`.
 Every :class:`~gemd.entity.object.material_run.MaterialRun` that is assigned to any template in the list is used as the root of a  Material History to be mapped to a Row.

--- a/docs/source/workflows/code_examples.rst
+++ b/docs/source/workflows/code_examples.rst
@@ -2,6 +2,7 @@ AI Engine Code Examples
 =======================
 
 .. _graph_predictor_example:
+
 Example: preprocessing and postprocessing in a GraphPredictor
 -------------------------------------------------------------
 

--- a/docs/source/workflows/data_sources.rst
+++ b/docs/source/workflows/data_sources.rst
@@ -1,3 +1,5 @@
+.. _data-sources:
+
 Data Sources
 ============
 

--- a/docs/source/workflows/descriptors.rst
+++ b/docs/source/workflows/descriptors.rst
@@ -1,9 +1,9 @@
 Descriptors
-==========
+===========
 
 Descriptors allow users to define a controlled vocabulary with which to describe the physical context of an AI task.
 Each descriptor defines a term in that vocabulary, which is comprised of a name, a datatype, and bounds on that data type.
-If you are familiar with the GEMD data model, descriptors are roughly equivalent to `AttributeTemplate`s.
+If you are familiar with the GEMD data model, descriptors are roughly equivalent to :class:`AttributeTemplates <citrine.resources.attribute_templates.AttributeTemplate>`.
 
 The AI Engine currently supports _ kinds of descriptors:
 
@@ -14,7 +14,8 @@ The AI Engine currently supports _ kinds of descriptors:
 -  `Formulation Descriptor <#formulation-descriptor>`__
 
 Real Descriptor
------------------------------------
+---------------
+
 :class:`~citrine.informatics.descriptors.RealDescriptor` is used to represent continuous variables.
 Each Real Descriptor must provide a lower and upper bound, which is used to both validate input data and as a prior when making predictions.
 If you are not sure what bounds to use, you may want to look at the attribute templates to see if another user has defined bounds for you.
@@ -25,19 +26,22 @@ Any `GEMD-compatible <https://citrineinformatics.github.io/gemd-python/depth/uni
 If a variable is dimensionless, you can use an empty string.
 
 Categorical Descriptor
------------------------------------
+----------------------
+
 :class:`~citrine.informatics.descriptors.CategoricalDescriptor` is used to represent variables that can take one of
 a set of values, i.e. categories.
 All of the possible categories must be known ahead of time and specified in the Categorical Descriptor.
 
 Chemical Formula Descriptor
------------------------------------
+---------------------------
+
 :class:`~citrine.informatics.descriptors.ChemicalFormulaDescriptor` is used to represent variables that should be
 interpreted as chemical formulas.
 The Chemical Formula Descriptor has no parameters other than a name.
 
 Molecular Structure Descriptor
------------------------------------
+------------------------------
+
 :class:`~citrine.informatics.descriptors.MolecularStructureDescriptor` is used to represent variables that should be
 interpreted as molecular structures.
 Both `SMILES <https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system>`__
@@ -45,14 +49,15 @@ and `InChI <https://en.wikipedia.org/wiki/International_Chemical_Identifier>`__ 
 The Molecular Structure Descriptor has no parameters other than a name.
 
 Formulation Descriptor (ALPHA)
------------------------------------
+------------------------------
+
 :class:`~citrine.informatics.descriptors.FormulationDescriptor` is used to represent variables that contain information
 about mixtures of other materials.
 The Formulation Descriptor has no parameters other than a name.
 
 
 Platform Vocabularies
-==================================
+=====================
 
 A set of descriptors defines a controlled vocabulary with which to describe AI tasks.
 The :class:`~citrine.builders.descriptors.PlatformVocabulary` class is provided to collect a set of descriptors,

--- a/docs/source/workflows/design_spaces.rst
+++ b/docs/source/workflows/design_spaces.rst
@@ -1,4 +1,4 @@
-Design spaces
+Design Spaces
 =============
 
 A design space defines a set of materials that should be searched over when performing a material design.

--- a/docs/source/workflows/design_workflows.rst
+++ b/docs/source/workflows/design_workflows.rst
@@ -1,4 +1,4 @@
-Design workflows
+Design Workflows
 ================
 
 A design workflow ranks materials according to a :doc:`score <scores>`.

--- a/docs/source/workflows/getting_started.rst
+++ b/docs/source/workflows/getting_started.rst
@@ -11,12 +11,12 @@ These capabilities include generating candidates for sequential learning, identi
 Workflows Overview
 ------------------
 
-Currently, there are two types of workflows on the AI Engine: the :doc:`DesignWorkflow <design_workflows>` and the :doc:`PerformanceWorkflow <performance_workflows>`.
+Currently, there are two workflows on the AI Engine: the :doc:`DesignWorkflow <design_workflows>` and the :doc:`PredictorEvaluationWorkflow <predictor_evaluation_workflows>`.
 Workflows employ reusable modules in order to execute.
 There are three different types of modules, and these are discussed in greater detail below.
 
-DesignWorkflow
-**************
+Design Workflow
+***************
 
 The :doc:`DesignWorkflow <design_workflows>` is the core AI workflow on the platform.
 This workflow generates scored candidates for sequential learning.
@@ -31,12 +31,12 @@ After a given number of iterations, candidates are ranked according to their sco
 
 Design workflows are further parameterized by :doc:`Scores <scores>`, which codify experimental objectives and constraints on desired candidates, and define the strategy for candidate acquisition.
 
-PerformanceWorkflow
-*******************
+Predictor Evaluation Workflow
+*****************************
 
-The :doc:`PerformanceWorkflow <performance_workflows>` is used to perform analysis on a predictor module.
-The PerformanceWorkflow exists to help the user understand how well their predictor module works with their data: in essence, it describes the trustworthiness of their model.
-These outcomes are captured in a series of performance metrics.
+The :doc:`PredictorEvaluationWorkflow <predictor_evaluation_workflows>` is used to analyze a :doc:`Predictor <predictors>`.
+This workflow helps users understand how well their predictor module works with their data: in essence, it describes the trustworthiness of their model.
+These outcomes are captured in a series of response metrics.
 
 Modules Overview
 ----------------
@@ -52,7 +52,7 @@ There are 3 types of modules on the platform:
    The processor and design space are coupled: depending on the design space used, only a subset of processors are applicable.
 
 Archiving
-**********
+*********
 
 Modules come active by default when created. If you would like to `archive` a module so it cannot be used again consider this example:
 
@@ -88,7 +88,7 @@ Validation status can be one of the following states:
 Validation of a workflow and all constituent modules must complete with ready status before the workflow can be executed.
 
 Experimental functionality
-***************************
+**************************
 
 Both modules and workflows can be used to access experimental functionality on the platform.
 In some cases, the module or workflow type itself may be experimental.

--- a/docs/source/workflows/index.rst
+++ b/docs/source/workflows/index.rst
@@ -16,5 +16,6 @@
     scores
     data_sources
     predictor_reports
+    predictor_evaluation_workflows
     performance_workflows
     code_examples

--- a/docs/source/workflows/performance_workflows.rst
+++ b/docs/source/workflows/performance_workflows.rst
@@ -1,7 +1,7 @@
-Performance workflows
+Performance Workflows
 =====================
 
-A :class:`performance workflow <citrine.informatics.workflows.PerformanceWorkflow>` performs analysis on a module.
+A :class:`performance workflow <citrine.informatics.workflows.performance_workflow.PerformanceWorkflow>` performs analysis on a module.
 Running a performance workflow produces a report (currently in JSON format) that describes the results of the analysis.
 Each analysis computes one or more performance metrics, e.g. accuracy of an ML predictor.
 An analysis is codified by a configuration object that stores all relevant settings and parameters required to run the workflow.

--- a/docs/source/workflows/performance_workflows.rst
+++ b/docs/source/workflows/performance_workflows.rst
@@ -1,7 +1,12 @@
-Performance Workflows
-=====================
+[DEPRECATED] Performance Workflows
+==================================
 
-A :class:`performance workflow <citrine.informatics.workflows.performance_workflow.PerformanceWorkflow>` performs analysis on a module.
+.. warning::
+
+    :class:`PerformanceWorkflows <citrine.informatics.workflows.performance_workflow.PerformanceWorkflow>` are deprecated.
+    Please use :doc:`PredictorEvaluationWorkflow <predictor_evaluation_workflows>` instead.
+
+A :class:`~citrine.informatics.workflows.performance_workflow.PerformanceWorkflow` performs analysis on a module.
 Running a performance workflow produces a report (currently in JSON format) that describes the results of the analysis.
 Each analysis computes one or more performance metrics, e.g. accuracy of an ML predictor.
 An analysis is codified by a configuration object that stores all relevant settings and parameters required to run the workflow.

--- a/docs/source/workflows/predictor_evaluation_workflows.rst
+++ b/docs/source/workflows/predictor_evaluation_workflows.rst
@@ -1,0 +1,264 @@
+Predictor Evaluation Workflows
+==============================
+
+A :class:`~citrine.informatics.workflows.predictor_evaluation_workflow.PredictorEvaluationWorkflow` evaluates the performance of a :doc:`Predictor <predictors>`.
+Each workflow is composed of one or more :class:`PredictorEvaluators <citrine.informatics.predictor_evaluator.PredictorEvaluator>`.
+
+Predictor evaluators
+--------------------
+
+A predictor evaluator defines a method to evaluate a predictor and any relevant configuration, e.g. k-fold cross-validation evaluation that specifies 3 folds.
+Minimally, each predictor evaluator specifies a name, a set of predictor responses to evaluate and a set of metrics to compute for each response.
+Evaluator names must be unique within a single workflow (more on that `below <#execution-and-results>`__).
+Responses are specified as a set of strings, where each string corresponds to a descriptor key of a predictor output.
+Metrics are specified as a set of :class:`PredictorEvaluationMetrics <citrine.informatics.predictor_evaluation_metrics.PredictorEvaluationMetric>`.
+When defining an evaluator, the top-level metrics should be the union of all metrics computed across all responses.
+The evaluator will only compute the subset of metrics valid for each response.
+
+Cross-validation evaluator
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A :class:`~citrine.informatics.predictor_evaluator.CrossValidationEvaluator` performs k-fold cross-validation on a predictor.
+In addition to a name, set of responses to validate and metrics to compute, this evaluator defines the number of folds, number of trials and set of descriptor keys to ignore when grouping.
+The latter allows candidates with different values for the specified (ignored) keys and identical values all other predictor inputs to be placed in the same fold.
+
+Cross-validation can only be evaluated on predictors that define training data.
+During cross-validation, the predictor's training data is partitioned into k equally sized folds.
+Each fold acts as the test set once, and the remaining k-1 folds are used as training data.
+When the number of folds equals the number of training data points, the analysis is equivalent to leave-one-out cross-validation.
+Metrics are computed by comparing the model's predictions to observed values.
+
+Predictor evaluation metrics
+----------------------------
+
+Predictor evaluation metrics are defined as part of a :class:`~citrine.informatics.predictor_evaluator.PredictorEvaluator`.
+Available metrics depend on response type.
+For numeric responses, the following metrics are available:
+
+  - *Root-mean squared error* (:class:`~citrine.informatics.predictor_evaluation_metrics.RMSE`): square root of the average of the squared prediction error.
+    RMSE is a useful and popular statistical metric for model quality.
+    RMSE is optimized by least-squares regression, and in that sense is the most "natural" measure for it; it has the same units as the predicted quantity, and corresponds to the standard deviation of the variance not explained by the predictor.
+    Lower RMSE means the model is more accurate.
+  - *Non-dimensional error* (:class:`~citrine.informatics.predictor_evaluation_metrics.NDME`): RMSE divided by the standard deviation of the observed values in the test set.
+    (If training and test set are drawn from the same distribution, the standard deviation of the test set observed values is equivalent to the RMSE of a model that always predicts the mean of the observed values).
+    NDME is a useful non-dimensional model quality metric.
+    A value of NDME == 0 is a perfect model.
+    If NDME == 1, then the model is uninformative.
+    An acceptable NDME depends on how the model is used.
+    Generally, NDME > 0.9 indicates a model with low accuracy.
+    If 0.9 > NDME > 0.6, this model is typically a good candidate for a design workflow.
+    Lower values of NDE indicate increasingly accurate models.
+  - *Standard residual* (:class:`~citrine.informatics.predictor_evaluation_metrics.StandardRMSE`) is the root mean square of standardized errors (prediction errors divided by their predicted uncertainty).
+    1.0 is perfectly calibrated.
+    Standard residual provides a way to determine whether uncertainty estimates are well-calibrated for this model.
+    Residuals are calculated using ``(Predicted - Actual)/(Uncertainty Estimate)``.
+    A value below 1 indicates the model is underconfident, i.e. actual values are within predicted error bars, on average.
+    A value over 1 indicates the model is overconfident, i.e. actual values fall outside predicted error bars, on average.
+  - *Coverage probability* (:class:`~citrine.informatics.predictor_evaluation_metrics.CoverageProbability`) is the fraction of observations for which the magnitude of the error is within a confidence interval of a given coverage level.
+    The default coverage level is 0.683, corresponding to one standard deviation.
+    The coverage level and coverage probability must both be between 0 and 1.0.
+    If the coverage probability is greater than the coverage level then the model is under-confident, and if the coverage probability is less than the coverage level then the model is over-confident.
+    While standard residual is weighted towards the outside of the residual distribution (because it looks like a 2-norm), coverage probability gives information about the center of the residual distribution.
+
+For categorical responses, performance metrics include either the area under the receiver operating characteristic (ROC) curve (if there are 2 categories) or the F1 score (if there are > 2 categories).
+
+-  Area under the ROC curve (:class:`~citrine.informatics.predictor_evaluation_metrics.AreaUnderROC`) represents the ability of the model to correctly distinguish samples between two categories.
+   If AUC == 1.0, all samples are classified correctly.
+   If AUC == 0.5, the model cannot distinguish between the two categories.
+   If AUC == 0.0, all samples are classified incorrectly.
+-  Support-weighted F1 score (:class:`~citrine.informatics.predictor_evaluation_metrics.F1`) is calculated from averaged precision and recall of the model, weighted by the in-class fraction of true positives according to the formula ``2.0 * precision * recall / (precision + recall) * fraction_true_positives`` summed over each class.
+   Scores are bounded by 0 and 1.
+   At a value of 1, the model has perfect precision and recall.
+
+In addition to the aforementioned metrics, predicted vs. actual data (:class:`~citrine.informatics.predictor_evaluation_metrics.PVA`) are also available.
+
+
+.. _execution-and-results:
+
+Execution and results
+---------------------
+
+Triggering a Predictor Evaluation Workflow produces a :class:`~citrine.resources.predictor_evaluation_execution.PredictorEvaluationExecution`.
+This execution allows you to track the progress using its ``status`` and ``status_info`` properties.
+The ``status`` can be one of ``INPROGRESS``, ``READY`` or ``FAILED``.
+Information about the execution status, e.g. warnings or reasons for failure, can be accessed via ``status_info``.
+
+When the ``status`` is ``READY``, results for each evaluation defined as part of the workflow can be accessed using the ``results`` method:
+
+.. code:: python
+
+    results = execution.results('evaluator_name')
+
+or by indexing into the execution object directly:
+
+.. code:: python
+
+    results = execution['evaluator_name']
+
+Both methods return a :class:`~citrine.informatics.predictor_evaluation_result.PredictorEvaluationResult`.
+
+Each evaluator defines its own result.
+A :class:`~citrine.informatics.predictor_evaluator.CrossValidationEvaluator` returns a :class:`~citrine.informatics.predictor_evaluation_result.CrossValidationResult`, for example.
+All predictor evaluation results contain a reference to the evaluator that created the result, the set of responses that were evaluated and the metrics that were computed.
+
+Values associated with computed metrics can be accessed by response key:
+
+.. code:: python
+
+    response_metrics = results['response_key']
+
+This returns a :class:`~citrine.informatics.predictor_evaluation_result.ResponseMetrics` object.
+This object contains all metrics that were computed for the ``response_key``.
+These metrics can be listed using ``list(response_metrics)``,
+and the value associated with a specific metric can be accessed by the metric itself, e.g. ``response_metrics[RMSE()]`` to retrieve the root-mean squared error.
+
+With the exception of predicted vs. actual data, all metric values are returned as a :class:`~citrine.informatics.predictor_evaluation_result.RealMetricValue`.
+This object defines properties ``mean`` and ``standard_error``.
+The latter optionally returns a float if the evaluation was configured with enough trials allow ``standard_error`` to be computed.
+(A :class:`~citrine.informatics.predictor_evaluator.CrossValidationEvaluator` requires at least 3 trials to compute ``standard_error``.)
+
+Predicted vs. actual data (e.g. ``response_metrics[PVA()]``) is returned as a list of predicted vs. actual data points.
+Each data point defines properties ``uuid``, ``identifiers``, ``trial``, ``fold``, ``predicted`` and ``actual``:
+
+ -  ``uuid`` and ``identifiers`` allow you to link a predicted vs. actual data point to the corresponding row in the :ref:`Predictor <predictors>`'s :ref:`Data Source <data-sources>`.
+ -  ``trial`` and ``fold`` return the each respective index during the evaluation.
+ -  The form of ``predicted`` and ``actual`` data depends on whether the response is numeric or categorical.
+    For numeric responses, ``predicted`` and ``actual`` return a :class:`~citrine.informatics.predictor_evaluation_result.RealMetricValue` which reports mean and standard error associated the data point.
+    For categorical responses, class probabilities are returned as a mapping from each class name (as a string) to the its relative frequency (as a float).
+
+Example
+-------
+
+The following demonstrates how to create a :class:`~citrine.informatics.predictor_evaluator.CrossValidationEvaluator`, add it to a :class:`~citrine.informatics.workflows.predictor_evaluation_workflow.PredictorEvaluationWorkflow` and use it to evaluate a :class:`~citrine.informatics.predictors.Predictor`.
+
+The predictor we'll evaluate is defined below:
+
+.. code:: python
+
+    from citrine.informatics.predictors import SimpleMLPredictor
+    from citrine.informatics.descriptors import RealDescriptor
+
+    x = RealDescriptor('x', lower_bound=0.0, upper_bound=1.0)
+    y = RealDescriptor('y', lower_bound=0.0, upper_bound=1.0)
+
+    data_source = CSVDataSource(
+        filename, # path to CSV that contains training data for x and y
+        column_definitions={'x': x, 'y': y}
+    )
+
+    predictor = SimpleMLPredictor(
+        name='y predictor',
+        description='predicts y given x',
+        inputs=[y],
+        outputs=[x],
+        latent_variables=[],
+        training_data=[data_source]
+    )
+
+This predictor expects ``x`` as an input and predicts ``y``.
+Training data is provided by a :class:`~citrine.informatics.data_sources.CSVDataSource` that assumes ``filename`` represents the path to a CSV that contains ``x`` and ``y``.
+
+Next, we'll create a cross-validation evaluator for the response ``y`` with 8 folds and 3 trials and request metrics for root-mean square error (:class:`~citrine.informatics.predictor_evaluation_metrics.RMSE`) and predicted vs. actual data (:class:`~citrine.informatics.predictor_evaluation_metrics.PVA`).
+
+.. note::
+    Here, we're performing cross-validation on an output, but latent variables are valid cross-validation responses as well.
+
+.. code:: python
+
+    from citrine.informatics.predictor_evaluator import CrossValidationEvaluator
+    from citrine.informatics.predictor_evaluation_metrics import RMSE, PVA
+
+    evaluator = CrossValidationEvaluator(
+        name='cv',
+        n_folds=8,
+        n_trials=3,
+        responses={'y'},
+        metrics={RMSE(), PVA()}
+    )
+
+Then add the evaluator to a :class:`~citrine.informatics.workflows.predictor_evaluation_workflow.PredictorEvaluationWorkflow`, register it with your project and wait for validation to finish:
+
+.. code:: python
+
+    from citrine.seeding.find_or_create import find_or_create_project
+    from citrine.informatics.workflows import PredictorEvaluationWorkflow
+    from citrine.jobs.waiting import wait_while_validating
+
+    api_key = os.environ.get('CITRINE_API_KEY')
+    client = Citrine(api_key)
+    project = find_or_create_project(client.projects, 'example project')
+
+    workflow = PredictorEvaluationWorkflow(
+        name='workflow that evaluates y',
+        evaluators=[evaluator]
+    )
+
+    workflow = project.predictor_evaluation_workflows.register(workflow)
+    wait_while_validating(project.predictor_evaluation_workflows, workflow)
+
+Trigger the workflow against a predictor to start an execution. Then wait for the results to be ready:
+
+.. code:: python
+
+    from time import sleep
+
+    execution = workflow.executions.trigger(predictor.uid)
+    while project.predictor_evaluation_exeuctions.get(execution.uid).status == 'INPROGRESS':
+        time.sleep(10)
+
+Finally, load the results and inspect the metrics and their computed values:
+
+.. code:: python
+
+    # load the results computed by the CV evaluator defined above
+    cv_results = execution[evaluator.name]
+
+    # load results for y
+    y_results = cv_results['y']
+
+    # listing the results should return the metrics we requested: RMSE and PVA
+    computed_metrics = list(y_results)
+    print(computed_metrics) # ['rmse', 'predicted_vs_actual']
+
+    # access RMSE and print the mean and standard error
+    y_rmse = y_results[RMSE()]
+    print(f'RMSE: mean = {y_rmse.mean:0.2f}, standard error = {y_rmse.standard_error:0.2f}')
+
+    # access PVA:
+    y_pva = y_results[PVA()]
+
+    print(len(y_pva)) # this should equal the num_trials * num_folds * num_rows
+                      # where num_rows == the number of rows in the data source
+
+    # inspect the first data point
+    pva_data_point = y_pva[0]
+
+    # print trial and fold indices
+    print(pva_data_point.trial) # should be == 1 since trials are 1-indexed,
+                                # and this it the first data point
+    print(pva_data_point.fold) # should also be == 1
+
+    # inspect predicted and actual values
+    predicted = pva_data_point.predicted
+    print(f'predicted = {predicted.mean:0.2f} +/- {predicted.standard_error}')
+    actual = pva_data_point.actual
+    print(f'actual = {actual.mean} +/- {actual.standard_error}')
+
+
+Archive and restore
+-------------------
+Both :class:`PredictorEvaluationWorkflows <citrine.informatics.workflows.predictor_evaluation_workflow.PredictorEvaluationWorkflow>` and :class:`PredictorEvaluationExecutions <citrine.resources.predictor_evaluation_execution.PredictorEvaluationExecution>` can be archived and restored.
+To archive a workflow:
+
+.. code:: python
+
+    project.predictor_evaluation_workflows.archive(workflow.uid)
+
+and to archive all executions associated with a workflow:
+
+.. code:: python
+
+    for execution in workflow.executions.list():
+        project.predictor_evaluation_executions.archive(execution.uid)
+
+To restore a workflow or execution, simply replace ``archive`` with ``restore`` in the code above.

--- a/docs/source/workflows/predictor_evaluation_workflows.rst
+++ b/docs/source/workflows/predictor_evaluation_workflows.rst
@@ -7,7 +7,7 @@ Each workflow is composed of one or more :class:`PredictorEvaluators <citrine.in
 Predictor evaluators
 --------------------
 
-A predictor evaluator defines a method to evaluate a predictor and any relevant configuration, e.g. k-fold cross-validation evaluation that specifies 3 folds.
+A predictor evaluator defines a method to evaluate a predictor and any relevant configuration, e.g., k-fold cross-validation evaluation that specifies 3 folds.
 Minimally, each predictor evaluator specifies a name, a set of predictor responses to evaluate and a set of metrics to compute for each response.
 Evaluator names must be unique within a single workflow (more on that `below <#execution-and-results>`__).
 Responses are specified as a set of strings, where each string corresponds to a descriptor key of a predictor output.
@@ -20,7 +20,7 @@ Cross-validation evaluator
 
 A :class:`~citrine.informatics.predictor_evaluator.CrossValidationEvaluator` performs k-fold cross-validation on a predictor.
 In addition to a name, set of responses to validate and metrics to compute, this evaluator defines the number of folds, number of trials and set of descriptor keys to ignore when grouping.
-The latter allows candidates with different values for the specified (ignored) keys and identical values all other predictor inputs to be placed in the same fold.
+The latter allows candidates with different values for the specified (ignored) keys and identical values for all other predictor inputs to be placed in the same fold.
 
 Cross-validation can only be evaluated on predictors that define training data.
 During cross-validation, the predictor's training data is partitioned into k equally sized folds.
@@ -37,7 +37,7 @@ For numeric responses, the following metrics are available:
 
   - *Root-mean squared error* (:class:`~citrine.informatics.predictor_evaluation_metrics.RMSE`): square root of the average of the squared prediction error.
     RMSE is a useful and popular statistical metric for model quality.
-    RMSE is optimized by least-squares regression, and in that sense is the most "natural" measure for it; it has the same units as the predicted quantity, and corresponds to the standard deviation of the variance not explained by the predictor.
+    RMSE is optimized by least-squares regression, and in that sense is the most "natural" measure for it; it has the same units as the predicted quantity and corresponds to the standard deviation of the variance not explained by the predictor.
     Lower RMSE means the model is more accurate.
   - *Non-dimensional error* (:class:`~citrine.informatics.predictor_evaluation_metrics.NDME`): RMSE divided by the standard deviation of the observed values in the test set.
     (If training and test set are drawn from the same distribution, the standard deviation of the test set observed values is equivalent to the RMSE of a model that always predicts the mean of the observed values).
@@ -70,7 +70,7 @@ For categorical responses, performance metrics include either the area under the
    Scores are bounded by 0 and 1.
    At a value of 1, the model has perfect precision and recall.
 
-In addition to the aforementioned metrics, predicted vs. actual data (:class:`~citrine.informatics.predictor_evaluation_metrics.PVA`) are also available.
+In addition to the aforementioned metrics, predicted vs. actual data (:class:`~citrine.informatics.predictor_evaluation_metrics.PVA`) are also available for both real and categorical responses.
 
 
 .. _execution-and-results:
@@ -81,7 +81,7 @@ Execution and results
 Triggering a Predictor Evaluation Workflow produces a :class:`~citrine.resources.predictor_evaluation_execution.PredictorEvaluationExecution`.
 This execution allows you to track the progress using its ``status`` and ``status_info`` properties.
 The ``status`` can be one of ``INPROGRESS``, ``READY`` or ``FAILED``.
-Information about the execution status, e.g. warnings or reasons for failure, can be accessed via ``status_info``.
+Information about the execution status, e.g., warnings or reasons for failure, can be accessed via ``status_info``.
 
 When the ``status`` is ``READY``, results for each evaluation defined as part of the workflow can be accessed using the ``results`` method:
 
@@ -110,21 +110,21 @@ Values associated with computed metrics can be accessed by response key:
 This returns a :class:`~citrine.informatics.predictor_evaluation_result.ResponseMetrics` object.
 This object contains all metrics that were computed for the ``response_key``.
 These metrics can be listed using ``list(response_metrics)``,
-and the value associated with a specific metric can be accessed by the metric itself, e.g. ``response_metrics[RMSE()]`` to retrieve the root-mean squared error.
+and the value associated with a specific metric can be accessed by the metric itself, e.g., ``response_metrics[RMSE()]`` to retrieve the root-mean squared error.
 
 With the exception of predicted vs. actual data, all metric values are returned as a :class:`~citrine.informatics.predictor_evaluation_result.RealMetricValue`.
 This object defines properties ``mean`` and ``standard_error``.
 The latter optionally returns a float if the evaluation was configured with enough trials allow ``standard_error`` to be computed.
 (A :class:`~citrine.informatics.predictor_evaluator.CrossValidationEvaluator` requires at least 3 trials to compute ``standard_error``.)
 
-Predicted vs. actual data (e.g. ``response_metrics[PVA()]``) is returned as a list of predicted vs. actual data points.
+Predicted vs. actual data (``response_metrics[PVA()]``) is returned as a list of predicted vs. actual data points.
 Each data point defines properties ``uuid``, ``identifiers``, ``trial``, ``fold``, ``predicted`` and ``actual``:
 
  -  ``uuid`` and ``identifiers`` allow you to link a predicted vs. actual data point to the corresponding row in the :ref:`Predictor <predictors>`'s :ref:`Data Source <data-sources>`.
  -  ``trial`` and ``fold`` return the each respective index during the evaluation.
  -  The form of ``predicted`` and ``actual`` data depends on whether the response is numeric or categorical.
     For numeric responses, ``predicted`` and ``actual`` return a :class:`~citrine.informatics.predictor_evaluation_result.RealMetricValue` which reports mean and standard error associated the data point.
-    For categorical responses, class probabilities are returned as a mapping from each class name (as a string) to the its relative frequency (as a float).
+    For categorical responses, class probabilities are returned as a mapping from each class name (as a string) to its relative frequency (as a float).
 
 Example
 -------
@@ -161,7 +161,7 @@ Training data is provided by a :class:`~citrine.informatics.data_sources.CSVData
 Next, we'll create a cross-validation evaluator for the response ``y`` with 8 folds and 3 trials and request metrics for root-mean square error (:class:`~citrine.informatics.predictor_evaluation_metrics.RMSE`) and predicted vs. actual data (:class:`~citrine.informatics.predictor_evaluation_metrics.PVA`).
 
 .. note::
-    Here, we're performing cross-validation on an output, but latent variables are valid cross-validation responses as well.
+    Here we're performing cross-validation on an output, but latent variables are valid cross-validation responses as well.
 
 .. code:: python
 

--- a/docs/source/workflows/predictor_evaluation_workflows.rst
+++ b/docs/source/workflows/predictor_evaluation_workflows.rst
@@ -36,7 +36,8 @@ For numeric responses, the following metrics are available:
 
   - *Root-mean squared error* (:class:`~citrine.informatics.predictor_evaluation_metrics.RMSE`): square root of the average of the squared prediction error.
     RMSE is a useful and popular statistical metric for model quality.
-    RMSE is optimized by least-squares regression, and in that sense is the most "natural" measure for it; it has the same units as the predicted quantity and corresponds to the standard deviation of the variance not explained by the predictor.
+    RMSE is optimized by least-squares regression.
+    It has the same units as the predicted quantity and corresponds to the standard deviation of the residuals not explained by the predictor.
     Lower RMSE means the model is more accurate.
   - *Non-dimensional error* (:class:`~citrine.informatics.predictor_evaluation_metrics.NDME`): RMSE divided by the standard deviation of the observed values in the test set.
     (If training and test set are drawn from the same distribution, the standard deviation of the test set observed values is equivalent to the RMSE of a model that always predicts the mean of the observed values).

--- a/docs/source/workflows/predictor_reports.rst
+++ b/docs/source/workflows/predictor_reports.rst
@@ -1,10 +1,10 @@
-Predictor reports
+Predictor Reports
 =================
 
 Training a predictor generally produces a set of inter-connected models.
 A predictor report describes those models, for example their settings and what features are important to the model.
-It does not include performance metrics.
-To learn more about performance metrics, please see :doc:`PerformanceWorkflows <performance_workflows>`.
+It does not include predictor evaluation metrics.
+To learn more about predictor evaluation metrics, please see :doc:`PredictorEvaluationMetrics <predictor_evaluation_workflows>`.
 The report can be accessed via ``predictor.report``.
 
 A task to generate a predictor report is scheduled when a predictor is registered.

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -1,3 +1,5 @@
+.. _predictors:
+
 Predictors
 ==========
 
@@ -141,7 +143,7 @@ Expression predictor
 --------------------
 
 The :class:`~citrine.informatics.predictors.ExpressionPredictor` defines an analytic (lossless) model that computes one real-valued output descriptor from one or more input descriptors.
-An ``ExpressionPredictor`` should be used when the relationship between inputs and outputs is known.
+An :class:`~citrine.informatics.predictors.ExpressionPredictor` should be used when the relationship between inputs and outputs is known.
 
 A string is used to define the expression, and the corresponding output is defined by a :class:`~citrine.informatics.descriptors.RealDescriptor`.
 An alias is required for each expression argument.
@@ -488,7 +490,8 @@ Predictor reports
 -----------------
 
 A :doc:`predictor report <predictor_reports>` describes a machine-learned model, for example its settings and what features are important to the model. 
-It does not include performance metrics. To learn more about performance metrics, please see :doc:`PerformanceWorkflows <performance_workflows>`.
+It does not include predictor evaluation metrics.
+To learn more about predictor evaluation metrics, please see :doc:`PredictorEvaluationWorkflow <predictor_evaluation_workflows>`.
 
 Training data
 -------------

--- a/docs/source/workflows/processors.rst
+++ b/docs/source/workflows/processors.rst
@@ -15,7 +15,7 @@ The maximum number of candidates sampled from the design space is defined by the
 To be valid, enumerated processors must have a maximum size of at least 1.
 
 An enumerated processor can be used with finite and infinite design spaces.
-A finite space can be defined using an :class:`~citrine.informatics.design_spaces.EnumeratedDesignSpace` or a :class:`~citrine.informatics.design_spaces.ProductDesignSpace` composed only of :class:`~citrine.informatics.dimensions.EnumeratedDimension` s.
+A finite space can be defined using an :class:`~citrine.informatics.design_spaces.EnumeratedDesignSpace` or a :class:`~citrine.informatics.design_spaces.ProductDesignSpace` composed only of :class:`EnumeratedDimensions <citrine.informatics.dimensions.EnumeratedDimension>`.
 In these cases, the processor will systematically pull up to ``max_size`` samples from the space.
 
 An infinite design space is created when a :class:`~citrine.informatics.design_spaces.ProductDesignSpace` contains one or more continuous dimensions.

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.77.3',
+      version='0.77.4',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/gemtables/columns.py
+++ b/src/citrine/gemtables/columns.py
@@ -13,7 +13,8 @@ class CompositionSortOrder(BaseEnumeration):
     """[ALPHA] Order to use when sorting the components in a composition.
 
     * ``ALPHABETICAL`` is alpha-numeric order by the component name
-    * ``QUANTITY`` is ordered from the largest to smallest quantity, with ties broken alphabetically
+    * ``QUANTITY`` is ordered from the largest to smallest quantity, with ties
+      broken alphabetically
     """
 
     ALPHABETICAL = "alphabetical"
@@ -135,7 +136,7 @@ class QuantileColumn(Serializable["QuantileColumn"], Column):
 
     .. math::
 
-        mean + stddev * \sqrt{2} * erf^{-1}(2 * quantile - 1)
+        mean + stddev * \\sqrt{2} * erf^{-1}(2 * quantile - 1)
 
     Parameters
     ----------
@@ -232,8 +233,8 @@ class FlatCompositionColumn(Serializable["FlatCompositionColumn"], Column):
     """[ALPHA] Column that flattens the composition into a string of names and quantities.
 
     The numeric formatting tries to be human readable. For example, if all of the quantities
-    are round numbers like ``{"spam": 4.0, "eggs": 1.0}`` then the result omit the decimal points like
-    ``"(spam)4(eggs)1"`` (if sort_order is by quantity).
+    are round numbers like ``{"spam": 4.0, "eggs": 1.0}`` then the result omit the decimal points
+    like ``"(spam)4(eggs)1"`` (if sort_order is by quantity).
 
     Parameters
     ----------

--- a/src/citrine/gemtables/columns.py
+++ b/src/citrine/gemtables/columns.py
@@ -12,8 +12,8 @@ from citrine._serialization import properties
 class CompositionSortOrder(BaseEnumeration):
     """[ALPHA] Order to use when sorting the components in a composition.
 
-    * ALPHABETICAL is alpha-numeric order by the component name
-    * QUANTITY is ordered from the largest to smallest quantity, with ties broken alphabetically
+    * ``ALPHABETICAL`` is alpha-numeric order by the component name
+    * ``QUANTITY`` is ordered from the largest to smallest quantity, with ties broken alphabetically
     """
 
     ALPHABETICAL = "alphabetical"
@@ -23,8 +23,8 @@ class CompositionSortOrder(BaseEnumeration):
 class ChemicalDisplayFormat(BaseEnumeration):
     """[ALPHA] Format to use when rendering a molecular structure.
 
-    * SMILES Simplified molecular-input line-entry system
-    * INCHI International Chemical Identifier
+    * ``SMILES`` Simplified molecular-input line-entry system
+    * ``INCHI`` International Chemical Identifier
     """
 
     SMILES = "smiles"
@@ -75,7 +75,7 @@ class MeanColumn(Serializable['MeanColumn'], Column):
     ----------
     data_source: str
         name of the variable to use when populating the column
-    target_units: optional[str]
+    target_units: Optional[str]
         units to convert the real variable into
 
     """
@@ -101,7 +101,7 @@ class StdDevColumn(Serializable["StdDevColumn"], Column):
     ----------
     data_source: str
         name of the variable to use when populating the column
-    target_units: optional[str]
+    target_units: Optional[str]
         units to convert the real variable into
 
     """
@@ -126,9 +126,16 @@ class QuantileColumn(Serializable["QuantileColumn"], Column):
     The column is populated with the quantile function of the distribution evaluated at "quantile".
     For example, for a uniform distribution parameterized by a lower and upper bound, the value
     in the column would be:
+
+    .. math::
+
         lower + (upper - lower) * quantile
+
     while for a normal distribution parameterized by a mean and stddev, the value would be:
-        mean + stddev * sqrt(2) * inverse error function (2 * quantile - 1)
+
+    .. math::
+
+        mean + stddev * \sqrt{2} * erf^{-1}(2 * quantile - 1)
 
     Parameters
     ----------
@@ -136,7 +143,7 @@ class QuantileColumn(Serializable["QuantileColumn"], Column):
         name of the variable to use when populating the column
     quantile: float
         the quantile to use for the column, defined between 0.0 and 1.0
-    target_units: optional[str]
+    target_units: Optional[str]
         units to convert the real variable into
 
     """
@@ -225,8 +232,8 @@ class FlatCompositionColumn(Serializable["FlatCompositionColumn"], Column):
     """[ALPHA] Column that flattens the composition into a string of names and quantities.
 
     The numeric formatting tries to be human readable. For example, if all of the quantities
-    are round numbers like {"spam": 4.0, "eggs": 1.0} then the result omit the decimal points like
-    "(spam)4(eggs)1" (if sort_order is by quantity).
+    are round numbers like ``{"spam": 4.0, "eggs": 1.0}`` then the result omit the decimal points like
+    ``"(spam)4(eggs)1"`` (if sort_order is by quantity).
 
     Parameters
     ----------

--- a/src/citrine/informatics/data_sources.py
+++ b/src/citrine/informatics/data_sources.py
@@ -9,6 +9,10 @@ from citrine._serialization.serializable import Serializable
 from citrine.informatics.descriptors import Descriptor, FormulationDescriptor
 from citrine.resources.file_link import FileLink
 
+__all__ = ['DataSource',
+           'CSVDataSource',
+           'GemTableDataSource']
+
 
 class DataSource(PolymorphicSerializable['DataSource']):
     """A source of data for the AI engine.

--- a/src/citrine/informatics/predictor_evaluation_metrics.py
+++ b/src/citrine/informatics/predictor_evaluation_metrics.py
@@ -6,6 +6,15 @@ from citrine._serialization import properties
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
 from citrine._serialization.serializable import Serializable
 
+__all__ = ['PredictorEvaluationMetric',
+           'RMSE',
+           'NDME',
+           'StandardRMSE',
+           'PVA',
+           'F1',
+           'AreaUnderROC',
+           'CoverageProbability']
+
 
 class PredictorEvaluationMetric(PolymorphicSerializable["PredictorEvaluationMetric"]):
     """[ALPHA] A metric computed during a Predictor Evaluation Workflow.

--- a/src/citrine/informatics/predictor_evaluation_result.py
+++ b/src/citrine/informatics/predictor_evaluation_result.py
@@ -7,6 +7,16 @@ from citrine.informatics.predictor_evaluation_metrics import PredictorEvaluation
 from citrine.informatics.predictor_evaluator import PredictorEvaluator
 
 
+__all__ = ['MetricValue',
+           'RealMetricValue',
+           'PredictedVsActualRealPoint',
+           'PredictedVsActualCategoricalPoint',
+           'RealPredictedVsActual',
+           'CategoricalPredictedVsActual',
+           'ResponseMetrics',
+           'PredictorEvaluationResult',
+           'CrossValidationResult']
+
 class MetricValue(PolymorphicSerializable["MetricValue"]):
     """[ALPHA] Value associated with a metric computed during a Predictor Evaluation Workflow."""
 
@@ -31,7 +41,7 @@ class RealMetricValue(Serializable["RealMetricValue"], MetricValue):
     ----------
     mean: float
         Mean value
-    standard_error: float
+    standard_error: Optional[float]
         Standard error of the mean
 
     """

--- a/src/citrine/informatics/predictor_evaluation_result.py
+++ b/src/citrine/informatics/predictor_evaluation_result.py
@@ -17,6 +17,7 @@ __all__ = ['MetricValue',
            'PredictorEvaluationResult',
            'CrossValidationResult']
 
+
 class MetricValue(PolymorphicSerializable["MetricValue"]):
     """[ALPHA] Value associated with a metric computed during a Predictor Evaluation Workflow."""
 

--- a/src/citrine/informatics/predictor_evaluator.py
+++ b/src/citrine/informatics/predictor_evaluator.py
@@ -5,6 +5,9 @@ from citrine._serialization.polymorphic_serializable import PolymorphicSerializa
 from citrine._serialization.serializable import Serializable
 from citrine.informatics.predictor_evaluation_metrics import PredictorEvaluationMetric
 
+__all__ = ['PredictorEvaluator',
+           'CrossValidationEvaluator']
+
 
 class PredictorEvaluator(PolymorphicSerializable["PredictorEvaluator"]):
     """[ALPHA] A Citrine Predictor Evaluator computes metrics on a predictor."""
@@ -66,7 +69,7 @@ class CrossValidationEvaluator(Serializable["CrossValidationEvaluator"], Predict
     n_folds: int
         Number of cross-validation folds
     n_trials: int
-        Number of cross-valiation trials, each contains ``n_folds`` folds
+        Number of cross-validation trials, each contains ``n_folds`` folds
     metrics: Optional[Set[PredictorEvaluationMetric]]
         Optional set of metrics to compute for each response.
         Default is all metrics.

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -239,20 +239,20 @@ class Project(Resource['Project']):
         Transfer ownership of a resource.
 
         The new owner of the the supplied resource becomes the project
-        with uid = receiving_project_uid.
+        with ``uid == receiving_project_uid``.
 
         Parameters
         ----------
         resource: Resource
             The resource owned by this project, which will get transferred to
-            the project with uid = receiving_project_uid.
+            the project with ``uid == receiving_project_uid``.
         receiving_project_uid: Union[string, UUID]
             The uid of the project to which the resource will be transferred.
 
         Returns
         -------
         bool
-            Returns True upon successful resource transfer.
+            Returns ``True`` upon successful resource transfer.
 
         """
         self.session.checked_post(self._path() + "/transfer-resource", {
@@ -274,7 +274,7 @@ class Project(Resource['Project']):
         Returns
         -------
         bool
-            True if the action was performed successfully
+            ``True`` if the action was performed successfully
 
         """
         self.session.checked_post(self._path() + "/make-public", {
@@ -295,7 +295,7 @@ class Project(Resource['Project']):
         Returns
         -------
         bool
-            True if the action was performed successfully
+            ``True`` if the action was performed successfully
 
         """
         self.session.checked_post(self._path() + "/make-private", {
@@ -320,14 +320,14 @@ class Project(Resource['Project']):
         """
         Update a User's role and action permissions in the Project.
 
-        Valid roles are MEMBER or LEAD.
+        Valid roles are ``MEMBER`` or ``LEAD``.
 
-        WRITE is the only action available for specification.
+        ``WRITE`` is the only action available for specification.
 
         Returns
         -------
         bool
-            Returns True if user role successfully updated
+            Returns ``True`` if user role successfully updated
 
         """
         self.session.checked_post(self._path() + "/users/{}".format(user_uid),
@@ -338,13 +338,13 @@ class Project(Resource['Project']):
         """
         Add a User to a Project.
 
-        Adds User with MEMBER role to the Project.
-        Use the update_user_rule method to change a User's role.
+        Adds User with ``MEMBER`` role to the Project.
+        Use the ``update_user_rule`` method to change a User's role.
 
         Returns
         -------
         bool
-            Returns True if user successfully added
+            Returns ``True`` if user successfully added
 
         """
         self.session.checked_post(self._path() + "/users/{}".format(user_uid),
@@ -358,7 +358,7 @@ class Project(Resource['Project']):
         Returns
         -------
         bool
-            Returns True if user successfully removed
+            Returns ``True`` if user successfully removed
 
         """
         self.session.checked_delete(
@@ -455,36 +455,40 @@ class ProjectCollection(Collection[Project]):
         or substring match, as specified by the search_params argument. Defaults to no search
         criteria.
 
-        Like list, this method allows for pagination. This differs from the list function, because
+        Like ``list``, this method allows for pagination. This differs from the list function, because
         it makes a POST request to resourceType/search with search fields in a post body.
 
         Leaving page and per_page as default values will yield all elements in the collection,
         paginating over all available pages.
 
-        Leaving search_params as its default value will return mimic the behavior of a full list
+        Leaving ``search_params`` as its default value will return mimic the behavior of a full list
         with no search parameters.
 
         Parameters
-        ---------
+        ----------
         search_params: dict, optional
-            A dict representing the body of the post request that will be sent to the search
-            endpoint to filter the results ie.
-            {
-                "name": {
-                    "value": "Polymer Project",
-                    "search_method": "EXACT"
-                },
-                "description": {
-                    "value": "polymer chain length",
-                    "search_method": "SUBSTRING"
-                },
-            }
-            The dict can constain any combination of (one or all) search specifications for the
+            A ``dict`` representing the body of the post request that will be sent to the search
+            endpoint to filter the results i.e.
+
+            .. code:: python
+
+                {
+                    "name": {
+                        "value": "Polymer Project",
+                        "search_method": "EXACT"
+                    },
+                    "description": {
+                        "value": "polymer chain length",
+                        "search_method": "SUBSTRING"
+                    },
+                }
+
+            The ``dict`` can contain any combination of (one or all) search specifications for the
             name, description, and status fields of a project. For each parameter specified, the
-            "value" to match, as well as the "search_method" must be provided. The available
-            search_methods are "SUBSTRING" and "EXACT". The example above demonstrates the input
-            necessary to list projects with the exact name "Polymer Project," and descriptions
-            including the phrase "polymer chain length,"
+            ``"value"`` to match, as well as the ``"search_method"`` must be provided. The available
+            ``search_methods`` are ``"SUBSTRING"`` and ``"EXACT"``. The example above demonstrates the input
+            necessary to list projects with the exact name ``"Polymer Project"`` and descriptions
+            including the phrase ``"polymer chain length"``.
 
         per_page: int, optional
             Max number of results to return per page. Default is 100.  This parameter is used when
@@ -515,8 +519,8 @@ class ProjectCollection(Collection[Project]):
         """
         Fetch resources that match the supplied search parameters.
 
-        Fetches resources that match the supplied search_params, by calling _fetch_page with
-        checked_post, the path to the POST resource-type/search endpoint, any pagination
+        Fetches resources that match the supplied ``search_params``, by calling ``_fetch_page`` with
+        ``checked_post``, the path to the POST resource-type/search endpoint, any pagination
         parameters, and the request body to the search endpoint.
 
         Parameters
@@ -526,11 +530,11 @@ class ProjectCollection(Collection[Project]):
         per_page: int, optional
             Max number of results to return. Default is 20.
         search_params: dict, optional
-            A dict representing a request body that could be sent to a POST request. The "json"
-            field should be passed as the key for the outermost dict, with its value the request
+            A ``dict`` representing a request body that could be sent to a POST request. The "json"
+            field should be passed as the key for the outermost ``dict``, with its value the request
             body, so that we can easily unpack the keyword argument when it gets passed to
-            fetch_func.
-            ie. {'name': {'value': 'Project', 'search_method': 'SUBSTRING'} }
+            ``fetch_func``.
+            i.e. ``{'name': {'value': 'Project', 'search_method': 'SUBSTRING'} }``
 
         Returns
         -------

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -455,14 +455,14 @@ class ProjectCollection(Collection[Project]):
         or substring match, as specified by the search_params argument. Defaults to no search
         criteria.
 
-        Like ``list``, this method allows for pagination. This differs from the list function, because
-        it makes a POST request to resourceType/search with search fields in a post body.
+        Like ``list``, this method allows for pagination. This differs from the list function,
+        because it makes a POST request to resourceType/search with search fields in a post body.
 
         Leaving page and per_page as default values will yield all elements in the collection,
         paginating over all available pages.
 
-        Leaving ``search_params`` as its default value will return mimic the behavior of a full list
-        with no search parameters.
+        Leaving ``search_params`` as its default value will return mimic the behavior of
+        a full list with no search parameters.
 
         Parameters
         ----------
@@ -485,10 +485,10 @@ class ProjectCollection(Collection[Project]):
 
             The ``dict`` can contain any combination of (one or all) search specifications for the
             name, description, and status fields of a project. For each parameter specified, the
-            ``"value"`` to match, as well as the ``"search_method"`` must be provided. The available
-            ``search_methods`` are ``"SUBSTRING"`` and ``"EXACT"``. The example above demonstrates the input
-            necessary to list projects with the exact name ``"Polymer Project"`` and descriptions
-            including the phrase ``"polymer chain length"``.
+            ``"value"`` to match, as well as the ``"search_method"`` must be provided.
+            The available ``search_methods`` are ``"SUBSTRING"`` and ``"EXACT"``. The example above
+            demonstrates the input necessary to list projects with the exact name
+            ``"Polymer Project"`` and descriptions including the phrase ``"polymer chain length"``.
 
         per_page: int, optional
             Max number of results to return per page. Default is 100.  This parameter is used when
@@ -519,8 +519,8 @@ class ProjectCollection(Collection[Project]):
         """
         Fetch resources that match the supplied search parameters.
 
-        Fetches resources that match the supplied ``search_params``, by calling ``_fetch_page`` with
-        ``checked_post``, the path to the POST resource-type/search endpoint, any pagination
+        Fetches resources that match the supplied ``search_params``, by calling ``_fetch_page``
+        with ``checked_post``, the path to the POST resource-type/search endpoint, any pagination
         parameters, and the request body to the search endpoint.
 
         Parameters
@@ -531,10 +531,9 @@ class ProjectCollection(Collection[Project]):
             Max number of results to return. Default is 20.
         search_params: dict, optional
             A ``dict`` representing a request body that could be sent to a POST request. The "json"
-            field should be passed as the key for the outermost ``dict``, with its value the request
-            body, so that we can easily unpack the keyword argument when it gets passed to
-            ``fetch_func``.
-            i.e. ``{'name': {'value': 'Project', 'search_method': 'SUBSTRING'} }``
+            field should be passed as the key for the outermost ``dict``, with its value the
+            request body, so that we can easily unpack the keyword argument when it gets passed to
+            ``fetch_func``, i.e. ``{'name': {'value': 'Project', 'search_method': 'SUBSTRING'} }``
 
         Returns
         -------

--- a/src/citrine/resources/table_config.py
+++ b/src/citrine/resources/table_config.py
@@ -373,11 +373,11 @@ class TableConfigCollection(Collection[TableConfig]):
     def preview(self, table_config: TableConfig, preview_roots: List[LinkByUID]) -> dict:
         """[ALPHA] Preview a Table Config on an explicit set of roots.
 
-         Parameters
+        Parameters
         ----------
-        defn: TableConfig
+        table_config: TableConfig
             Table Config to preview
-        preview_roots: list[LinkByUID]
+        preview_roots: List[LinkByUID]
             List of links to the material history roots to use in the preview
 
         """


### PR DESCRIPTION
This PR adds user docs for predictor evaluation workflows. I also took the liberty of cleaning some of the Sphinx formatting warnings, mostly broken links, misaligned headings and inconsistencies with text formatting.
