### PR TITLE
add debug statement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.77.4',
+      version='0.77.5',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       author='Citrine Informatics',

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -128,10 +128,15 @@ class Session(requests.Session):
             if response.status_code == 401 and response.json().get("reason") == "invalid-token":
                 self._refresh_access_token()
                 response = self._request_with_retry(method, uri, **kwargs)
+        except AttributeError:
+            # Catch AttributeErrors and log response
+            # The 401 status will be handled further down
+            logger.error("Failed to decode json from response: {}".format(response.text))
         except ValueError:
             # Ignore ValueErrors thrown by attempting to decode json bodies. This
             # might occur if we get a 401 response without a JSON body
             pass
+
 
         # TODO: More substantial/careful error handling
         if 200 <= response.status_code <= 299:

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -137,7 +137,6 @@ class Session(requests.Session):
             # might occur if we get a 401 response without a JSON body
             pass
 
-
         # TODO: More substantial/careful error handling
         if 200 <= response.status_code <= 299:
             logger.info('%s %s %s', response.status_code, method, path)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -196,6 +196,18 @@ def test_delete_unauthorized_without_json_legacy(session: Session):
             session.delete_resource('/bar/something')
 
 
+def test_delete_unauthorized_with_str_json_legacy(session: Session):
+    with requests_mock.Mocker() as m:
+        m.delete(
+            'http://citrine-testing.fake/api/v1/bar/something',
+            status_code=401,
+            json='an error string'
+        )
+
+        with pytest.raises(Unauthorized):
+            session.delete_resource('/bar/something')
+
+
 def test_delete_unauthorized_without_json(session: Session):
     with requests_mock.Mocker() as m:
         m.delete('http://citrine-testing.fake/api/v1/bar/something', status_code=403)


### PR DESCRIPTION
Adds a logging statement to catch an unexpectedly formatted json response as seen in jenkins

```
11:44:58  /usr/local/lib/python3.6/site-packages/citrine/_session.py:128: in checked_request
11:44:58      if response.status_code == 401 and response.json().get("reason") == "invalid-token":
11:44:58  E   AttributeError: 'str' object has no attribute 'get'
````

# Citrine Python PR

## Description 
Please briefly explain the goal of the changes/this PR.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
