### PR TITLE
Populating the long_description field in setup() for use on Pypi.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.78.0',
+      version='0.78.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,14 @@ from setuptools.command.develop import develop
 from setuptools.command.build_py import build_py
 import sys
 from os.path import join
-from os import walk
+from os import walk, path
 
 STRIP_DIRS = ["src", "tests"]
+
+# read the contents of your README file
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
 
 
 def strip_file(file_path):
@@ -60,6 +65,8 @@ setup(name='citrine',
       version='0.78.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       author='Citrine Informatics',
       package_dir={'': 'src'},
       packages=find_packages(where='src'),


### PR DESCRIPTION
Currently the citrine package on pypi.org does not have a description.  This minor change uses the contents of README.md as the long_description which will be displayed on https://pypi.org/project/citrine/.  This uses the recommended approach from https://packaging.python.org/guides/making-a-pypi-friendly-readme/.

# Citrine Python PR

## Description 
Please briefly explain the goal of the changes/this PR.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
