### PR TITLE
PLA-5878 fix wait_while_executing bug

### DIFF
--- a/docs/source/workflows/predictor_evaluation_workflows.rst
+++ b/docs/source/workflows/predictor_evaluation_workflows.rst
@@ -208,11 +208,10 @@ Then wait for the results to be ready:
 
 .. code:: python
 
-    from time import sleep
+    from citrine.jobs.waiting import wait_while_executing
 
     execution = workflow.executions.trigger(predictor.uid)
-    while project.predictor_evaluation_exeuctions.get(execution.uid).status == 'INPROGRESS':
-        time.sleep(10)
+    wait_while_executing(execution, print_status_info=True, collection = project.predictor_evaluation_executions)
 
 Finally, load the results and inspect the metrics and their computed values:
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.78.1',
+      version='0.78.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/src/citrine/jobs/waiting.py
+++ b/src/citrine/jobs/waiting.py
@@ -2,12 +2,10 @@ import time
 from pprint import pprint
 from citrine._rest.collection import Collection
 from citrine.informatics.modules import Module
+from citrine.resources.predictor_evaluation_execution import PredictorEvaluationExecution
 from citrine.resources.workflow_executions import (
     WorkflowExecution,
     WorkflowExecutionStatus,
-)
-from citrine.resources.predictor_evaluation_execution import (
-    PredictorEvaluationExecution
 )
 from typing import Union
 

--- a/tests/jobs/test_waiting.py
+++ b/tests/jobs/test_waiting.py
@@ -3,11 +3,17 @@ import pytest
 import mock
 import io
 import sys
+from datetime import datetime
+import time
 
 from citrine.jobs.waiting import wait_while_executing, wait_while_validating, ConditionTimeoutError
+from citrine.resources.predictor_evaluation_execution import (
+    PredictorEvaluationExecution
+)
 
-def test_wait_while_validating():
 
+@mock.patch('time.sleep', return_value=None)
+def test_wait_while_validating(sleep_mock):
     captured_output = io.StringIO()
     sys.stdout = captured_output
 
@@ -24,7 +30,15 @@ def test_wait_while_validating():
     assert("Status = VALID" in captured_output.getvalue())
     assert("The predictor is now validated." in captured_output.getvalue())
 
-def test_wait_while_validating_timeout():
+
+@mock.patch('time.time')
+@mock.patch('time.sleep', return_value=None)
+def test_wait_while_validating_timeout(sleep_mock, time_mock):
+    time_mock.side_effect = [
+        time.mktime(datetime(2020, 10, 30).timetuple()),
+        time.mktime(datetime(2020, 10, 31).timetuple())
+    ]
+
     captured_output = io.StringIO()
     sys.stdout = captured_output
 
@@ -37,8 +51,9 @@ def test_wait_while_validating_timeout():
     with pytest.raises(ConditionTimeoutError):
         wait_while_validating(collection, module, timeout=1.0)
 
-def test_wait_while_executing():
 
+@mock.patch('time.sleep', return_value=None)
+def test_wait_while_executing(sleep_mock):
     captured_output = io.StringIO()
     sys.stdout = captured_output
 
@@ -55,7 +70,38 @@ def test_wait_while_executing():
     assert("Finished" in captured_output.getvalue())
 
 
-def test_while_executing_timeout():
+@mock.patch('time.sleep', return_value=None)
+def test_wait_while_executing_predictor_evaluation_execution(sleep_mock):
+    captured_output = io.StringIO()
+    sys.stdout = captured_output
+
+    collection = mock.Mock()
+    predictor_evaluation_execution = mock.Mock(spec=PredictorEvaluationExecution)
+    execution_status = mock.Mock()
+    statuses = mock.PropertyMock(side_effect = ["INPROGRESS", "READY", "READY"])
+    status_info = mock.PropertyMock(return_value = "???")
+    type(predictor_evaluation_execution).status = statuses
+    type(predictor_evaluation_execution).status_info = status_info
+    collection.get.return_value = predictor_evaluation_execution
+
+    wait_while_executing(predictor_evaluation_execution, print_status_info=True, collection=collection)
+    assert("READY" in captured_output.getvalue())
+
+
+def test_wait_while_executing_predictor_evaluation_execution_missing_collection():
+    predictor_evaluation_execution = mock.Mock(spec=PredictorEvaluationExecution)
+
+    with pytest.raises(ValueError):
+        wait_while_executing(predictor_evaluation_execution, print_status_info=True)
+
+
+@mock.patch('time.time')
+@mock.patch('time.sleep', return_value=None)
+def test_while_executing_timeout(sleep_mock, time_mock):
+    time_mock.side_effect = [
+        time.mktime(datetime(2020, 10, 30).timetuple()),
+        time.mktime(datetime(2020, 10, 31).timetuple())
+    ]
     
     captured_output = io.StringIO()
     sys.stdout = captured_output

--- a/tests/jobs/test_waiting.py
+++ b/tests/jobs/test_waiting.py
@@ -7,9 +7,7 @@ from datetime import datetime
 import time
 
 from citrine.jobs.waiting import wait_while_executing, wait_while_validating, ConditionTimeoutError
-from citrine.resources.predictor_evaluation_execution import (
-    PredictorEvaluationExecution
-)
+from citrine.resources.predictor_evaluation_execution import PredictorEvaluationExecution
 
 
 @mock.patch('time.sleep', return_value=None)


### PR DESCRIPTION
# Citrine Python PR

## Description 
This fixes `wait_while_executing` so that it works both with the old style executions and the new ones. I've tested this against development as seen in the doc update.
I also added mocks for the sleep and time calls so that the unit tests run a little faster, and had to change the imports a little to get that to work.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
