### PR TITLE
Pla 5877 add collection key for pew

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.78.1',
+      version='0.78.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.78.2',
+      version='0.78.3',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/src/citrine/resources/predictor_evaluation_workflow.py
+++ b/src/citrine/resources/predictor_evaluation_workflow.py
@@ -12,6 +12,7 @@ class PredictorEvaluationWorkflowCollection(Collection[PredictorEvaluationWorkfl
 
     _path_template = '/projects/{project_id}/predictor-evaluation-workflows'
     _individual_key = None
+    _collection_key = 'response'
     _resource = PredictorEvaluationWorkflow
 
     def __init__(self, project_id: UUID, session: Session):


### PR DESCRIPTION
# Citrine Python PR

## Description 
Take 2 on this PR, previous PR got stuck in a weird requirements state.

Allows users to:

```
from citrine.informatics.workflows import PredictorEvaluationWorkflow
from citrine.seeding.find_or_create import get_by_name_or_create

workflow = PredictorEvaluationWorkflow(
    name='workflow that evaluates y 4',
    evaluators=[evaluator]
)
def register_pew():
    pew = project.predictor_evaluation_workflows.register(workflow)
    wait_while_validating(project.predictor_evaluation_workflows, pew, print_status_info=True)
    return pew

registered_pew = get_by_name_or_create(project.predictor_evaluation_workflows, workflow.name, register_pew)
```

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
