### PR TITLE
Use str() instead of __class__ to avoid constructing resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.78.4',
+      version='0.78.5',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -216,7 +216,7 @@ class Collection(Generic[ResourceType]):
     def _check_experimental(self, data):
         if data.get("experimental", False):
             uid = data.get("id")
-            typ = self._resource().__class__.__name__
+            typ = str(self._resource)
             msg = "The {} with id {} is experimental because: \n  {}".format(
                 typ, uid,
                 "\n  ".join(data.get("experimental_reasons") or ["Unknown reason"])


### PR DESCRIPTION
# Citrine Python PR

## Description 

The existing logic tried to construct a resource with an empty
constructor and then use __class__ to figure out the class name.
This failed when the constructor had required arguments.

The change is to just use str() on the class, which should have
the same behavior and avoid hitting the constructor.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
