### PR TITLE
Raise NotImplementedError when deleting PEWs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.78.5',
+      version='0.78.6',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.79.1',
+      version='0.79.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/src/citrine/resources/predictor_evaluation_execution.py
+++ b/src/citrine/resources/predictor_evaluation_execution.py
@@ -1,6 +1,6 @@
 """Resources that represent both individual and collections of workflow executions."""
 from functools import lru_cache, partial
-from typing import Optional, Iterable
+from typing import Optional, Iterable, Union
 from uuid import UUID
 
 from citrine._rest.collection import Collection
@@ -9,6 +9,7 @@ from citrine._serialization import properties
 from citrine._session import Session
 from citrine.informatics.modules import ModuleRef
 from citrine.informatics.predictor_evaluation_result import PredictorEvaluationResult
+from citrine.resources.response import Response
 
 
 class PredictorEvaluationExecution(Resource['PredictorEvaluationExecution']):
@@ -195,3 +196,8 @@ class PredictorEvaluationExecutionCollection(Collection["PredictorEvaluationExec
                                         collection_builder=self._build_collection_elements,
                                         page=page,
                                         per_page=per_page)
+
+    def delete(self, uid: Union[UUID, str]) -> Response:
+        """Predictor Evaluation Workflows cannot be deleted; they can be archived instead."""
+        raise NotImplementedError(
+            "Predictor Evaluation Workflows cannot be deleted; they can be archived instead.")

--- a/src/citrine/resources/predictor_evaluation_execution.py
+++ b/src/citrine/resources/predictor_evaluation_execution.py
@@ -198,6 +198,6 @@ class PredictorEvaluationExecutionCollection(Collection["PredictorEvaluationExec
                                         per_page=per_page)
 
     def delete(self, uid: Union[UUID, str]) -> Response:
-        """Predictor Evaluation Workflows cannot be deleted; they can be archived instead."""
+        """Predictor Evaluation Executions cannot be deleted; they can be archived instead."""
         raise NotImplementedError(
-            "Predictor Evaluation Workflows cannot be deleted; they can be archived instead.")
+            "Predictor Evaluation Executions cannot be deleted; they can be archived instead.")

--- a/src/citrine/resources/predictor_evaluation_workflow.py
+++ b/src/citrine/resources/predictor_evaluation_workflow.py
@@ -1,10 +1,12 @@
 """Resources that represent both individual and collections of workflow executions."""
+from typing import Union
 from uuid import UUID
 
 from citrine._rest.collection import Collection
 from citrine._session import Session
 from citrine.informatics.modules import ModuleRef
 from citrine.informatics.workflows import PredictorEvaluationWorkflow
+from citrine.resources.response import Response
 
 
 class PredictorEvaluationWorkflowCollection(Collection[PredictorEvaluationWorkflow]):
@@ -52,3 +54,8 @@ class PredictorEvaluationWorkflowCollection(Collection[PredictorEvaluationWorkfl
         url = self._get_path(subpath)
         ref = ModuleRef(str(workflow_id))
         return self.session.put_resource(url, ref.dump())
+
+    def delete(self, uid: Union[UUID, str]) -> Response:
+        """Predictor Evaluation Workflows cannot be deleted; they can be archived instead."""
+        raise NotImplementedError(
+            "Predictor Evaluation Workflows cannot be deleted; they can be archived instead.")

--- a/tests/resources/test_predictor_evaluation_executions.py
+++ b/tests/resources/test_predictor_evaluation_executions.py
@@ -121,3 +121,8 @@ def test_restore(workflow_execution, collection):
     collection.restore(workflow_execution.uid)
     expected_path = '/projects/{}/predictor-evaluation-executions/restore'.format(collection.project_id)
     assert collection.session.last_call == FakeCall(method='PUT', path=expected_path, json={"module_uid": str(workflow_execution.uid)})
+
+
+def test_delete(collection):
+    with pytest.raises(NotImplementedError):
+        collection.delete(uuid.uuid4())

--- a/tests/resources/test_predictor_evaluation_workflows.py
+++ b/tests/resources/test_predictor_evaluation_workflows.py
@@ -41,3 +41,7 @@ def test_restore(workflow, collection):
     expected_path = '/projects/{}/predictor-evaluation-workflows/restore'.format(collection.project_id)
     assert collection.session.last_call == FakeCall(method='PUT', path=expected_path, json={"module_uid": str(workflow.uid)})
 
+
+def test_delete(collection):
+    with pytest.raises(NotImplementedError):
+        collection.delete(uuid.uuid4())


### PR DESCRIPTION
# Citrine Python PR

## Description 
Predictor evaluation workflows and executions cannot be deleted;
rather they are archived (and unarchived).  This raises a
NotImplementedError instead of trying to delete them and getting
a 404 since there is no such route in the API.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
