### PR TITLE
Re-fetch the executions after waiting before returning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.78.5',
+      version='0.78.6',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/src/citrine/jobs/waiting.py
+++ b/src/citrine/jobs/waiting.py
@@ -154,4 +154,8 @@ def wait_while_executing(
     if not execution_is_finished():
         msg = "Timeout reached, but condition is still {}".format(execution_is_finished())
         raise ConditionTimeoutError(msg)
+
+    # re-fetch the execution if we have a collection to fetch it with
+    if collection is not None:
+        execution = collection.get(execution.uid)
     return execution


### PR DESCRIPTION
# Citrine Python PR

## Description 
Predictor Evaluation Executions (and expected future workflow
executions) need to be re-fetched at the end of wait_while_executing
so that the return value has a SUCCEEDED or FAILED status.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
