### PR TITLE
Remove alpha doc tags from predictor evaluation workflows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.79.4',
+      version='0.79.5',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/src/citrine/informatics/predictor_evaluation_metrics.py
+++ b/src/citrine/informatics/predictor_evaluation_metrics.py
@@ -17,7 +17,7 @@ __all__ = ['PredictorEvaluationMetric',
 
 
 class PredictorEvaluationMetric(PolymorphicSerializable["PredictorEvaluationMetric"]):
-    """[ALPHA] A metric computed during a Predictor Evaluation Workflow.
+    """A metric computed during a Predictor Evaluation Workflow.
 
     Abstract type that returns the proper type given a serialized dict.
     """
@@ -55,7 +55,7 @@ class PredictorEvaluationMetric(PolymorphicSerializable["PredictorEvaluationMetr
 
 
 class RMSE(Serializable["RMSE"], PredictorEvaluationMetric):
-    """[ALPHA] Root-mean-square error."""
+    """Root-mean-square error."""
 
     typ = properties.String("type", default="RMSE", deserializable=False)
 
@@ -67,7 +67,10 @@ class RMSE(Serializable["RMSE"], PredictorEvaluationMetric):
 
 
 class NDME(Serializable["NDME"], PredictorEvaluationMetric):
-    """[ALPHA] Non-dimensional model error."""
+    """Non-dimensional model error.
+
+    The non-dimensional model error is the RMSE divided by the standard deviation
+    of the labels in the training data (including all folds, not just the training folds)."""
 
     typ = properties.String("type", default="NDME", deserializable=False)
 
@@ -79,7 +82,7 @@ class NDME(Serializable["NDME"], PredictorEvaluationMetric):
 
 
 class StandardRMSE(Serializable["StandardRMSE"], PredictorEvaluationMetric):
-    """[ALPHA] Standardized root-mean-square error."""
+    """Standardized root-mean-square error."""
 
     typ = properties.String("type", default="StandardRMSE", deserializable=False)
 
@@ -91,7 +94,7 @@ class StandardRMSE(Serializable["StandardRMSE"], PredictorEvaluationMetric):
 
 
 class PVA(Serializable["PVA"], PredictorEvaluationMetric):
-    """[ALPHA] Predicted vs. actual data.
+    """Predicted vs. actual data.
 
     Results are returned as a flattened list, where each item represents
     predicted vs. actual data for a single point.
@@ -107,7 +110,7 @@ class PVA(Serializable["PVA"], PredictorEvaluationMetric):
 
 
 class F1(Serializable["F1"], PredictorEvaluationMetric):
-    """[ALPHA] Support-weighted F1 score."""
+    """Support-weighted F1 score."""
 
     typ = properties.String("type", default="F1", deserializable=False)
 
@@ -119,7 +122,7 @@ class F1(Serializable["F1"], PredictorEvaluationMetric):
 
 
 class AreaUnderROC(Serializable["AreaUnderROC"], PredictorEvaluationMetric):
-    """[ALPHA] Area under the receiver operating characteristic (ROC) curve."""
+    """Area under the receiver operating characteristic (ROC) curve."""
 
     typ = properties.String("type", default="AreaUnderROC", deserializable=False)
 
@@ -131,7 +134,7 @@ class AreaUnderROC(Serializable["AreaUnderROC"], PredictorEvaluationMetric):
 
 
 class CoverageProbability(Serializable["CoverageProbability"], PredictorEvaluationMetric):
-    """[ALPHA] Percentage of observations that fall within a given confidence interval.
+    """Percentage of observations that fall within a given confidence interval.
 
     The coverage level can be specified to 3 digits, e.g. 0.123 but not 0.1234.
 

--- a/src/citrine/informatics/predictor_evaluation_metrics.py
+++ b/src/citrine/informatics/predictor_evaluation_metrics.py
@@ -70,7 +70,8 @@ class NDME(Serializable["NDME"], PredictorEvaluationMetric):
     """Non-dimensional model error.
 
     The non-dimensional model error is the RMSE divided by the standard deviation
-    of the labels in the training data (including all folds, not just the training folds)."""
+    of the labels in the training data (including all folds, not just the training folds).
+    """
 
     typ = properties.String("type", default="NDME", deserializable=False)
 

--- a/src/citrine/informatics/predictor_evaluation_result.py
+++ b/src/citrine/informatics/predictor_evaluation_result.py
@@ -19,7 +19,7 @@ __all__ = ['MetricValue',
 
 
 class MetricValue(PolymorphicSerializable["MetricValue"]):
-    """[ALPHA] Value associated with a metric computed during a Predictor Evaluation Workflow."""
+    """Value associated with a metric computed during a Predictor Evaluation Workflow."""
 
     def __init__(self):
         """These are results, so they should be built rather than constructed."""
@@ -36,7 +36,7 @@ class MetricValue(PolymorphicSerializable["MetricValue"]):
 
 
 class RealMetricValue(Serializable["RealMetricValue"], MetricValue):
-    """[ALPHA] Mean and standard error computed for a real-valued metric.
+    """Mean and standard error computed for a real-valued metric.
 
     Parameters
     ----------
@@ -59,7 +59,7 @@ class RealMetricValue(Serializable["RealMetricValue"], MetricValue):
 
 
 class PredictedVsActualRealPoint(Serializable["PredictedVsActualRealPoint"]):
-    """[ALPHA] Predicted vs. actual data for a single real-valued data point.
+    """Predicted vs. actual data for a single real-valued data point.
 
     Parameters
     ----------
@@ -90,7 +90,7 @@ class PredictedVsActualRealPoint(Serializable["PredictedVsActualRealPoint"]):
 
 
 class PredictedVsActualCategoricalPoint(Serializable["PredictedVsActualCategoricalPoint"]):
-    """[ALPHA] Predicted vs. actual data for a single categorical data point.
+    """Predicted vs. actual data for a single categorical data point.
 
     Parameters
     ----------
@@ -123,7 +123,7 @@ class PredictedVsActualCategoricalPoint(Serializable["PredictedVsActualCategoric
 
 
 class CategoricalPredictedVsActual(Serializable["CategoricalPredictedVsActual"], MetricValue):
-    """[ALPHA] List of predicted vs. actual data points for a categorical value.
+    """List of predicted vs. actual data points for a categorical value.
 
     Parameters
     ----------
@@ -144,7 +144,7 @@ class CategoricalPredictedVsActual(Serializable["CategoricalPredictedVsActual"],
 
 
 class RealPredictedVsActual(Serializable["RealPredictedVsActual"], MetricValue):
-    """[ALPHA] List of predicted vs. actual data points for a real value.
+    """List of predicted vs. actual data points for a real value.
 
     Parameters
     ----------
@@ -165,7 +165,7 @@ class RealPredictedVsActual(Serializable["RealPredictedVsActual"], MetricValue):
 
 
 class ResponseMetrics(Serializable["ResponseMetrics"]):
-    """[ALPHA] Set of metrics computed by a Predictor Evaluator for a single response.
+    """Set of metrics computed by a Predictor Evaluator for a single response.
 
     Results computed for a metric can be accessed by the metric's ``__repr__`` or
     by the metric itself.
@@ -195,7 +195,7 @@ class ResponseMetrics(Serializable["ResponseMetrics"]):
 
 
 class PredictorEvaluationResult(PolymorphicSerializable["PredictorEvaluationResult"]):
-    """[ALPHA] A Citrine Predictor Evaluation Result.
+    """A Citrine Predictor Evaluation Result.
 
     This class represents a set of metrics computed by a Predictor Evaluator.
     """
@@ -227,7 +227,7 @@ class PredictorEvaluationResult(PolymorphicSerializable["PredictorEvaluationResu
 
 
 class CrossValidationResult(Serializable["CrossValidationResult"], PredictorEvaluationResult):
-    """[ALPHA] Result of performing a cross-validation evaluation on a predictor.
+    """Result of performing a cross-validation evaluation on a predictor.
 
     Results for a cross-validated response can be accessed via ``cvResult['response_name']``,
     where ``cvResult`` is a

--- a/src/citrine/informatics/predictor_evaluator.py
+++ b/src/citrine/informatics/predictor_evaluator.py
@@ -10,7 +10,7 @@ __all__ = ['PredictorEvaluator',
 
 
 class PredictorEvaluator(PolymorphicSerializable["PredictorEvaluator"]):
-    """[ALPHA] A Citrine Predictor Evaluator computes metrics on a predictor."""
+    """A Citrine Predictor Evaluator computes metrics on a predictor."""
 
     @classmethod
     def get_type(cls, data) -> Type[Serializable]:
@@ -53,7 +53,7 @@ class PredictorEvaluator(PolymorphicSerializable["PredictorEvaluator"]):
 
 
 class CrossValidationEvaluator(Serializable["CrossValidationEvaluator"], PredictorEvaluator):
-    """[ALPHA] Evaluate a predictor via cross validation.
+    """Evaluate a predictor via cross validation.
 
     Performs cross-validation on requested predictor responses and
     computes the requested metrics on each response.

--- a/src/citrine/informatics/workflows/predictor_evaluation_workflow.py
+++ b/src/citrine/informatics/workflows/predictor_evaluation_workflow.py
@@ -12,7 +12,7 @@ __all__ = ['PredictorEvaluationWorkflow']
 
 
 class PredictorEvaluationWorkflow(Resource['PredictorEvaluationWorkflow'], Workflow):
-    """[ALPHA] A workflow that evaluations a predictor.
+    """A workflow that evaluations a predictor.
 
     Parameters
     ----------

--- a/src/citrine/resources/predictor_evaluation_execution.py
+++ b/src/citrine/resources/predictor_evaluation_execution.py
@@ -13,7 +13,7 @@ from citrine.resources.response import Response
 
 
 class PredictorEvaluationExecution(Resource['PredictorEvaluationExecution']):
-    """[ALPHA] The execution of a PredictorEvaluationWorkflow.
+    """The execution of a PredictorEvaluationWorkflow.
 
     Parameters
     ----------
@@ -91,7 +91,7 @@ class PredictorEvaluationExecution(Resource['PredictorEvaluationExecution']):
 
 
 class PredictorEvaluationExecutionCollection(Collection["PredictorEvaluationExecution"]):
-    """[ALPHA] A collection of PredictorEvaluationExecutions."""
+    """A collection of PredictorEvaluationExecutions."""
 
     _path_template = '/projects/{project_id}/predictor-evaluation-executions'  # noqa
     _individual_key = None

--- a/src/citrine/resources/predictor_evaluation_workflow.py
+++ b/src/citrine/resources/predictor_evaluation_workflow.py
@@ -10,7 +10,7 @@ from citrine.resources.response import Response
 
 
 class PredictorEvaluationWorkflowCollection(Collection[PredictorEvaluationWorkflow]):
-    """[ALPHA] A collection of PredictorEvaluationWorkflows."""
+    """A collection of PredictorEvaluationWorkflows."""
 
     _path_template = '/projects/{project_id}/predictor-evaluation-workflows'
     _individual_key = None


### PR DESCRIPTION
# Citrine Python PR

## Description 
The change to their experimental field is being handled on the
backend.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
