### PR TITLE
Add status for timed out

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.79.4',
+      version='0.80.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/src/citrine/resources/workflow_executions.py
+++ b/src/citrine/resources/workflow_executions.py
@@ -122,5 +122,10 @@ class WorkflowExecutionStatus(Resource['WorkflowExecutionStatus']):
         """Determine whether or not the execution failed."""
         return self.status == "Failed"
 
+    @property
+    def timed_out(self):
+        """Determine whether or not the execution timed out."""
+        return self.status == "TimedOut"
+
     def __str__(self):
         return '<WorkflowExecutionStatus {!r}>'.format(self.status)

--- a/tests/resources/test_workflow_executions.py
+++ b/tests/resources/test_workflow_executions.py
@@ -109,12 +109,14 @@ def test_workflow_success_status():
     assert status.succeeded
     assert not status.in_progress
     assert not status.failed
+    assert not status.timed_out
 
 
 def test_workflow_in_progress_status():
     status = WorkflowExecutionStatus('InProgress', None)
 
     assert not status.succeeded
+    assert not status.timed_out
     assert status.in_progress
     assert not status.failed
 
@@ -124,4 +126,14 @@ def test_workflow_failed_status():
 
     assert not status.succeeded
     assert not status.in_progress
+    assert not status.timed_out
     assert status.failed
+
+
+def test_workflow_timedout_status():
+    status = WorkflowExecutionStatus('TimedOut', None)
+
+    assert not status.succeeded
+    assert not status.in_progress
+    assert not status.failed
+    assert status.timed_out


### PR DESCRIPTION
# Citrine Python PR

## Description 
Workflow execution has a new status for timed out status, this can happen when jobs unexpectedly die.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
