### PR TITLE
Migration utilities for enumerated -> data source design spaces

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.83.2',
+      version='0.84.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -290,7 +290,7 @@ def migrate_enumerated_design_space(*,
                                     cleanup: bool = True
                                     ) -> DataSourceDesignSpace:
     """
-    Migrate an EnumeratedDesignSpace on the Citrine Platform to a DataSourceDesignSpace.
+    [ALPHA] Migrate an EnumeratedDesignSpace on the Citrine Platform to a DataSourceDesignSpace.
 
     Parameters
     ----------

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -307,13 +307,13 @@ def migrate_enumerated_design_space(*,
         Optional string name to specify for the data CSV file.
         Defaults to the design space name + "source data"
     cleanup: bool
-        Whether or not to archive the migrated dataset if the migration is successful
+        Whether or not to archive the migrated design space if the migration is successful
         Default: true
 
     Returns
     -------
     DataSourceDesignSpace
-        The resulting dataset, which should have functional parity with the source design space.
+        The resulting design space, which should have functional parity with the source design space.
 
     """
     enumerated_ds = project.design_spaces.get(uid)

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -1,3 +1,12 @@
+import csv
+from uuid import UUID
+
+from citrine.informatics.data_sources import CSVDataSource
+from citrine.resources.dataset import Dataset
+from citrine.resources.project import Project
+from citrine.seeding import find_or_create
+from citrine.seeding.find_or_create import find_or_create_dataset
+
 try:
     import pandas as pd
 except ImportError:  # pragma: no cover
@@ -7,9 +16,9 @@ try:
 except ImportError:  # pragma: no cover
     raise ImportError('numpy is a requirement for the builders module')
 from itertools import product
-from typing import Mapping, Sequence, List
+from typing import Mapping, Sequence, List, Optional, Union
 from warnings import warn
-from citrine.informatics.design_spaces import EnumeratedDesignSpace
+from citrine.informatics.design_spaces import EnumeratedDesignSpace, DataSourceDesignSpace
 from citrine.informatics.descriptors import Descriptor, RealDescriptor
 
 
@@ -235,3 +244,93 @@ def cartesian_join_design_spaces(
                                          descriptors=descriptors,
                                          data=data)
     return design_space
+
+
+def enumerated_to_data_source(*,
+                              enumerated_ds: EnumeratedDesignSpace,
+                              dataset: Dataset,
+                              filename: Optional[str] = None
+                              ) -> DataSourceDesignSpace:
+    """[ALPHA] Convert an EnumeratedDesignSpace into a DataSourceDesignSpace.
+
+    Converts an EnumeratedDesignSpace into a DataSourceDesignSpace by writing
+    the data to a csv file, uploading it to the given dataset, and wrapping it
+    in a CSVDataSource.
+
+    Parameters
+    ----------
+    enumerated_ds: EnumeratedDesignSpace
+        data source to convert
+    dataset: Dataset
+        dataset into which to upload the data file
+    filename: Optional[str]
+        filename to use for the data file (default: design space name + "source data")
+
+    """
+
+    descriptors = {d.key: d for d in enumerated_ds.descriptors}
+    headers = [d.key for d in enumerated_ds.descriptors]
+
+    csv_filename = filename or "{} source data".format(enumerated_ds.name)
+    with open(csv_filename, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(headers)
+        for datum in enumerated_ds.data:
+            writer.writerow([datum.get(k, '') for k in headers])
+
+    file_link = dataset.files.upload(csv_filename)
+    data_source = CSVDataSource(file_link, descriptors)
+    data_source_ds = DataSourceDesignSpace(
+        name=enumerated_ds.name, description=enumerated_ds.description, data_source=data_source)
+    return data_source_ds
+
+
+def migrate_enumerated_design_space(*,
+                                    project: Project,
+                                    uid: UUID,
+                                    dataset: Union[str, Dataset],
+                                    filename: Optional[str],
+                                    cleanup: bool = True
+) -> DataSourceDesignSpace:
+    """
+    Migrate an EnumeratedDesignSpace on the Citrine Platform to a DataSourceDesignSpace
+    Parameters
+    ----------
+    project: Project
+        Project to use when accessing the Citrine Platform
+    uid: UUID
+        Unique identifier of the EnumeratedDesignSpace to migrate
+    dataset: Union[str, Dataset]
+        Dataset or name of dataset into which to write the data as a CSV.
+        If given as a string, will find_or_create using that name.
+    filename: Optional[str]
+        Optional string name to specify for the data CSV file.
+        Defaults to the design space name + "source data"
+    cleanup: bool
+        Whether or not to archive the migrated dataset if the migration is successful
+        Default: true
+
+    Returns
+    -------
+    DataSourceDesignSpace
+        The resulting dataset, which should have functional parity with the source design space.
+
+    """
+    enumerated_ds = project.design_spaces.get(uid)
+    if not isinstance(enumerated_ds, EnumeratedDesignSpace):
+        msg = "Trying to migrate an enumerated design space but this is a {}".format(type(enumerated_ds))
+        raise ValueError(msg)
+
+    if isinstance(dataset, str):
+        dataset = find_or_create_dataset(project.datasets, dataset)
+
+    # create the new data source design space
+    data_source_ds = enumerated_to_data_source(enumerated_ds, dataset, filename)
+    data_source_ds = project.design_spaces.register(data_source_ds)
+
+    if cleanup:
+        # archive the old enumerated design space
+        data_source_ds.archived = True
+        project.design_spaces.update(data_source_ds)
+
+    return data_source_ds

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -14,7 +14,7 @@ try:
 except ImportError:  # pragma: no cover
     raise ImportError('numpy is a requirement for the builders module')
 from itertools import product
-from typing import Mapping, Sequence, List, Optional, Union
+from typing import Mapping, Sequence, List, Optional
 from warnings import warn
 from citrine.informatics.design_spaces import EnumeratedDesignSpace, DataSourceDesignSpace
 from citrine.informatics.descriptors import Descriptor, RealDescriptor
@@ -268,7 +268,7 @@ def enumerated_to_data_source(*,
     descriptors = {d.key: d for d in enumerated_ds.descriptors}
     headers = [d.key for d in enumerated_ds.descriptors]
 
-    csv_filename = filename or "{} source data".format(enumerated_ds.name)
+    csv_filename = filename or "{} source data.csv".format(enumerated_ds.name).replace(" ", "_")
     with open(csv_filename, "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(headers)
@@ -285,7 +285,7 @@ def enumerated_to_data_source(*,
 def migrate_enumerated_design_space(*,
                                     project: Project,
                                     uid: UUID,
-                                    dataset: Union[str, Dataset],
+                                    dataset: Dataset,
                                     filename: Optional[str],
                                     cleanup: bool = True
                                     ) -> DataSourceDesignSpace:

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -4,7 +4,6 @@ from uuid import UUID
 from citrine.informatics.data_sources import CSVDataSource
 from citrine.resources.dataset import Dataset
 from citrine.resources.project import Project
-from citrine.seeding import find_or_create
 from citrine.seeding.find_or_create import find_or_create_dataset
 
 try:
@@ -267,7 +266,6 @@ def enumerated_to_data_source(*,
         filename to use for the data file (default: design space name + "source data")
 
     """
-
     descriptors = {d.key: d for d in enumerated_ds.descriptors}
     headers = [d.key for d in enumerated_ds.descriptors]
 
@@ -291,9 +289,10 @@ def migrate_enumerated_design_space(*,
                                     dataset: Union[str, Dataset],
                                     filename: Optional[str],
                                     cleanup: bool = True
-) -> DataSourceDesignSpace:
+                                    ) -> DataSourceDesignSpace:
     """
-    Migrate an EnumeratedDesignSpace on the Citrine Platform to a DataSourceDesignSpace
+    Migrate an EnumeratedDesignSpace on the Citrine Platform to a DataSourceDesignSpace.
+
     Parameters
     ----------
     project: Project
@@ -313,24 +312,27 @@ def migrate_enumerated_design_space(*,
     Returns
     -------
     DataSourceDesignSpace
-        The resulting design space, which should have functional parity with the source design space.
+        The resulting design space, which should have functional parity with
+        the original design space.
 
     """
     enumerated_ds = project.design_spaces.get(uid)
     if not isinstance(enumerated_ds, EnumeratedDesignSpace):
-        msg = "Trying to migrate an enumerated design space but this is a {}".format(type(enumerated_ds))
+        msg = "Trying to migrate an enumerated design space but this is a {}".format(
+            type(enumerated_ds))
         raise ValueError(msg)
 
     if isinstance(dataset, str):
         dataset = find_or_create_dataset(project.datasets, dataset)
 
     # create the new data source design space
-    data_source_ds = enumerated_to_data_source(enumerated_ds, dataset, filename)
+    data_source_ds = enumerated_to_data_source(
+        enumerated_ds=enumerated_ds, dataset=dataset, filename=filename)
     data_source_ds = project.design_spaces.register(data_source_ds)
 
     if cleanup:
         # archive the old enumerated design space
-        data_source_ds.archived = True
-        project.design_spaces.update(data_source_ds)
+        enumerated_ds.archived = True
+        project.design_spaces.update(enumerated_ds)
 
     return data_source_ds

--- a/src/citrine/builders/design_spaces.py
+++ b/src/citrine/builders/design_spaces.py
@@ -4,7 +4,6 @@ from uuid import UUID
 from citrine.informatics.data_sources import CSVDataSource
 from citrine.resources.dataset import Dataset
 from citrine.resources.project import Project
-from citrine.seeding.find_or_create import find_or_create_dataset
 
 try:
     import pandas as pd
@@ -299,9 +298,8 @@ def migrate_enumerated_design_space(*,
         Project to use when accessing the Citrine Platform
     uid: UUID
         Unique identifier of the EnumeratedDesignSpace to migrate
-    dataset: Union[str, Dataset]
-        Dataset or name of dataset into which to write the data as a CSV.
-        If given as a string, will find_or_create using that name.
+    dataset: Dataset
+        Dataset into which to write the data as a CSV.
     filename: Optional[str]
         Optional string name to specify for the data CSV file.
         Defaults to the design space name + "source data"
@@ -321,9 +319,6 @@ def migrate_enumerated_design_space(*,
         msg = "Trying to migrate an enumerated design space but this is a {}".format(
             type(enumerated_ds))
         raise ValueError(msg)
-
-    if isinstance(dataset, str):
-        dataset = find_or_create_dataset(project.datasets, dataset)
 
     # create the new data source design space
     data_source_ds = enumerated_to_data_source(

--- a/src/citrine/informatics/descriptors.py
+++ b/src/citrine/informatics/descriptors.py
@@ -19,6 +19,8 @@ class Descriptor(PolymorphicSerializable['Descriptor']):
     Abstract type that returns the proper type given a serialized dict.
     """
 
+    key = properties.String('descriptor_key')
+
     @classmethod
     def get_type(cls, data) -> Type[Serializable]:
         """Return the subtype."""
@@ -51,7 +53,6 @@ class RealDescriptor(Serializable['RealDescriptor'], Descriptor):
 
     """
 
-    key = properties.String('descriptor_key')
     lower_bound = properties.Float('lower_bound')
     upper_bound = properties.Float('upper_bound')
     units = properties.Optional(properties.String, 'units', default='')
@@ -94,7 +95,6 @@ class ChemicalFormulaDescriptor(Serializable['ChemicalFormulaDescriptor'], Descr
 
     """
 
-    key = properties.String('descriptor_key')
     # `threshold` exists in the backend but is not configurable through this client. It is fixed
     # to 1.0 which means that chemical formula string parsing is strict with regards to typos.
     threshold = properties.Float('threshold', deserializable=False, default=1.0)
@@ -132,7 +132,6 @@ class MolecularStructureDescriptor(Serializable['MolecularStructureDescriptor'],
 
     """
 
-    key = properties.String('descriptor_key')
     typ = properties.String('type', default='Organic', deserializable=False)
 
     def __eq__(self, other):
@@ -168,7 +167,6 @@ class CategoricalDescriptor(Serializable['CategoricalDescriptor'], Descriptor):
 
     """
 
-    key = properties.String('descriptor_key')
     typ = properties.String('type', default='Categorical', deserializable=False)
     categories = properties.Set(properties.String, 'descriptor_values')
 
@@ -205,7 +203,6 @@ class FormulationDescriptor(Serializable['FormulationDescriptor'], Descriptor):
 
     """
 
-    key = properties.String('descriptor_key')
     typ = properties.String('type', default='Formulation', deserializable=False)
 
     def __eq__(self, other):


### PR DESCRIPTION
# Citrine Python PR

## Description 

There are two utilities here:
 - enumerated_to_data_source to convert a local copy of an enumerated
   design space to a data source design space, including the file upload
 - migrate_enumerated_design_space migrates an on-platform enumerated
   design space to an on-platform data source design space

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
