### PR TITLE
Fixed ingredient count constraint min/max types.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.83.1',
+      version='0.83.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/src/citrine/informatics/constraints/ingredient_count_constraint.py
+++ b/src/citrine/informatics/constraints/ingredient_count_constraint.py
@@ -35,13 +35,13 @@ class IngredientCountConstraint(Serializable['IngredientCountConstraint'], Const
 
     def __init__(self, *,
                  formulation_descriptor: FormulationDescriptor,
-                 min: float,
-                 max: float,
+                 min: int,
+                 max: int,
                  label: Optional[str] = None,
                  session: Optional[Session] = None):
         self.formulation_descriptor: FormulationDescriptor = formulation_descriptor
-        self.min: float = min
-        self.max: float = max
+        self.min: int = min
+        self.max: int = max
         self.label: Optional[str] = label
         self.session: Optional[Session] = session
 


### PR DESCRIPTION
Min and max types for the ingredient count constraints were incorrectly labeled as `float` s. This PR changes min and max to `int`.
