### PR TITLE
Modified unit to be required, consistent with backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.84.0',
+      version='0.85.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.83.3',
+      version='0.84.0',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/src/citrine/gemtables/variables.py
+++ b/src/citrine/gemtables/variables.py
@@ -434,6 +434,12 @@ class IngredientQuantityByProcessAndName(
         self.ingredient_name = ingredient_name
         self.quantity_dimension = quantity_dimension
         self.type_selector = type_selector
+        if quantity_dimension == IngredientQuantityDimension.ABSOLUTE:
+            if unit is None:
+                raise ValueError("Absolute Quantity variables require that 'unit' is set")
+        else:
+            if unit is not None and unit != "":
+                raise ValueError("Fractional variables cannot take a 'unit'")
         self.unit = unit
 
 

--- a/src/citrine/resources/table_config.py
+++ b/src/citrine/resources/table_config.py
@@ -164,7 +164,9 @@ class TableConfig(Resource["TableConfig"]):
                             process_template: LinkByUID,
                             project,
                             quantity_dimension: IngredientQuantityDimension,
-                            scope: str = CITRINE_SCOPE):
+                            scope: str = CITRINE_SCOPE,
+                            unit: Optional[str] = None
+                            ):
         """[ALPHA] Add variables and columns for all of the possible ingredients in a process.
 
         For each allowed ingredient name in the process template there is a column for the if of
@@ -181,6 +183,8 @@ class TableConfig(Resource["TableConfig"]):
             the dimension in which to report ingredient quantities
         scope: Optional[str]
             the scope for which to get ingredient ids (default is Citrine scope, 'id')
+        unit: Optional[str]
+            the units for the quantity, if selecting Absolute Quantity
 
         """
         dimension_display = {
@@ -212,7 +216,8 @@ class TableConfig(Resource["TableConfig"]):
                 headers=[process.name, name, dimension_display[quantity_dimension]],
                 process_template=process_template,
                 ingredient_name=name,
-                quantity_dimension=quantity_dimension
+                quantity_dimension=quantity_dimension,
+                unit=unit
             )
 
             if identifier_variable.name not in [var.name for var in self.variables]:

--- a/tests/gemtable/test_variables.py
+++ b/tests/gemtable/test_variables.py
@@ -60,6 +60,42 @@ def test_quantity_dimension_serializes_to_string():
     variable_data = variable.dump()
     assert variable_data["quantity_dimension"] == "number"
 
+
 def test_renamed_classes_are_the_same():
     # Mostly make code coverage happy
     assert oldvariables.IngredientQuantityDimension == IngredientQuantityDimension
+
+
+def test_absolute_units():
+    IngredientQuantityByProcessAndName(
+        name="This should be fine",
+        headers=["quantity"],
+        process_template=LinkByUID(scope="template", id="process"),
+        ingredient_name="ingredient",
+        quantity_dimension=IngredientQuantityDimension.NUMBER
+    )
+    IngredientQuantityByProcessAndName(
+        name="This should be fine, too",
+        headers=["quantity"],
+        process_template=LinkByUID(scope="template", id="process"),
+        ingredient_name="ingredient",
+        quantity_dimension=IngredientQuantityDimension.ABSOLUTE,
+        unit='kg'
+    )
+    with pytest.raises(ValueError):
+        IngredientQuantityByProcessAndName(
+            name="This needs units",
+            headers=["quantity"],
+            process_template=LinkByUID(scope="template", id="process"),
+            ingredient_name="ingredient",
+            quantity_dimension=IngredientQuantityDimension.ABSOLUTE
+        )
+    with pytest.raises(ValueError):
+        IngredientQuantityByProcessAndName(
+            name="This shouldn't have units",
+            headers=["quantity"],
+            process_template=LinkByUID(scope="template", id="process"),
+            ingredient_name="ingredient",
+            quantity_dimension=IngredientQuantityDimension.NUMBER,
+            unit='kg'
+        )

--- a/tests/resources/test_table_config.py
+++ b/tests/resources/test_table_config.py
@@ -297,7 +297,8 @@ def test_add_all_ingredients(session, project):
     )
     # WHEN we add all ingredients to the same Table Config as absolute quantities
     def2 = def1.add_all_ingredients(process_template=process_link, project=project,
-                                    quantity_dimension=IngredientQuantityDimension.ABSOLUTE)
+                                    quantity_dimension=IngredientQuantityDimension.ABSOLUTE,
+                                    unit='kg')
     # THEN there should be 1 new variable for each name, corresponding to the quantity
     #   There is already a variable for id
     #   There should be 2 new columns for each name, one for the quantity and one for the units


### PR DESCRIPTION
# Citrine Python PR

## Description 
PLA-6124

DS ran into an issue because backend now requires a unit argument for IngredientQuantityDimension.ABSOLUTE.  Based on user feedback, this migrated from previous behavior, where unit was not required to build a table.

The original platform behavior was likely informed by not being concerned about unit consistency from a display perspective.  However, in order to train a predictor, original unit is required.

IngredientQuantityInOutput does not have a unit requirement.  We therefore are now in a state where two very similar methods have inconsistent signatures and possibly inconsistent behavior on the back end.

This PR is intended to quickly address the present pitfall, with documentation for the broader issue logged in the ticket.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X] I have added tests for 100% coverage
- [X] I have written Numpy-style docstrings for every method and class.
- [X] I have communicated the downstream consequences of the PR to others.
- [X] I have bumped the version in setup.py
