### PR TITLE
PLA-4041 list no ignore error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.85.1',
+      version='0.85.2',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class PreBuildCommand(build_py):
 
 
 setup(name='citrine',
-      version='0.85.0',
+      version='0.85.1',
       url='http://github.com/CitrineInformatics/citrine-python',
       description='Python library for the Citrine Platform',
       long_description=long_description,

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -199,13 +199,7 @@ class Collection(Generic[ResourceType]):
 
         """
         for element in collection:
-            try:
-                yield self.build(element)
-            except(KeyError, ValueError):
-                # TODO:  Right now this is a hack.  Clean this up soon.
-                # Module collections are not filtering on module type
-                # properly, so we are filtering client-side.
-                pass  # pragma: no cover
+            yield self.build(element)
 
     def _page_params(self,
                      page: Optional[int],

--- a/src/citrine/resources/workflow.py
+++ b/src/citrine/resources/workflow.py
@@ -3,11 +3,13 @@ from uuid import UUID
 from typing import TypeVar
 
 from citrine.informatics.workflows import Workflow
+from typing import Iterable
 
 from citrine._rest.collection import Collection
 from citrine._session import Session
 
 CreationType = TypeVar('CreationType', bound=Workflow)
+ResourceType = TypeVar('ResourceType', bound='Resource')
 
 
 class WorkflowCollection(Collection[Workflow]):
@@ -27,6 +29,13 @@ class WorkflowCollection(Collection[Workflow]):
     def __init__(self, project_id: UUID, session: Session):
         self.project_id = project_id
         self.session: Session = session
+
+    def _build_collection_elements(self,
+                                   collection: Iterable[dict]) -> Iterable[ResourceType]:
+        for element in collection:
+            if (element['module_type'] == 'DESIGN_WORKFLOW' or
+                    element['module_type'] == 'PERFORMANCE_WORKFLOW'):
+                yield self.build(element)
 
     def build(self, data: dict) -> Workflow:
         """Build an individual Workflow."""

--- a/src/citrine/resources/workflow.py
+++ b/src/citrine/resources/workflow.py
@@ -90,10 +90,7 @@ class WorkflowCollection(Collection[Workflow]):
                            additional_params: Optional[dict] = None
                            ) -> Tuple[Iterable[dict], str]:
 
-        if additional_params is None:
-            additional_params = {"module_type": "DESIGN_WORKFLOW"}
-        else:
-            additional_params.update({"module_type": "DESIGN_WORKFLOW"})
+        additional_params = {"module_type": "DESIGN_WORKFLOW"}
         return self._fetch_page(path, fetch_func, page, per_page, json_body, additional_params)
 
     def _fetch_performance_page(self,
@@ -105,8 +102,5 @@ class WorkflowCollection(Collection[Workflow]):
                                 additional_params: Optional[dict] = None,
                                 ) -> Tuple[Iterable[dict], str]:
 
-        if additional_params is None:
-            additional_params = {"module_type": "PERFORMANCE_WORKFLOW"}
-        else:
-            additional_params.update({"module_type": "PERFORMANCE_WORKFLOW"})
+        additional_params = {"module_type": "PERFORMANCE_WORKFLOW"}
         return self._fetch_page(path, fetch_func, page, per_page, json_body, additional_params)

--- a/src/citrine/resources/workflow.py
+++ b/src/citrine/resources/workflow.py
@@ -1,6 +1,7 @@
 """Resources that represent collections of Workflows."""
+from itertools import chain
 from uuid import UUID
-from typing import TypeVar
+from typing import TypeVar, Optional, Callable, Tuple
 
 from citrine.informatics.workflows import Workflow
 from typing import Iterable
@@ -30,12 +31,48 @@ class WorkflowCollection(Collection[Workflow]):
         self.project_id = project_id
         self.session: Session = session
 
-    def _build_collection_elements(self,
-                                   collection: Iterable[dict]) -> Iterable[ResourceType]:
-        for element in collection:
-            if (element['module_type'] == 'DESIGN_WORKFLOW' or
-                    element['module_type'] == 'PERFORMANCE_WORKFLOW'):
-                yield self.build(element)
+    def list(self,
+             page: Optional[int] = None,
+             per_page: int = 100) -> Iterable[ResourceType]:
+        """
+        Paginate over the Design Workflows and Performance Workflows.
+
+        Leaving page and per_page as default values will yield all workflows,
+        paginating over all available pages.
+
+        Parameters
+        ---------
+        page: int, optional
+            The "page" of results to list. Default is to read all pages and yield
+            all results.  This option is deprecated.
+        per_page: int, optional
+            Max number of results to return per page. Default is 100.  This parameter
+            is used when making requests to the backend service.  If the page parameter
+            is specified it limits the maximum number of elements in the response.
+
+        Returns
+        -------
+        Iterable[ResourceType]
+            Resources in this collection.
+
+        """
+        # List all Design Workflows
+        design_workflows = self._paginator.paginate(
+            page_fetcher=self._fetch_design_page,
+            collection_builder=self._build_collection_elements,
+            page=page,
+            per_page=per_page
+        )
+
+        # List all Performance Workflows
+        performance_workflows = self._paginator.paginate(
+            page_fetcher=self._fetch_performance_page,
+            collection_builder=self._build_collection_elements,
+            page=page,
+            per_page=per_page
+        )
+
+        return chain(design_workflows, performance_workflows)
 
     def build(self, data: dict) -> Workflow:
         """Build an individual Workflow."""
@@ -43,3 +80,33 @@ class WorkflowCollection(Collection[Workflow]):
         workflow.session = self.session
         workflow.project_id = self.project_id
         return workflow
+
+    def _fetch_design_page(self,
+                           path: Optional[str] = None,
+                           fetch_func: Optional[Callable[..., dict]] = None,
+                           page: Optional[int] = None,
+                           per_page: Optional[int] = None,
+                           json_body: Optional[dict] = None,
+                           additional_params: Optional[dict] = None
+                           ) -> Tuple[Iterable[dict], str]:
+
+        if additional_params is None:
+            additional_params = {"module_type": "DESIGN_WORKFLOW"}
+        else:
+            additional_params.update({"module_type": "DESIGN_WORKFLOW"})
+        return self._fetch_page(path, fetch_func, page, per_page, json_body, additional_params)
+
+    def _fetch_performance_page(self,
+                                path: Optional[str] = None,
+                                fetch_func: Optional[Callable[..., dict]] = None,
+                                page: Optional[int] = None,
+                                per_page: Optional[int] = None,
+                                json_body: Optional[dict] = None,
+                                additional_params: Optional[dict] = None,
+                                ) -> Tuple[Iterable[dict], str]:
+
+        if additional_params is None:
+            additional_params = {"module_type": "PERFORMANCE_WORKFLOW"}
+        else:
+            additional_params.update({"module_type": "PERFORMANCE_WORKFLOW"})
+        return self._fetch_page(path, fetch_func, page, per_page, json_body, additional_params)

--- a/tests/resources/test_workflow.py
+++ b/tests/resources/test_workflow.py
@@ -1,12 +1,15 @@
 import uuid
+import pytest
 from datetime import datetime
 from citrine.resources.workflow import WorkflowCollection
+from citrine.informatics.workflows.design_workflow import DesignWorkflow
+from citrine.informatics.workflows.performance_workflow import PerformanceWorkflow
+from tests.utils.session import FakeSession, FakeCall
 
 
-def test_build_workflow():
-    # Given
-    workflow_collection = WorkflowCollection(project_id=uuid.uuid4(), session=None)
-    design_workspace_data = {
+@pytest.fixture(scope='module')
+def basic_design_workflow_data():
+    return {
         'id': str(uuid.uuid4()),
         'display_name': 'Test Workflow',
         'status': 'READY',
@@ -16,15 +19,64 @@ def test_build_workflow():
             'predictor_id': str(uuid.uuid4()),
         },
         'module_type': 'DESIGN_WORKFLOW',
-        'schema_id': '8af8b007-3e81-4185-82b2-6f62f4a2e6f1',
         'create_time': datetime(2020, 1, 1, 1, 1, 1, 1).isoformat("T"),
-        'created_by': str(uuid.uuid4())
-
+        'created_by': str(uuid.uuid4()),
     }
 
+
+@pytest.fixture(scope='module')
+def basic_performance_workflow_data():
+    return {
+        'id': str(uuid.uuid4()),
+        'display_name': 'Test Performance Workflow',
+        'status': 'READY',
+        'config': {
+            'analysis': {
+                'name': "Some Analysis",
+                'description': "This is one cool analysis",
+                'n_folds': 2,
+                'n_trials': 5,
+                'max_rows': 100,
+            },
+            'type': "PerformanceWorkflow",
+        },
+        'module_type': 'PERFORMANCE_WORKFLOW',
+        'created_by': str(uuid.uuid4()),
+        'create_time': datetime(2020, 1, 1, 1, 1, 1, 1).isoformat("T")
+    }
+
+
+def test_build_workflow(basic_design_workflow_data):
+    # Given
+    workflow_collection = WorkflowCollection(project_id=uuid.uuid4(), session=None)
+
     # When
-    workflow = workflow_collection.build(design_workspace_data)
+    workflow = workflow_collection.build(basic_design_workflow_data)
 
     # Then
     assert workflow.project_id == workflow_collection.project_id
     assert workflow.session is None
+
+def test_list_workflows(basic_design_workflow_data, basic_performance_workflow_data):
+    #Given
+    session = FakeSession()
+    workflow_collection = WorkflowCollection(project_id=uuid.uuid4(), session=session)
+    session.set_responses(
+        {'entries': [basic_design_workflow_data], 'next': ''},
+        {'entries': [basic_performance_workflow_data], 'next': ''},
+    )
+
+    # When
+    workflows = list(workflow_collection.list(per_page=20))
+
+    # Then
+    expected_design_call = FakeCall(method='GET', path='/projects/{}/modules'.format(workflow_collection.project_id),
+                                   params={'per_page': 20, 'module_type': 'DESIGN_WORKFLOW'})
+    expected_performance_call = FakeCall(method='GET', path='/projects/{}/modules'.format(workflow_collection.project_id),
+                                   params={'per_page': 20, 'module_type': 'PERFORMANCE_WORKFLOW'})
+    assert 2 == session.num_calls
+    assert expected_design_call == session.calls[0]
+    assert expected_performance_call == session.calls[1]
+    assert len(workflows) == 2
+    assert isinstance(workflows[0], DesignWorkflow)
+    assert isinstance(workflows[1], PerformanceWorkflow)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ max-doc-length = 119
 # D301: backslash is used in making docstrings for sphinx to parse
 # D401: Imperative mood requirement basically gets in the way
 # E221: When stripping hints for python 3.5 compliance, an extra space is left before operators
-ignore = D100,D104,D105,D107,D301,D401,E221
+ignore = D100,D104,D105,D107,D301,D401,E221,W504
 
 # D101, D102 would result in redundant documentation for subclasses.
 per-file-ignores = 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ max-doc-length = 119
 # D301: backslash is used in making docstrings for sphinx to parse
 # D401: Imperative mood requirement basically gets in the way
 # E221: When stripping hints for python 3.5 compliance, an extra space is left before operators
-ignore = D100,D104,D105,D107,D301,D401,E221,W504
+ignore = D100,D104,D105,D107,D301,D401,E221
 
 # D101, D102 would result in redundant documentation for subclasses.
 per-file-ignores = 


### PR DESCRIPTION
# Citrine Python PR

## Description 
Removes the exception catching for elements in collection when listing. The exception catching was swallowing actual list errors causing e2es to create extra resources.
Adds the `module_type` to Workflow list endpoint. There are two (`DESIGN` and `PERFORMANCE`), so I chained the generators for those endpoints.

I haven't written tests yet, but I have run this locally against projects on development, and was able to get the correct workflows listing.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
