### PR TITLE
Standardize predictor inputs/outputs

### DIFF
--- a/src/citrine/builders/predictors.py
+++ b/src/citrine/builders/predictors.py
@@ -59,9 +59,7 @@ def build_mean_feature_property_predictors(
         as inputs to one or more ML models.
 
     """
-    if isinstance(featurizer, MolecularStructureFeaturizer):
-        input_descriptor = featurizer.descriptor
-    elif isinstance(featurizer, ChemicalFormulaFeaturizer):
+    if isinstance(featurizer, (MolecularStructureFeaturizer, ChemicalFormulaFeaturizer)):
         input_descriptor = featurizer.input_descriptor
     else:
         raise TypeError(f"Featurizer of type {type(featurizer)} is not supported.")

--- a/src/citrine/informatics/predictors/molecular_structure_featurizer.py
+++ b/src/citrine/informatics/predictors/molecular_structure_featurizer.py
@@ -2,6 +2,7 @@
 # The docstring includes many long links that violate flake8, and it's easier to noqa
 # the whole file than to pick out the offending lines.
 from typing import List, Optional
+from warnings import warn
 
 from citrine._rest.resource import Resource, ResourceTypeEnum
 from citrine._serialization import properties as _properties
@@ -81,23 +82,35 @@ class MolecularStructureFeaturizer(Resource['MolecularStructureFeaturizer'], Pre
 
     _resource_type = ResourceTypeEnum.MODULE
 
-    descriptor = _properties.Object(Descriptor, 'config.descriptor')
+    input_descriptor = _properties.Object(Descriptor, 'config.descriptor')
     features = _properties.List(_properties.String, 'config.features')
     excludes = _properties.List(_properties.String, 'config.excludes')
 
     typ = _properties.String('config.type', default='MoleculeFeaturizer', deserializable=False)
     module_type = _properties.String('module_type', default='PREDICTOR')
 
-    def __init__(self,
+    def __init__(self, *,
                  name: str,
                  description: str,
-                 descriptor: MolecularStructureDescriptor,
+                 input_descriptor: MolecularStructureDescriptor = None,
                  features: Optional[List[str]] = None,
                  excludes: Optional[List[str]] = None,
+                 descriptor: MolecularStructureDescriptor = None,
                  archived: bool = False):
         self.name: str = name
         self.description: str = description
-        self.descriptor = descriptor
+        if descriptor is not None:
+            warn("\'descriptor\' argument is deprecated in favor of \'input_descriptor\' for "
+                 "MolecularStructureFeaturizer", DeprecationWarning)
+            if input_descriptor is None:
+                input_descriptor = descriptor
+            else:
+                raise ValueError("Cannot specify both \'descriptor\' and \'input_descriptor\' "
+                                 "for MolecularStructureFeaturizer")
+        elif input_descriptor is None:
+            raise ValueError("Must specify \'input_descriptor\' for MolecularStructureFeaturizer")
+
+        self.input_descriptor = input_descriptor
         self.features = features if features is not None else ["standard"]
         self.excludes = excludes if excludes is not None else []
         self.archived: bool = archived

--- a/tests/builders/test_predictors.py
+++ b/tests/builders/test_predictors.py
@@ -32,10 +32,7 @@ class FakeDescriptorMethods(DescriptorMethods):
 
     def from_predictor_responses(self, predictor: Predictor, inputs: List[Descriptor]):
         if isinstance(predictor, (MolecularStructureFeaturizer, ChemicalFormulaFeaturizer)):
-            if isinstance(predictor, MolecularStructureFeaturizer):
-                input_descriptor = predictor.descriptor
-            else:
-                input_descriptor = predictor.input_descriptor
+            input_descriptor = predictor.input_descriptor
             return [
                 RealDescriptor(f"{input_descriptor.key} real property {i}", lower_bound=0, upper_bound=1, units="")
                        for i in range(self.num_properties)
@@ -52,6 +49,7 @@ class FakeDescriptorMethods(DescriptorMethods):
                 )
                 for prop in predictor.properties
             ]
+
 
 class FakeProject(Project):
     def __init__(self, fake_descriptors: FakeDescriptorMethods):

--- a/tests/informatics/test_predictors.py
+++ b/tests/informatics/test_predictors.py
@@ -41,7 +41,7 @@ def molecule_featurizer() -> MolecularStructureFeaturizer:
     return MolecularStructureFeaturizer(
         name="Molecule featurizer",
         description="description",
-        descriptor=MolecularStructureDescriptor("SMILES"),
+        input_descriptor=MolecularStructureDescriptor("SMILES"),
         features=["all"],
         excludes=["standard"]
     )
@@ -212,7 +212,7 @@ def test_expression_initialization(expression_predictor):
 def test_molecule_featurizer(molecule_featurizer):
     assert molecule_featurizer.name == "Molecule featurizer"
     assert molecule_featurizer.description == "description"
-    assert molecule_featurizer.descriptor == MolecularStructureDescriptor("SMILES")
+    assert molecule_featurizer.input_descriptor == MolecularStructureDescriptor("SMILES")
     assert molecule_featurizer.features == ["all"]
     assert molecule_featurizer.excludes == ["standard"]
 
@@ -229,6 +229,21 @@ def test_molecule_featurizer(molecule_featurizer):
         'module_type': 'PREDICTOR',
         'display_name': 'Molecule featurizer'
     }
+
+
+def test_molecule_featurizer_deprecation():
+    with pytest.raises(ValueError):
+        MolecularStructureFeaturizer(name="", description="")
+
+    descriptor = MolecularStructureDescriptor("SMILES")
+    with pytest.raises(ValueError):
+        MolecularStructureFeaturizer(name="", description="", descriptor=descriptor, input_descriptor=descriptor)
+
+    with warnings.catch_warnings(record=True) as caught:
+        featurizer = MolecularStructureFeaturizer(name="", description="", descriptor=descriptor)
+        assert featurizer.input_descriptor == descriptor
+        w = caught[0]
+        assert issubclass(w.category, DeprecationWarning)
 
 
 def test_chemical_featurizer(chemical_featurizer):


### PR DESCRIPTION
# Citrine Python PR
PLA-7244

## Description 
Ideally, the input(s) and output(s) of a predictor would always be `input` or `inputs` and `output` or `outputs`. Unfortunately, `input` is a built-in method in python. As a compromise, a single input is therefore called `input_descriptor`. This makes the `SimpleMixturePredictor` somewhat awkward, since it takes a single input and produces a single output. Having the arguments be `input_descriptor` and `output` seems torturous, so I decided to leave it as `output_descriptor`.

After proceeding through this logic, the only thing that I decided to change was that the `MolecularStructureFeaturizer`'s input should be `input_descriptor` instead of `descriptor`. This required the featurizer to enforce keyword args.

### PR Type:
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
