### PR TITLE
pull default key and host from environment variables

### DIFF
--- a/docs/source/workflows/descriptors.rst
+++ b/docs/source/workflows/descriptors.rst
@@ -77,7 +77,7 @@ The descriptors can then be associated with the names from that namespace.
    from citrine.builders.descriptors import PlatformVocabulary
 
    # create a session with citrine using your API key
-   session = Citrine(api_key = API_KEY)
+   session = Citrine(api_key=API_KEY)
 
    # create project
    project = session.projects.register('Example project')

--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -630,7 +630,7 @@ The following example demonstrates how to use the python SDK to create a :class:
    from citrine.informatics.data_sources import GemTableDataSource
 
    # create a session with citrine using your API key
-   session = Citrine(api_key = API_KEY)
+   session = Citrine(api_key=API_KEY)
 
    # find project by name 'Example project' or create it if not found
    project = find_or_create_project(project_collection=session.projects,
@@ -676,7 +676,7 @@ The following demonstrates how to create an :class:`~citrine.informatics.predict
     from citrine.informatics.descriptors import FormulationDescriptor
 
     # create a session with citrine using your API key
-    session = Citrine(api_key = API_KEY)
+    session = Citrine(api_key=API_KEY)
 
     # find project by name 'Example project' or create it if not found
     project = find_or_create_project(project_collection=session.projects,

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -35,7 +35,7 @@ class Session(requests.Session):
                  port: Optional[str] = None):
         super().__init__()
         self.scheme: str = scheme
-        self.authority = ':'.join([host, port or ''])
+        self.authority = ':'.join([host or '', port or ''])
         self.refresh_token: str = refresh_token
         self.access_token: Optional[str] = None
         self.access_token_expiration: datetime = datetime.utcnow()

--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -29,9 +29,9 @@ class Session(requests.Session):
     """Wrapper around requests.Session that is both refresh-token and schema aware."""
 
     def __init__(self,
-                 refresh_token: str = environ.get('CITRINE_API_TOKEN'),
+                 refresh_token: str = environ.get('CITRINE_API_KEY'),
                  scheme: str = 'https',
-                 host: str = 'citrine.io',
+                 host: str = environ.get('CITRINE_API_HOST'),
                  port: Optional[str] = None):
         super().__init__()
         self.scheme: str = scheme

--- a/src/citrine/citrine.py
+++ b/src/citrine/citrine.py
@@ -1,20 +1,31 @@
 from typing import Optional
+from os import environ
+
 from citrine._session import Session
 from citrine.resources.project import ProjectCollection
 from citrine.resources.user import UserCollection
 
 
-DEFAULT_HOST: str = 'citrine.io'
-DEFAULT_SCHEME: str = 'https'
-
-
 class Citrine:
-    """The entry point for interacting with the Citrine Platform."""
+    """The entry point for interacting with the Citrine Platform.
+
+    Parameters
+    ----------
+    api_key: str
+        Unique key that allows a user to access the Citrine Platform.
+    scheme: str
+        Networking protocol; usually https
+    host: str
+        Host URL, generally '<your_site>.citrine-platform.com'
+    port: Optional[str]
+        Optional networking port
+
+    """
 
     def __init__(self,
-                 api_key: str,
-                 scheme: str = DEFAULT_SCHEME,
-                 host: str = DEFAULT_HOST,
+                 api_key: str = environ.get('CITRINE_API_KEY'),
+                 scheme: str = 'https',
+                 host: str = environ.get('CITRINE_API_HOST'),
                  port: Optional[str] = None):
         self.session: Session = Session(api_key, scheme, host, port)
 

--- a/src/citrine/resources/design_space.py
+++ b/src/citrine/resources/design_space.py
@@ -25,7 +25,7 @@ class DesignSpaceCollection(AbstractModuleCollection[DesignSpace]):
     _module_type = 'DESIGN_SPACE'
     _enumerated_cell_limit = 128 * 2000
 
-    def __init__(self, project_id: UUID, session: Session = Session()):
+    def __init__(self, project_id: UUID, session: Session):
         self.project_id = project_id
         self.session: Session = session
 

--- a/src/citrine/resources/module.py
+++ b/src/citrine/resources/module.py
@@ -22,7 +22,7 @@ class ModuleCollection(Collection[Module]):
     _individual_key = None
     _resource = Module
 
-    def __init__(self, project_id: UUID, session: Session = Session()):
+    def __init__(self, project_id: UUID, session: Session):
         self.project_id = project_id
         self.session: Session = session
 

--- a/src/citrine/resources/project.py
+++ b/src/citrine/resources/project.py
@@ -84,7 +84,7 @@ class Project(Resource['Project']):
     def __init__(self,
                  name: str,
                  description: Optional[str] = None,
-                 session: Optional[Session] = Session()):
+                 session: Optional[Session] = None):
         self.name: str = name
         self.description: Optional[str] = description
         self.session: Session = session
@@ -511,7 +511,7 @@ class ProjectCollection(Collection[Project]):
     _collection_key = 'projects'
     _resource = Project
 
-    def __init__(self, session: Session = Session()):
+    def __init__(self, session: Session):
         self.session = session
 
     def build(self, data) -> Project:

--- a/tests/seeding/test_find_or_create.py
+++ b/tests/seeding/test_find_or_create.py
@@ -57,7 +57,7 @@ def project_collection() -> Callable[[bool], ProjectCollection]:
         projects = []
 
         def __init__(self, search_implemented: bool = True):
-            ProjectCollection.__init__(self)
+            ProjectCollection.__init__(self, session=FakeSession)
             self.search_implemented = search_implemented
 
         def register(self, name: str, description: Optional[str] = None) -> Project:

--- a/tests/test_citrine.py
+++ b/tests/test_citrine.py
@@ -2,14 +2,14 @@ from citrine import Citrine
 
 
 def test_citrine_creation():
-    assert '1234' == Citrine('1234').session.refresh_token
+    assert '1234' == Citrine(api_key='1234', host='citrine.io').session.refresh_token
 
 
 def test_citrine_project_session():
-    citrine = Citrine('foo')
+    citrine = Citrine(api_key='foo', host='bar')
     assert citrine.session == citrine.projects.session
 
 
 def test_citrine_user_session():
-    citrine = Citrine('foo')
+    citrine = Citrine(api_key='foo', host='bar')
     assert citrine.session == citrine.users.session


### PR DESCRIPTION
# Citrine Python PR
PLA-7422

## Description 
Make default api_key and host the environment variables `CITRINE_API_KEY` and `CITRINE_API_HOST`. This is consistent with the "getting started" guide we send users: https://citrineinformatics.app.box.com/file/807512210850?s=gpbtec5aiawucno41oellc5h78rk9n0c

### PR Type:
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in setup.py
