### PR TITLE
From a list of GEMDs create a table of Attribute Templates

### DIFF
--- a/src/citrine/_utils/template_util.py
+++ b/src/citrine/_utils/template_util.py
@@ -1,0 +1,41 @@
+import pandas as pd
+from gemd.entity.object import *
+from gemd.entity.attribute import PropertyAndConditions
+
+def make_attribute_table(gems: list):
+    """[ALPHA] the current status of make_attribute_table
+
+    Given a list of GEMD Objects, this method returns a Pandas DataFrame where each row represents an attribute-containing
+    Object and each column represent a unique Attribute Type + Name pair. The values within the cells are the various GEMD Value Types.
+
+    """
+    types_with_attributes = (
+        ProcessSpec,
+        ProcessRun,
+        MaterialSpec,
+        MeasurementSpec,
+        MeasurementRun
+    )
+    all_rows = []
+    gems = [x for x in gems if isinstance(x, types_with_attributes)]
+    for gem in gems:
+        row_dict = {
+            "object" : gem,
+            "object_type": type(gem).__name__
+        }
+        if hasattr(gem, "conditions"):
+            for cond in gem.conditions:
+                row_dict[f"CONDITION: {cond.name}"] = cond.value
+        if hasattr(gem, "parameters"):
+            for param in gem.parameters:
+                row_dict[f"PARAMETER: {param.name}"] = param.value
+        if hasattr(gem, "properties"):
+            for prop in gem.properties:
+                if isinstance(prop, PropertyAndConditions):
+                    row_dict[f"PROPERTY: {prop.property.name}"] = prop.property.value
+                    for cond in prop.conditions:
+                        row_dict[f"CONDITION: {cond.name}"] = cond.value
+                else:
+                    row_dict[f"PROPERTY: {prop.name}"] = prop.value
+        all_rows.append(row_dict)
+    return pd.DataFrame(all_rows)

--- a/tests/_util/test_template_util.py
+++ b/tests/_util/test_template_util.py
@@ -1,0 +1,129 @@
+from citrine._utils.template_util import make_attribute_table
+from gemd.entity.object import *
+from gemd.entity.attribute import *
+from gemd.entity.value import *
+from gemd.entity.link_by_uid import LinkByUID
+import pandas as pd
+
+def _make_list_of_gems():
+    faux_gems = [
+        ProcessSpec(
+            name = "hello world",
+            parameters = [
+                Parameter(
+                    name = "param 1",
+                    value = NominalReal(nominal=4.2, units="g")
+                ),
+                Parameter(
+                    name = "param 2",
+                    value = NominalCategorical(category="foo")
+                ),
+                Parameter(
+                    name = "attr 1",
+                    value = InChI(inchi="InChI=1S/C8H10N4O2/c1-10-4-9-6-5(10)7(13)12(3)8(14)11(6)2/h4H,1-3H3")
+                )
+            ],
+            conditions = [
+                Condition(
+                    name = "cond 1",
+                    value = NormalReal(mean=4, std=0.5, units="")
+                )
+            ]
+        ),
+        IngredientSpec(
+            name = "I shouldn't be a row",
+            material=LinkByUID(scope = "faux", id = "abcde"),
+            process=LinkByUID(scope = "foo", id = "bar")
+        ),
+        ProcessRun(
+            name = "process 1",
+            spec = LinkByUID(scope = "faux", id = "id"),
+            parameters = [
+                Parameter(
+                    name = "param 1",
+                    value = NormalReal(mean=4.2, std = 0.1, units="g")
+                ),
+                Parameter(
+                    name = "param 3",
+                    value = NominalCategorical(category="bar")
+                )
+            ],
+            conditions = [
+                Condition(
+                    name = "cond 1",
+                    value = NormalReal(mean=4, std=0.5, units="")
+                ),
+                Condition(
+                    name = "cond 2",
+                    value = NominalCategorical(category="hi")
+                ),
+                Condition(
+                    name = "attr 1",
+                    value = InChI(inchi="InChI=1S/C34H34N4O4.Fe/c1-7-21-17(3)25-13-26-19(5)23(9-11-33(39)40)31(37-26)16-32-24(10-12-34(41)42)20(6)28(38-32)15-30-22(8-2)18(4)27(36-30)14-29(21)35-25;/h7-8,13-16H,1-2,9-12H2,3-6H3,(H4,35,36,37,38,39,40,41,42);/q;+2/p-2")
+                ),
+            ]
+        ),
+        MaterialSpec(
+            name = "material 1",
+            process = LinkByUID(scope = "faux 2", id = "id2"),
+            properties=[
+                PropertyAndConditions(
+                    property=Property(
+                        name = "prop 1",
+                        value = NormalReal(mean=100, std=10, units="g/cm**3")
+                    ),
+                    conditions=[
+                        Condition(
+                        name = "cond 2",
+                        value = NominalCategorical(category="hi")
+                        )
+                    ]
+                ),
+                PropertyAndConditions(
+                    property=Property(
+                        name = "prop 2",
+                        value = NominalReal(nominal=33, units="1/lb")
+                    ),
+                    conditions=[
+                        Condition(
+                        name = "cond 3",
+                        value = NominalCategorical(category="citrine")
+                        )
+                    ]
+                ),
+            ]
+        ),
+        MeasurementSpec(
+            name = "meas spec 1",
+            parameters = [
+                Parameter(
+                    name = "param 1",
+                    value = NominalReal(nominal=2.2, units="kg")
+                ),
+                Parameter(
+                    name = "param 2",
+                    value = NominalCategorical(category="bar")
+                )
+            ],
+        ),
+        MeasurementRun(
+            name = "meas run 1",
+            spec = LinkByUID(scope="another fake scope", id = "another fake id"),
+            properties=[
+                Property(
+                    name = "prop 1",
+                    value=NominalReal(nominal=4.1, units="")
+                )
+            ]
+        )
+    ]
+    return faux_gems
+
+def test_attribute_alignment():
+    df = make_attribute_table(_make_list_of_gems())
+    assert isinstance(df.iloc[0,3], NominalReal)
+    assert isinstance(df.iloc[1,3], NormalReal)
+    assert isinstance(df.iloc[3,3], NominalReal)
+    assert isinstance(df.iloc[0,5], InChI)
+    assert pd.isnull(df.iloc[1,5])
+    assert df.shape == (5,12)


### PR DESCRIPTION
# Citrine Python PR

## Description 
This PR adds in the first of several template-creation helper-functions. Given a list of GEMD objects, this method returns a Pandas DataFrame containing all of the GEMD-values for each of Attributes of the same name and type. This allows a user to see all of the different values and value types associated with the "same" Attribute.



### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)

### Adherence to team decisions
- [X ] I have added tests for 100% coverage
- [ X] I have written Numpy-style docstrings for every method and class.
- [X ] I have communicated the downstream consequences of the PR to others.
- [ X] I have bumped the version in setup.py
