### PR TITLE
AutoML Doc Fix

### DIFF
--- a/docs/source/workflows/predictors.rst
+++ b/docs/source/workflows/predictors.rst
@@ -10,7 +10,7 @@ Types of predictors include machine learning models, featurizers, and analytic e
 A predictor must be registered to a project to be used in a :doc:`design workflow <design_workflows>`.
 
 
-Auto ML predictor (ALPHA)
+Auto ML predictor
 -------------------------
 
 The :class:`~citrine.informatics.predictors.auto_ml_predictor.AutoMLPredictor` predicts material properties using a machine-learned model.
@@ -18,21 +18,13 @@ AutoMLPredictors allow you to use your domain knowledge to construct custom `Gra
 Each AutoMLPredictor is defined by a set of inputs and outputs.
 Inputs are used as input features to the machine learning model.
 The outputs are the properties that you would like the model to predict.
-There must be at least one input and at least one output.
+Currently, only one output per AutoML predictor is supported, and there must be at least one input.
 Unlike the `SimpleMLPredictor <#simple-ml-predictor>`__, only one model is trained from inputs to the outputs.
 
 AutoMLPredictors support both regression and classification.
 For each :class:`~citrine.informatics.descriptors.RealDescriptor` output, regression is performed.
 For each :class:`~citrine.informatics.descriptors.CategoricalDescriptor` output, classification is performed.
 Both binary and multi-class classification are supported automatically based on the number of categories in the data.
-
-Assuming they have the same inputs, it is generally preferable to combine multiple related outputs into a single Auto ML Predictor.
-This has several benefits when compared to creating one Auto ML Predictor for each output.
-
-* Higher model accuracy (especially if the data are sparse)
-* Faster training and prediction
-* More accurate uncertainty estimates that understand the correlations between outputs
-* More accurate scoring and candidate suggestions when running a :doc:`design workflow <design_workflows>`
 
 Models are trained using data provided by a :class:`~citrine.informatics.data_sources.DataSource` specified when creating a predictor.
 The inputs and outputs are descriptors, which must correspond precisely to descriptors that exist in the training data or are produced by other predictors in the graphical model.

--- a/src/citrine/informatics/predictors/auto_ml_predictor.py
+++ b/src/citrine/informatics/predictors/auto_ml_predictor.py
@@ -12,7 +12,7 @@ __all__ = ['AutoMLPredictor']
 
 
 class AutoMLPredictor(Resource['AutoMLPredictor'], Predictor, AIResourceMetadata):
-    """[ALPHA] A predictor interface that builds a single ML model.
+    """A predictor interface that builds a single ML model.
 
     The model uses the set of inputs to predict the output(s).
     Only one machine learning model is built.
@@ -29,7 +29,7 @@ class AutoMLPredictor(Resource['AutoMLPredictor'], Predictor, AIResourceMetadata
         [DEPRECATED] Please use ``outputs`` instead
         A single Descriptor that represents the output of the model
     outputs: list[Descriptor]
-        Descriptors that represents the output(s) of the model
+        Descriptors that represents the output(s) of the model. Currently, only one output Descriptor is supported.
     training_data: Optional[List[DataSource]]
         Sources of training data. Each can be either a CSV or an GEM Table. Candidates from
         multiple data sources will be combined into a flattened list and de-duplicated by uid and

--- a/src/citrine/informatics/predictors/auto_ml_predictor.py
+++ b/src/citrine/informatics/predictors/auto_ml_predictor.py
@@ -29,7 +29,8 @@ class AutoMLPredictor(Resource['AutoMLPredictor'], Predictor, AIResourceMetadata
         [DEPRECATED] Please use ``outputs`` instead
         A single Descriptor that represents the output of the model
     outputs: list[Descriptor]
-        Descriptors that represents the output(s) of the model. Currently, only one output Descriptor is supported.
+        Descriptors that represents the output(s) of the model. 
+        Currently, only one output Descriptor is supported.
     training_data: Optional[List[DataSource]]
         Sources of training data. Each can be either a CSV or an GEM Table. Candidates from
         multiple data sources will be combined into a flattened list and de-duplicated by uid and


### PR DESCRIPTION
# Citrine Python PR

## Description 
* Removing [ALPHA] in docs when referring to the AutoML Predictor
* State that only one output is supported currently for the AutoML Predictor

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (non-breaking change to assist developers)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in setup.py
