### PR TITLE
Convert Branch+BranchCollection to v2 api, add impl and tests for branch data updates/next version

### DIFF
--- a/src/citrine/_rest/resource.py
+++ b/src/citrine/_rest/resource.py
@@ -54,3 +54,17 @@ class ResourceRef(Serializable['ResourceRef']):
 
     def __init__(self, uid: Union[UUID, str]):
         self.uid = uid
+
+
+class PredictorRef(Serializable['PredictorRef']):
+    """A reference to a resource by UID."""
+
+    uid = properties.UUID('predictor_id')
+    version = properties.Optional(
+        properties.Union([properties.Integer(), properties.String()]),
+        'predictor_version'
+    )
+
+    def __init__(self, uid: Union[UUID, str], version: Optional[Union[int, str]] = None):
+        self.uid = uid
+        self.version = version

--- a/src/citrine/resources/data_version_update.py
+++ b/src/citrine/resources/data_version_update.py
@@ -1,0 +1,54 @@
+"""Record to hold branch data version update information."""
+from typing import List
+
+from citrine._rest.resource import PredictorRef, Resource
+from citrine._serialization import properties as _properties
+from citrine._serialization.serializable import Serializable
+from citrine.informatics.data_sources import DataSource
+
+
+class DataVersionUpdate(Serializable['DataVersionUpdate']):
+    """
+    Container for data updates
+    """
+    current = _properties.String('current')
+    latest = _properties.String('latest')
+
+    def __init__(self,
+                 current: str,
+                 latest: str):
+        self.current = current
+        self.latest = latest
+
+    typ = _properties.String('type', default='DataVersionUpdate')
+
+
+class BranchDataUpdate(Resource['BranchDataUpdate']):
+    """
+    Branch data updates with predictors using the versions indicated that are in READY status
+    """
+    data_updates = _properties.List(_properties.Object(DataVersionUpdate), "data_updates")
+    predictors = _properties.List(_properties.Object(PredictorRef), "predictors")
+
+    def __init__(self,
+                 data_updates: List[DataVersionUpdate],
+                 predictors: List[PredictorRef]):
+        self.data_updates = data_updates
+        self.predictors = predictors
+
+
+class NextBranchVersionRequest(Resource['NextBranchVersionRequest']):
+    """
+    Instructions for how the next version of a branch should handle its predictors when the workflows are
+    cloned.  data_updates contains the list of data source versions to upgrade (current->latest), and use_predictors
+    will wither have a <predictor_id>:latest to indicate the workflow should use a new version of the predictor.  Or
+    <predictor_id>:<version #> to indicate that the workflow should use an existing predictor version.
+    """
+    data_updates = _properties.List(_properties.Object(DataVersionUpdate), "data_updates")
+    use_predictors = _properties.List(_properties.Object(PredictorRef), "use_predictors")
+
+    def __init__(self,
+                 data_updates: List[DataVersionUpdate],
+                 use_predictors: List[PredictorRef]):
+        self.data_updates = data_updates
+        self.use_predictors = use_predictors

--- a/tests/resources/test_branch.py
+++ b/tests/resources/test_branch.py
@@ -5,10 +5,13 @@ from logging import getLogger
 import pytest
 from dateutil import tz
 
-from citrine._rest.resource import ResourceTypeEnum
+from citrine._rest.resource import ResourceTypeEnum, PredictorRef
+from citrine.resources.data_version_update import NextBranchVersionRequest, DataVersionUpdate, BranchDataUpdate
 from citrine.resources.dataset import Dataset
 from citrine.resources.branch import Branch, BranchCollection
-from tests.utils.factories import BranchDataFactory, CandidateExperimentSnapshotDataFactory, ExperimentDataSourceDataFactory
+from tests.utils.factories import BranchDataFactory, CandidateExperimentSnapshotDataFactory, \
+    ExperimentDataSourceDataFactory, BranchDataFieldFactory, BranchMetadataFieldFactory, BranchDataUpdateFactory, \
+    PredictorRefFactory, NextBranchVersionFactory
 from tests.utils.session import FakeSession, FakeCall, FakePaginatedSession
 
 logger = getLogger(__name__)
@@ -47,21 +50,25 @@ def test_branch_build(collection):
     branch_data = BranchDataFactory()
     new_branch = collection.build(branch_data)
 
-    assert new_branch.name == branch_data["name"]
-    assert new_branch.archived == branch_data["archived"]
+    assert new_branch.name == branch_data["data"]["name"]
+    assert new_branch.archived == branch_data["metadata"]["archived"]
     assert new_branch.project_id == collection.project_id
 
 
 def test_branch_register(session, collection, branch_path):
     # Given
+    root_id = str(uuid.uuid4())
     name = 'branch-name'
     now = datetime.now(tz.UTC).replace(microsecond=0)
     now_ms = int(now.timestamp() * 1000)  # ms since epoch
-    branch_data = BranchDataFactory(
-        name=name,
-        created_at=now_ms,
-        updated_at=now_ms
-    )
+    branch_data = BranchDataFactory(data=BranchDataFieldFactory(name=name),
+                                    metadata=BranchMetadataFieldFactory(
+                                        created={
+                                            'time': now_ms
+                                        },
+                                        updated={
+                                            'time': now_ms
+                                        }))
     session.set_response(branch_data)
 
     # When
@@ -73,10 +80,11 @@ def test_branch_register(session, collection, branch_path):
         method='POST',
         path=branch_path,
         json={
-            'name': name,
-            'id': None
-        }
+            'name': name
+        },
+        version="v2"
     )
+
     assert expected_call == session.last_call
     assert new_branch.uid is not None
     assert new_branch.name == name
@@ -138,12 +146,12 @@ def test_branch_update(session, collection, branch_path):
         method='PUT',
         path=f'{branch_path}/{branch_data["id"]}',
         json={
-            'name': branch_data['name'],
-            'id': str(branch_data['id'])
-        }
+            'name': branch_data['data']['name']
+        },
+        version='v2'
     )
     assert session.last_call == expected_call
-    assert updated_branch.name == branch_data['name']
+    assert updated_branch.name == branch_data['data']['name']
 
 
 def test_branch_get_design_workflows(collection):
@@ -167,7 +175,7 @@ def test_branch_get_design_workflows_no_project_id(session):
 def test_branch_archive(session, collection, branch_path):
     # Given
     branch_id = uuid.uuid4()
-    session.set_response(BranchDataFactory(archived=True))
+    session.set_response(BranchDataFactory(metadata=BranchMetadataFieldFactory(archived=True)))
 
     # When
     archived_branch = collection.archive(branch_id)
@@ -182,7 +190,7 @@ def test_branch_archive(session, collection, branch_path):
 def test_branch_restore(session, collection, branch_path):
     # Given
     branch_id = uuid.uuid4()
-    session.set_response(BranchDataFactory(archived=False))
+    session.set_response(BranchDataFactory(metadata=BranchMetadataFieldFactory(archived=False)))
 
     # When
     restored_branch = collection.restore(branch_id)
@@ -208,6 +216,73 @@ def test_branch_list_archived(session, collection, branch_path):
     assert session.last_call == FakeCall(method='GET', path=branch_path, params={'archived': True, 'per_page': 20})
 
 
+# Needed for coverage checks
+def test_brach_data_update_inits():
+    data_updates = [DataVersionUpdate("gemd::16f91e7e-0214-4866-8d7f-a4d5c2125d2b::1",
+                                      "gemd::16f91e7e-0214-4866-8d7f-a4d5c2125d2b::2")]
+    predictors = [PredictorRef("aa971886-d17c-43b4-b602-5af7b44fcd5a", 2)]
+    branch_update = BranchDataUpdate(data_updates, predictors)
+    assert branch_update.data_updates[0].current == "gemd::16f91e7e-0214-4866-8d7f-a4d5c2125d2b::1"
+
+
+def test_branch_data_updates(session, collection, branch_path):
+    # Given
+    branch_id = uuid.uuid4()
+    expected_data_updates = BranchDataUpdateFactory()
+    session.set_response(expected_data_updates)
+
+    # When
+    actual_data_updates = collection.data_updates(branch_id)
+
+    # Then
+    expected_path = f'{branch_path}/{branch_id}/data-version-updates-predictor'
+    assert session.last_call == FakeCall(method='GET',
+                                         path=expected_path,
+                                         version='v2')
+    assert expected_data_updates['data_updates'][0]['current'] == actual_data_updates.data_updates[0].current
+    assert expected_data_updates['data_updates'][0]['latest'] == actual_data_updates.data_updates[0].latest
+    assert expected_data_updates['predictors'][0]['predictor_id'] == str(actual_data_updates.predictors[0].uid)
+
+
+def test_branch_next_version(session, collection, branch_path):
+    # Given
+    branch_data = BranchDataFactory()
+    root_branch_id = branch_data['metadata']['root_id']
+    session.set_response(branch_data)
+    data_updates = [DataVersionUpdate("gemd::16f91e7e-0214-4866-8d7f-a4d5c2125d2b::1",
+                                      "gemd::16f91e7e-0214-4866-8d7f-a4d5c2125d2b::2")]
+    predictors = [PredictorRef("aa971886-d17c-43b4-b602-5af7b44fcd5a", 2)]
+    req = NextBranchVersionRequest(data_updates, predictors)
+
+    # When
+    branchv2 = collection.next_version(root_branch_id, req, False)
+
+    # Then
+    expected_path = f'{branch_path}/next-version-predictor'
+    expected_call = FakeCall(method='POST',
+                             path=expected_path,
+                             params={'root': str(root_branch_id),
+                                     'retrain_models': False},
+                             json={
+                                 'data_updates': [
+                                     {
+                                         'current': 'gemd::16f91e7e-0214-4866-8d7f-a4d5c2125d2b::1',
+                                         'latest': 'gemd::16f91e7e-0214-4866-8d7f-a4d5c2125d2b::2',
+                                         'type': 'DataVersionUpdate'
+                                     }
+                                 ],
+                                 'use_predictors': [
+                                     {
+                                         'predictor_id': 'aa971886-d17c-43b4-b602-5af7b44fcd5a',
+                                         'predictor_version': 2
+                                     }
+                                 ]
+                             },
+                             version='v2')
+    assert session.last_call == expected_call
+    assert str(branchv2.root_id) == root_branch_id
+
+
 def test_experiment_datasource(session, collection):
     # Given
     erds_path = f'projects/{collection.project_id}/candidate-experiment-datasources'
@@ -217,7 +292,6 @@ def test_experiment_datasource(session, collection):
 
     branch = collection.build(BranchDataFactory())
     session.set_response({'response': [erds]})
-
 
     # When / Then
     assert branch.experiment_datasource is not None

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -36,12 +36,42 @@ class ProjectDataFactory(factory.DictFactory):
     created_at = None
 
 
+class DataVersionUpdateFactory(factory.DictFactory):
+    current = "gemd::48e5e2f3-d447-458b-a8ea-d9cdb782b86e::1"
+    latest = "gemd::48e5e2f3-d447-458b-a8ea-d9cdb782b86e::2"
+
+
+class PredictorRefFactory(factory.DictFactory):
+    predictor_id = factory.Faker('uuid4')
+    version = randrange(10)
+
+
+class BranchDataUpdateFactory(factory.DictFactory):
+    data_updates = [DataVersionUpdateFactory()]
+    predictors = [PredictorRefFactory()]
+
+
+class NextBranchVersionFactory(factory.DictFactory):
+    data_updates = [DataVersionUpdateFactory()]
+    predictors = [PredictorRefFactory()]
+
+
+class BranchDataFieldFactory(factory.DictFactory):
+    name = factory.Faker('company')
+
+
+class BranchMetadataFieldFactory(factory.DictFactory):
+    root_id = factory.Faker('uuid4')
+    archived = factory.Faker('boolean')
+    version = randrange(10)
+    created = None
+    updated = None
+
+
 class BranchDataFactory(factory.DictFactory):
     id = factory.Faker('uuid4')
-    name = factory.Faker('company')
-    archived = factory.Faker('boolean')
-    created_at = None
-    updated_at = None
+    data = factory.SubFactory(BranchDataFieldFactory)
+    metadata = factory.SubFactory(BranchMetadataFieldFactory)
 
 
 class UserDataFactory(factory.DictFactory):


### PR DESCRIPTION

# Citrine Python PR

## Description 
There are 2 new endpoints for automating the branch data updates and next version capability.  Those endpoints are using the branches v2 api, and citrine-python is currently using v1.  Updating the Branch/BranchCollection to use v2, and the associated changes to the structure of the branch object.  The intention was to ensure that existing code around branch and collection stayed the same even though the underlying interactions were v2.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (non-breaking change to assist developers)

### Adherence to team decisions
- [x] I have added tests for 100% coverage
- [x] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [x] I have bumped the version in __version\__.py
