### PR TITLE
as_admin listing for users and teams

### DIFF
--- a/src/citrine/_rest/admin_collection.py
+++ b/src/citrine/_rest/admin_collection.py
@@ -1,0 +1,39 @@
+from typing import Iterator
+
+from citrine._rest.collection import Collection, ResourceType
+
+
+class AdminCollection(Collection[ResourceType]):
+    def list(
+        self, *, per_page: int = 100, as_admin: bool = False
+    ) -> Iterator[ResourceType]:
+        """
+        Paginate over the elements of the collection.
+
+        Leaving page and per_page as default values will yield all elements in the
+        collection, paginating over all available pages.
+
+        Parameters
+        ---------
+        per_page: int, optional
+            Max number of results to return per page. Default is 100.  This parameter
+            is used when making requests to the backend service.  If the page parameter
+            is specified it limits the maximum number of elements in the response.
+
+        as_admin: bool, optional
+            Whether this request should be made as an admin (returning all teams,
+            rather than only those to which the user belongs).
+
+        Returns
+        -------
+        Iterator[ResourceType]
+            An iterator that can be used to loop over all the resources in this collection.
+            Use list() to force evaluation of all results into an in-memory list.
+
+        """
+        return self._paginator.paginate(
+            page_fetcher=self._fetch_page,
+            collection_builder=self._build_collection_elements,
+            per_page=per_page,
+            search_params={"as_admin": "true"} if as_admin else {},
+        )

--- a/src/citrine/_rest/paginator.py
+++ b/src/citrine/_rest/paginator.py
@@ -53,7 +53,7 @@ class Paginator(Generic[ResourceType]):
         """
         # To avoid setting default to {} -> reduce mutation risk, and to make more extensible. Also
         # making 'search_params' key of outermost dict for keyword expansion by page_fetcher func
-        search_params = {} if search_params is None else {'search_params': search_params}
+        search_params = {} if search_params is None else {'additional_params': search_params}
 
         first_entity = None
         page_idx = 1

--- a/src/citrine/resources/team.py
+++ b/src/citrine/resources/team.py
@@ -2,7 +2,7 @@
 from typing import Optional, Union, List
 from uuid import UUID
 
-from citrine._rest.collection import Collection
+from citrine._rest.admin_collection import AdminCollection
 from citrine._rest.resource import Resource, ResourceTypeEnum
 from citrine._serialization import properties
 from citrine._session import Session
@@ -394,7 +394,7 @@ class Team(Resource['Team']):
                                resource_type=ResourceTypeEnum.TABLE_DEFINITION.value)
 
 
-class TeamCollection(Collection[Team]):
+class TeamCollection(AdminCollection[Team]):
     """
     Represents the collection of all teams as well as the resources belonging to it.
 

--- a/src/citrine/resources/user.py
+++ b/src/citrine/resources/user.py
@@ -1,7 +1,7 @@
 """Resources that represent both individual and collections of users."""
 from typing import Optional
 
-from citrine._rest.collection import Collection
+from citrine._rest.admin_collection import AdminCollection
 from citrine._rest.resource import Resource, ResourceTypeEnum
 from citrine._serialization import properties
 from citrine._session import Session
@@ -59,7 +59,7 @@ class User(Resource['User']):
         raise NotImplementedError("Get Not Implemented in Citrine Platform")
 
 
-class UserCollection(Collection[User]):
+class UserCollection(AdminCollection[User]):
     """Represents the collection of all users."""
 
     _path_template = '/users'


### PR DESCRIPTION
# Citrine Python PR

## Description 
In order to restrict the list of users to only those on shared teams, we must expose an admin variant of the users list for user management. This feature already exists for teams, but was not previously exposed in the SDK.

This PR adds a toggle to include the `?as_admin=true` query param, allowing an admin to request the entire user list (the backend still applies logic to ensure the requesting user is actually an admin).

While adding this implementation, I also discovered a discrepancy in kwarg naming between `search_params` and `additional_params` which would prevent this PR from working, so I fixed that.

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (non-breaking change to assist developers)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in __version\__.py
