### PR TITLE
[PLA-13800] Cleanup logging.

### DIFF
--- a/src/citrine/__init__.py
+++ b/src/citrine/__init__.py
@@ -6,9 +6,4 @@ https://citrineinformatics.github.io/citrine-python/index.html
 
 """
 from citrine.citrine import Citrine  # noqa: F401
-import logging
-import warnings
 from .__version__ import __version__  # noqa: F401
-
-logging.basicConfig(level=logging.WARNING)
-warnings.simplefilter("default", DeprecationWarning)

--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from logging import getLogger
 from typing import Optional, Union, Generic, TypeVar, Iterable, Iterator, Sequence, Dict
 from uuid import UUID
 
@@ -9,8 +8,6 @@ from citrine._rest.resource import Resource, ResourceRef
 from citrine._utils.functions import resource_path
 from citrine.exceptions import ModuleRegistrationFailedException, NonRetryableException
 from citrine.resources.response import Response
-
-logger = getLogger(__name__)
 
 ResourceType = TypeVar('ResourceType', bound=Resource)
 

--- a/src/citrine/_rest/pageable.py
+++ b/src/citrine/_rest/pageable.py
@@ -1,9 +1,5 @@
-from logging import getLogger
 from typing import Optional, Iterable, Dict, Tuple, Callable, Union, Sequence
 from uuid import UUID
-
-
-logger = getLogger(__name__)
 
 
 class Pageable():

--- a/src/citrine/resources/file_link.py
+++ b/src/citrine/resources/file_link.py
@@ -2,7 +2,6 @@
 import mimetypes
 import os
 from pathlib import Path
-from logging import getLogger
 from tempfile import TemporaryDirectory
 from typing import Optional, Tuple, Union, Dict, Iterable, Sequence
 from urllib.parse import urlparse, unquote_plus
@@ -25,8 +24,6 @@ from gemd.entity.dict_serializable import DictSerializableMeta
 from gemd.entity.bounds.base_bounds import BaseBounds
 from gemd.entity.file_link import FileLink as GEMDFileLink
 from gemd.enumeration.base_enumeration import BaseEnumeration
-
-logger = getLogger(__name__)
 
 
 class SearchFileFilterTypeEnum(BaseEnumeration):

--- a/src/citrine/resources/material_spec.py
+++ b/src/citrine/resources/material_spec.py
@@ -1,5 +1,4 @@
 """Resources that represent material spec data objects."""
-from logging import getLogger
 from typing import List, Dict, Optional, Type, Iterator, Union
 from uuid import UUID
 
@@ -14,8 +13,6 @@ from gemd.entity.link_by_uid import LinkByUID
 from gemd.entity.object.material_spec import MaterialSpec as GEMDMaterialSpec
 from gemd.entity.object.process_spec import ProcessSpec as GEMDProcessSpec
 from gemd.entity.template.material_template import MaterialTemplate as GEMDMaterialTemplate
-
-logger = getLogger(__name__)
 
 
 class MaterialSpec(

--- a/tests/resources/test_branch.py
+++ b/tests/resources/test_branch.py
@@ -1,6 +1,5 @@
 import uuid
 from datetime import datetime
-from logging import getLogger
 
 import pytest
 from dateutil import tz
@@ -13,8 +12,6 @@ from tests.utils.factories import BranchDataFactory, BranchRootDataFactory, \
     CandidateExperimentSnapshotDataFactory, ExperimentDataSourceDataFactory, \
     BranchDataFieldFactory, BranchMetadataFieldFactory, BranchDataUpdateFactory
 from tests.utils.session import FakeSession, FakeCall, FakePaginatedSession
-
-logger = getLogger(__name__)
 
 
 LATEST_VER = "latest"

--- a/tests/resources/test_project.py
+++ b/tests/resources/test_project.py
@@ -1,5 +1,4 @@
 import uuid
-from logging import getLogger, WARNING
 from unittest import mock
 
 import pytest
@@ -17,8 +16,6 @@ from citrine.resources.project_roles import MEMBER, LEAD, WRITE
 from tests.utils.factories import ProjectDataFactory, UserDataFactory, TeamDataFactory
 from tests.utils.session import FakeSession, FakeCall, FakePaginatedSession, FakeRequestResponse
 from citrine.resources.team import  READ, TeamMember
-
-logger = getLogger(__name__)
 
 
 @pytest.fixture

--- a/tests/resources/test_team.py
+++ b/tests/resources/test_team.py
@@ -1,5 +1,4 @@
 import uuid
-from logging import getLogger
 
 import pytest
 from dateutil.parser import parse
@@ -10,8 +9,6 @@ from citrine.resources.team import Team, TeamCollection, SHARE, READ, WRITE, Tea
 from citrine.resources.user import User
 from tests.utils.factories import UserDataFactory, TeamDataFactory
 from tests.utils.session import FakeSession, FakeCall, FakePaginatedSession
-
-logger = getLogger(__name__)
 
 
 @pytest.fixture

--- a/tests/serialization/test_attribute_template.py
+++ b/tests/serialization/test_attribute_template.py
@@ -1,6 +1,5 @@
 """Tests of the attribute template schema."""
 import pytest
-import logging
 from citrine.resources.condition_template import ConditionTemplate
 from citrine.resources.parameter_template import ParameterTemplate
 from citrine.resources.property_template import PropertyTemplate


### PR DESCRIPTION
# Citrine Python PR

Remove invocation of `basicConfig` on the root logger, so as to not set up a logger when the user has asked for none.

Drop explicitly setting the "default" warning filter.

Also get rid of a bunch of places the logger is imported but not used.


### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (non-breaking change to assist developers)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in __version\__.py
