### PR TITLE
Surface docs warnings.

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,44 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-version:
+    name: Check version bumped
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize the environment
+        uses: ./.github/actions/initialize
+      - name: Check version
+        run: python scripts/validate_version_bump.py
+  linting:
+    name: Run linting with flake8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize the environment
+        uses: ./.github/actions/initialize
+      - name: Lint the src/ directory
+        run: flake8 src/
+  check-deprecated:
+    name: Find code marked for removal in this version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize the environment
+        uses: ./.github/actions/initialize
+      - name: Deprecated check
+        run: derp src/ src/citrine/__version__.py
+  check-docs:
+    name: Check docs for warnings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize the environment
+        uses: ./.github/actions/initialize
+      - name: Build Docs
+        run: make -C docs/ html SPHINXOPTS='-W --keep-going'

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,37 +2,10 @@ name: PR Tests
 
 on:
   pull_request:
-    branches:    
+    branches:
       - main
 
 jobs:
-  check-version:
-    name: Check version bumped
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Initialize the environment
-        uses: ./.github/actions/initialize
-      - name: Check version
-        run: python scripts/validate_version_bump.py
-  linting:
-    name: Run linting with flake8
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Initialize the environment
-        uses: ./.github/actions/initialize
-      - name: Lint the src/ directory
-        run: flake8 src/
-  check-deprecated:
-    name: Find code marked for removal in this version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Initialize the environment
-        uses: ./.github/actions/initialize
-      - name: Deprecated check
-        run: derp src/ src/citrine/__version__.py
   run-tests:
     name: Execute unit tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Citrine Python PR

In order to keep the docs build messages useful, we should run a check on PR to surface all warnings. With the release of 3.0, they should be completely clean, so a failure of this job will be meaningful. Even such, we'll probably keep it non-required for now so as to not add unnecessarily to the development burden.


## Description 
Please briefly explain the goal of the changes/this PR.
The reviewer should be able to understand why the change is being made by reading this description
and its links (e.g. JIRA tickets).

### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (non-breaking change to assist developers)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in __version\__.py
