### PR TITLE
Final dependency bump.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ or a specific version can be installed, for example:
 
 .. code::
 
-  pip install citrine==1.0.0
+  pip install citrine==3.0.0
 
 
 Table of Contents

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 arrow==1.3.0
-boto3==1.34.13
+boto3==1.34.35
 deprecation==2.1.0
-gemd==1.16.7
+gemd==2.0.0
 pyjwt==2.8.0
 requests==2.31.0
 tqdm==4.66.1
 
-# boto3 (through botocore) depends on urllib3. Version 1.34.12 requires
+# boto3 (through botocore) depends on urllib3. Version 1.34.35 requires
 # urllib3 < 1.27 when using Python 3.9 or less, and urllib3 < 2.1 otherwise.
 urllib3==1.26.18; python_version < "3.10"
 urllib3==2.0.7; python_version >= "3.10"

--- a/setup.py
+++ b/setup.py
@@ -25,20 +25,19 @@ setup(name='citrine',
           "requests>=2.31.0,<3",
           "pyjwt>=2,<3",
           "arrow>=1.0.0,<2",
-          "gemd>=1.16.7,<2",
-          "boto3>=1.34.12,<2",
+          "gemd>=2.0.0,<3",
+          "boto3>=1.34.35,<2",
           "deprecation>=2.1.0,<3",
           "urllib3>=1.26.18,<3",
-          "tqdm>=4.27.0,<5",
-          "pint>=0.18,<=0.20"
+          "tqdm>=4.27.0,<5"
       ],
       extras_require={
           "../tests": [
               "factory-boy>=3.3.0,<4",
               "mock>=5.1.0,<6",
               "pandas>=2.0.3,<3",
-              "pytest>=7.4.4,<8",
-              "pytz>=2023.3.post1",
+              "pytest>=8.0.0,<9",
+              "pytz>=2024.1",
               "requests-mock>=1.11.0,<2",
           ]
       },

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,10 +3,10 @@ factory-boy==3.3.0
 flake8==7.0.0
 flake8-docstrings==1.7.0
 mock==5.1.0
-pytest==7.4.4
+pytest==8.0.0
 pytest-cov==4.1.0
-pytz==2023.3.post1
+pytz==2024.1
 requests-mock==1.11.0
-sphinx==7.1.2
+sphinx==7.2.6
 sphinx-rtd-theme==2.0.0
-sphinxcontrib-apidoc==0.4.0
+sphinxcontrib-apidoc==0.5.0


### PR DESCRIPTION
# Citrine Python PR
    
Some time has passed since we prepared the 3.0 release and the date of its release. As such, this does one final pass to upgrade everything. Most importantly, it upgrades gemd to the just released 2.0.0 version.


### PR Type:
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (non-breaking change to assist developers)

### Adherence to team decisions
- [ ] I have added tests for 100% coverage
- [ ] I have written Numpy-style docstrings for every method and class.
- [ ] I have communicated the downstream consequences of the PR to others.
- [ ] I have bumped the version in __version\__.py
