### PR TITLE
Fix error message bugs

### DIFF
--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -205,7 +205,7 @@ class Session(requests.Session):
                 raise Conflict(path, response)
             elif response.status_code == 425:
                 logger.debug('%s %s %s', response.status_code, method, path)
-                msg = 'Cant execute at this time. Try again later. Error: {}'.format(response.text)
+                msg = 'Cannot execute at this time. Try again later. Error: {}'.format(response.text)
                 raise WorkflowNotReadyException(msg)
             else:
                 logger.error('%s %s %s', response.status_code, method, path)

--- a/src/citrine/_utils/functions.py
+++ b/src/citrine/_utils/functions.py
@@ -32,8 +32,10 @@ def validate_type(data_dict: dict, type_name: str) -> dict:
     data_dict_copy = data_dict.copy()
     if 'type' in data_dict_copy:
         if data_dict_copy['type'] != type_name:
-            raise Exception(
-                "Object type must be {}, but was instead {}.".format(type_name, data_dict['type']))
+            raise TypeError(
+                "Object type must be '{}', but was '{}'. "
+                "Verify you are passing the correct object type."
+                .format(type_name, data_dict['type']))
     else:
         data_dict_copy['type'] = type_name
 
@@ -258,7 +260,7 @@ def migrate_deprecated_argument(
         if new_arg is None:
             return old_arg
         else:
-            raise ValueError(f"Cannot specify both \'{new_arg_name}\' and \'{new_arg_name}\'")
+            raise ValueError(f"Cannot specify both \'{new_arg_name}\' and \'{old_arg_name}\'")
     elif new_arg is None:
         raise ValueError(f"Please specify \'{new_arg_name}\'")
     return new_arg

--- a/src/citrine/exceptions.py
+++ b/src/citrine/exceptions.py
@@ -120,7 +120,7 @@ class NotFound(NonRetryableHttpException):
                 status_code=404,
                 request=SimpleNamespace(method=method.upper()),
                 reason="Not Found",
-                json=lambda self: {"code": 404, "message": message, "validation_errors": []}
+                json=lambda: {"code": 404, "message": message, "validation_errors": []}
             )
         )
 


### PR DESCRIPTION
## Summary
- Fix copy-paste bug in `migrate_deprecated_argument` where error message showed `new_arg_name` twice instead of `new_arg_name` and `old_arg_name`
- Replace bare `Exception` with `TypeError` in `validate_type` for clearer error semantics
- Fix `NotFound.build()` lambda signature (`lambda self:` → `lambda:`) that silently prevented `api_error` from being populated
- Fix "Cant" typo in `WorkflowNotReadyException` message → "Cannot"

## Test plan
- [x] All 1342 existing tests pass
- [x] No message format assertions broken (tests use `pytest.raises(Exception)` which catches `TypeError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*PR 1 of 11 in the error handling improvement series.*