### PR TITLE
Add hint support to CitrineException

### DIFF
--- a/src/citrine/exceptions.py
+++ b/src/citrine/exceptions.py
@@ -8,9 +8,26 @@ from requests import Response
 
 
 class CitrineException(Exception):
-    """The base exception class for Citrine-Python exceptions."""
+    """The base exception class for Citrine-Python exceptions.
 
-    pass
+    Parameters
+    ----------
+    *args
+        Positional arguments passed to the base Exception class.
+    hint : str, optional
+        An actionable suggestion for how the user can resolve
+        the error. Displayed after the main message.
+    """
+
+    def __init__(self, *args, hint=None):
+        super().__init__(*args)
+        self.hint = hint
+
+    def __str__(self):
+        base = super().__str__()
+        if self.hint:
+            return "{}\n\nHint: {}".format(base, self.hint)
+        return base
 
 
 class NonRetryableException(CitrineException):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,49 @@
+"""Tests for the Citrine exception hierarchy."""
+import pytest
+
+from citrine.exceptions import CitrineException
+
+
+def test_citrine_exception_without_hint():
+    exc = CitrineException("something went wrong")
+    assert str(exc) == "something went wrong"
+    assert exc.hint is None
+
+
+def test_citrine_exception_with_hint():
+    exc = CitrineException("bad request", hint="Check your input.")
+    assert "bad request" in str(exc)
+    assert "Hint: Check your input." in str(exc)
+    assert exc.hint == "Check your input."
+
+
+def test_citrine_exception_hint_format():
+    exc = CitrineException("error", hint="Try again.")
+    expected = "error\n\nHint: Try again."
+    assert str(exc) == expected
+
+
+def test_citrine_exception_no_args():
+    exc = CitrineException()
+    assert str(exc) == ""
+    assert exc.hint is None
+
+
+def test_citrine_exception_no_args_with_hint():
+    exc = CitrineException(hint="Do something.")
+    assert "Hint: Do something." in str(exc)
+
+
+def test_citrine_exception_is_catchable_as_exception():
+    with pytest.raises(Exception):
+        raise CitrineException("test")
+
+
+def test_hint_preserved_through_subclass():
+    """Subclasses that call super().__init__ with hint should work."""
+    class MyError(CitrineException):
+        pass
+
+    exc = MyError("oops", hint="Fix it.")
+    assert exc.hint == "Fix it."
+    assert "Hint: Fix it." in str(exc)


### PR DESCRIPTION
## Summary
- Add optional `hint` keyword argument to `CitrineException.__init__`
- Override `__str__` to append `\n\nHint: <hint>` when hint is present
- Foundation for adding actionable hints to all exception subclasses

## Test plan
- [x] 7 new tests in `tests/test_exceptions.py`
- [x] All 1349 tests pass (1342 existing + 7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*PR 2 of 11 in the error handling improvement series. PRs 3, 5, 11 depend on this.*