### PR TITLE
Add ServerError exception for 5xx responses

### DIFF
--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -19,6 +19,7 @@ from citrine.exceptions import (
     CitrineException,
     Conflict,
     NotFound,
+    ServerError,
     Unauthorized,
     UnauthorizedRefreshToken,
     WorkflowNotReadyException)
@@ -209,7 +210,13 @@ class Session(requests.Session):
                 raise WorkflowNotReadyException(msg)
             else:
                 logger.error('%s %s %s', response.status_code, method, path)
-                raise CitrineException(response.text)
+                raise ServerError(
+                    method=method, path=path,
+                    status_code=response.status_code,
+                    response_text=response.text,
+                    request_id=response.headers.get(
+                        'x-request-id')
+                )
 
     @staticmethod
     def _extract_response_stacktrace(response: Response) -> Optional[str]:

--- a/src/citrine/exceptions.py
+++ b/src/citrine/exceptions.py
@@ -192,3 +192,44 @@ class ModuleRegistrationFailedException(NonRetryableException):
         err = 'The "{0}" failed to register. {1}: {2}'.format(
             moduleType, exc.__class__.__name__, str(exc))
         super().__init__(err)
+
+
+class ServerError(NonRetryableException):
+    """A server-side error (5xx) occurred on the Citrine API.
+
+    Parameters
+    ----------
+    method : str
+        The HTTP method of the request (e.g. GET, POST).
+    path : str
+        The API path that was requested.
+    status_code : int
+        The HTTP status code returned by the server.
+    response_text : str
+        The body of the error response (truncated to 500 chars).
+    request_id : str, optional
+        The server-assigned request ID for support reference.
+    """
+
+    def __init__(self, *, method, path, status_code,
+                 response_text, request_id=None):
+        self.method = method
+        self.path = path
+        self.status_code = status_code
+        self.request_id = request_id
+        self.response_text = response_text[:500] if response_text else ""
+
+        parts = ["Server error {} from {} {}".format(
+            status_code, method, path)]
+        if request_id:
+            parts.append("Request ID: {}".format(request_id))
+        if self.response_text:
+            parts.append("Response: {}".format(self.response_text))
+
+        hint = ("This is a server-side issue. If it persists, "
+                "contact Citrine support")
+        if request_id:
+            hint += " with request ID '{}'.".format(request_id)
+        else:
+            hint += "."
+        super().__init__("\n".join(parts), hint=hint)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,7 +1,7 @@
 """Tests for the Citrine exception hierarchy."""
 import pytest
 
-from citrine.exceptions import CitrineException
+from citrine.exceptions import CitrineException, NonRetryableException, ServerError
 
 
 def test_citrine_exception_without_hint():
@@ -47,3 +47,66 @@ def test_hint_preserved_through_subclass():
     exc = MyError("oops", hint="Fix it.")
     assert exc.hint == "Fix it."
     assert "Hint: Fix it." in str(exc)
+
+
+# --- ServerError tests ---
+
+def test_server_error_attributes():
+    exc = ServerError(
+        method="POST", path="/api/v1/foo",
+        status_code=502, response_text="Bad Gateway",
+        request_id="abc-123"
+    )
+    assert exc.method == "POST"
+    assert exc.path == "/api/v1/foo"
+    assert exc.status_code == 502
+    assert exc.response_text == "Bad Gateway"
+    assert exc.request_id == "abc-123"
+
+
+def test_server_error_message_includes_context():
+    exc = ServerError(
+        method="GET", path="/api/v1/bar",
+        status_code=500, response_text="internal error"
+    )
+    msg = str(exc)
+    assert "500" in msg
+    assert "GET" in msg
+    assert "/api/v1/bar" in msg
+    assert "internal error" in msg
+
+
+def test_server_error_includes_request_id_in_message():
+    exc = ServerError(
+        method="PUT", path="/x",
+        status_code=503, response_text="",
+        request_id="req-456"
+    )
+    msg = str(exc)
+    assert "req-456" in msg
+
+
+def test_server_error_truncates_long_response():
+    long_text = "x" * 1000
+    exc = ServerError(
+        method="GET", path="/",
+        status_code=500, response_text=long_text
+    )
+    assert len(exc.response_text) == 500
+
+
+def test_server_error_has_hint():
+    exc = ServerError(
+        method="GET", path="/",
+        status_code=500, response_text="err"
+    )
+    assert exc.hint is not None
+    assert "server-side" in exc.hint.lower()
+
+
+def test_server_error_is_non_retryable():
+    exc = ServerError(
+        method="GET", path="/",
+        status_code=500, response_text=""
+    )
+    assert isinstance(exc, NonRetryableException)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,6 +5,7 @@ from citrine.exceptions import (
     BadRequest,
     Conflict,
     NonRetryableException,
+    ServerError,
     WorkflowNotReadyException,
     RetryableException)
 
@@ -246,10 +247,13 @@ def test_failed_put_with_stacktrace(session: Session):
                 json={'debug_stacktrace': 'blew up!'}
             )
 
-            with pytest.raises(Exception) as e:
+            with pytest.raises(ServerError) as e:
                 session.put_resource('/bad-endpoint', json={})
 
-        assert '{"debug_stacktrace": "blew up!"}' == str(e.value)
+        assert e.value.status_code == 500
+        assert e.value.method == "PUT"
+        assert e.value.path == "/bad-endpoint"
+        assert "blew up!" in e.value.response_text
 
 
 def test_cursor_paged_resource():


### PR DESCRIPTION
## Summary
- New `ServerError(NonRetryableException)` with structured attributes: `method`, `path`, `status_code`, `response_text`, `request_id`
- Response text truncated to 500 chars to avoid overwhelming error output
- Includes actionable hint about contacting support with request ID
- Updates `checked_request()` catch-all to raise `ServerError` instead of bare `CitrineException`

## Test plan
- [x] 6 new tests for ServerError in `tests/test_exceptions.py`
- [x] Updated `test_failed_put_with_stacktrace` to assert on structured attributes
- [x] All 1355 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*PR 3 of 11. Depends on PR 2 (hint support). Base branch: `feature/exception-hint-support`*