### PR TITLE
Add request_id and method to HTTP exceptions

### DIFF
--- a/src/citrine/exceptions.py
+++ b/src/citrine/exceptions.py
@@ -37,19 +37,29 @@ class NonRetryableHttpException(NonRetryableException):
     def __init__(self, path: str, response: Optional[Response] = None):
         self.url = path
         self.detailed_error_info = []
+        self.request_id = None
+        self.method = "unknown"
         if response is not None:
             self.response_text = response.text
             self.code = response.status_code
 
-            method = "unknown"
             if response.request is not None:
-                method = response.request.method
+                self.method = response.request.method
+
+            headers = getattr(response, 'headers', {}) or {}
+            self.request_id = (
+                headers.get('x-request-id')
+                or headers.get('x-correlation-id')
+            )
 
             self.detailed_error_info.append(
                 "{} (code: {}) returned from {} request to path: '{}'".format(
-                    response.reason, self.code, method, path
+                    response.reason, self.code, self.method, path
                 )
             )
+            if self.request_id:
+                self.detailed_error_info.append(
+                    "Request ID: {}".format(self.request_id))
             try:
                 resp_json = response.json()
                 if isinstance(resp_json, dict):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,6 +5,7 @@ from citrine.exceptions import (
     BadRequest,
     Conflict,
     NonRetryableException,
+    NotFound,
     WorkflowNotReadyException,
     RetryableException)
 
@@ -111,6 +112,41 @@ def test_get_not_found(session: Session):
         m.get('http://citrine-testing.fake/api/v1/foo', status_code=404)
         with pytest.raises(NotFound):
             session.get_resource('/foo')
+
+
+def test_request_id_captured_in_http_exception(session: Session):
+    with requests_mock.Mocker() as m:
+        m.get(
+            'http://citrine-testing.fake/api/v1/foo',
+            status_code=404,
+            headers={'x-request-id': 'test-req-123'}
+        )
+        with pytest.raises(NotFound) as exc_info:
+            session.get_resource('/foo')
+        assert exc_info.value.request_id == 'test-req-123'
+        assert 'test-req-123' in str(exc_info.value)
+
+
+def test_method_stored_on_http_exception(session: Session):
+    with requests_mock.Mocker() as m:
+        m.get(
+            'http://citrine-testing.fake/api/v1/foo',
+            status_code=404
+        )
+        with pytest.raises(NotFound) as exc_info:
+            session.get_resource('/foo')
+        assert exc_info.value.method == 'GET'
+
+
+def test_request_id_none_when_header_absent(session: Session):
+    with requests_mock.Mocker() as m:
+        m.get(
+            'http://citrine-testing.fake/api/v1/foo',
+            status_code=404
+        )
+        with pytest.raises(NotFound) as exc_info:
+            session.get_resource('/foo')
+        assert exc_info.value.request_id is None
 
 
 def test_status_code_409(session: Session):


### PR DESCRIPTION
## Summary
- Extract `x-request-id` / `x-correlation-id` from response headers, store as `request_id` attribute on `NonRetryableHttpException`
- Store HTTP `method` as attribute (was previously computed but discarded)
- Include request ID in error message when present for easier support escalation
- Gracefully handles mock/SimpleNamespace responses without headers

## Test plan
- [x] 3 new tests: request_id captured, method stored, request_id None when absent
- [x] All 1345 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*PR 4 of 11. Independent — no dependencies on other PRs.*