### PR TITLE
Add exception chaining and fix silent pagination error

### DIFF
--- a/src/citrine/_rest/collection.py
+++ b/src/citrine/_rest/collection.py
@@ -66,7 +66,7 @@ class Collection(Generic[ResourceType], Pageable):
             data = data[self._individual_key] if self._individual_key else data
             return self.build(data)
         except NonRetryableException as e:
-            raise ModuleRegistrationFailedException(model.__class__.__name__, e)
+            raise ModuleRegistrationFailedException(model.__class__.__name__, e) from e
 
     def list(self, *, per_page: int = 100) -> Iterator[ResourceType]:
         """

--- a/src/citrine/_rest/pageable.py
+++ b/src/citrine/_rest/pageable.py
@@ -1,5 +1,8 @@
+from logging import getLogger
 from typing import Optional, Iterable, Dict, Tuple, Callable, Union, Sequence
 from uuid import UUID
+
+logger = getLogger(__name__)
 
 
 class Pageable():
@@ -87,6 +90,10 @@ class Pageable():
         try:
             next_uri = data.get('next', "")
         except AttributeError:
+            logger.warning(
+                "Response data is not a dict (type: %s); "
+                "pagination may be incomplete.",
+                type(data).__name__)
             next_uri = ""
 
         # A 'None' collection key implies response has a top-level array

--- a/src/citrine/resources/ingestion.py
+++ b/src/citrine/resources/ingestion.py
@@ -255,7 +255,7 @@ class Ingestion(Resource['Ingestion']):
                                            delete_templates=delete_templates)
         except IngestionException as e:
             if self.raise_errors:
-                raise e
+                raise
             else:
                 return IngestionStatus.from_exception(e)
 
@@ -331,9 +331,9 @@ class Ingestion(Resource['Ingestion']):
             )
         except BadRequest as e:
             if e.api_error is not None:
-                raise IngestionException.from_api_error(e.api_error)
+                raise IngestionException.from_api_error(e.api_error) from e
             else:
-                raise e
+                raise
 
     def poll_for_job_completion(self,
                                 job: JobSubmissionResponse,
@@ -560,11 +560,11 @@ class IngestionCollection(Collection[Ingestion]):
                 else:
                     errors = [IngestionErrorTrace(msg=e.api_error.message)]
                 if raise_errors:
-                    raise IngestionException(errors=errors)
+                    raise IngestionException(errors=errors) from e
                 else:
                     return FailedIngestion(errors=errors)
             else:
-                raise e
+                raise
         return self.build({
             **response,
             "raise_errors": raise_errors


### PR DESCRIPTION
## Summary
- Add `from e` to exception re-raises in `collection.py` and `ingestion.py` so the original cause is preserved in tracebacks
- Replace `raise e` with bare `raise` to preserve traceback context
- Add `logger.warning` in `pageable.py` when response data is not a dict (was silently swallowed)

## Test plan
- [x] All 1342 existing tests pass
- [x] Exception chaining only affects traceback display, not catch behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*PR 7 of 11. Independent — no dependencies on other PRs.*