### PR TITLE
Add programmatic error access to HTTP exceptions

### DIFF
--- a/src/citrine/exceptions.py
+++ b/src/citrine/exceptions.py
@@ -80,6 +80,39 @@ class NonRetryableHttpException(NonRetryableException):
 
         super().__init__("\n\t".join(self.detailed_error_info))
 
+    @property
+    def validation_errors(self):
+        """Shortcut to api_error.validation_errors, or empty list.
+
+        Returns
+        -------
+        list
+            List of ValidationError objects, or [] if no
+            api_error is available.
+        """
+        if self.api_error is not None:
+            return self.api_error.validation_errors
+        return []
+
+    def has_failure(self, failure_id):
+        """Check if a specific validation failure ID is present.
+
+        Parameters
+        ----------
+        failure_id : str
+            The failure_id to check for.
+
+        Returns
+        -------
+        bool
+            True if a validation error with the given
+            failure_id exists.
+        """
+        return any(
+            ve.failure_id == failure_id
+            for ve in self.validation_errors
+        )
+
 
 class NotFound(NonRetryableHttpException):
     """A particular url was not found. (http status 404)."""

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,6 +5,8 @@ from citrine.exceptions import (
     BadRequest,
     Conflict,
     NonRetryableException,
+    NotFound,
+    Unauthorized,
     WorkflowNotReadyException,
     RetryableException)
 
@@ -159,6 +161,54 @@ def test_status_code_400(session: Session):
             session.get_resource('/foo')
         assert einfo.value.api_error.validation_errors[0].failure_message \
                == resp_json['validation_errors'][0]['failure_message']
+
+
+def test_validation_errors_property(session: Session):
+    with requests_mock.Mocker() as m:
+        resp_json = {
+            'code': 400,
+            'message': 'validation failed',
+            'validation_errors': [
+                {
+                    'failure_message': 'field required',
+                    'failure_id': 'missing_field',
+                },
+            ],
+        }
+        m.get('http://citrine-testing.fake/api/v1/foo',
+              status_code=400, json=resp_json)
+        with pytest.raises(BadRequest) as einfo:
+            session.get_resource('/foo')
+        assert len(einfo.value.validation_errors) == 1
+        assert einfo.value.validation_errors[0].failure_id \
+            == 'missing_field'
+
+
+def test_has_failure_method(session: Session):
+    with requests_mock.Mocker() as m:
+        resp_json = {
+            'code': 400,
+            'message': 'bad',
+            'validation_errors': [
+                {'failure_id': 'field_x_required'},
+            ],
+        }
+        m.get('http://citrine-testing.fake/api/v1/foo',
+              status_code=400, json=resp_json)
+        with pytest.raises(BadRequest) as einfo:
+            session.get_resource('/foo')
+        assert einfo.value.has_failure('field_x_required')
+        assert not einfo.value.has_failure('nonexistent')
+
+
+def test_validation_errors_empty_without_api_error(session: Session):
+    with requests_mock.Mocker() as m:
+        m.get('http://citrine-testing.fake/api/v1/foo',
+              status_code=404)
+        with pytest.raises(NotFound) as einfo:
+            session.get_resource('/foo')
+        assert einfo.value.validation_errors == []
+        assert not einfo.value.has_failure('anything')
 
 
 def test_status_code_401(session: Session):


### PR DESCRIPTION
## Summary
- Add `validation_errors` property to `NonRetryableHttpException` — shortcut to `api_error.validation_errors` (returns `[]` when no api_error)
- Add `has_failure(failure_id)` method — check if a specific validation failure occurred without null-checking api_error

## Test plan
- [x] 3 new tests: validation_errors with errors, has_failure matching/non-matching, empty validation_errors without api_error
- [x] All 1345 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*PR 10 of 11. Independent — no dependencies on other PRs.*