### PR TITLE
Add default hints to HTTP exception subclasses

### DIFF
--- a/src/citrine/exceptions.py
+++ b/src/citrine/exceptions.py
@@ -51,6 +51,8 @@ class UnauthorizedRefreshToken(NonRetryableException):
 class NonRetryableHttpException(NonRetryableException):
     """An exception originating from an HTTP error from a Citrine API."""
 
+    _default_hint = None  # Subclasses may set this
+
     def __init__(self, path: str, response: Optional[Response] = None):
         self.url = path
         self.detailed_error_info = []
@@ -95,11 +97,18 @@ class NonRetryableHttpException(NonRetryableException):
             self.code = None
             self.api_error = None
 
-        super().__init__("\n\t".join(self.detailed_error_info))
+        super().__init__(
+            "\n\t".join(self.detailed_error_info),
+            hint=self._default_hint)
 
 
 class NotFound(NonRetryableHttpException):
     """A particular url was not found. (http status 404)."""
+
+    _default_hint = (
+        "Verify the resource UID exists in the target "
+        "project/dataset. UIDs are case-sensitive."
+    )
 
     @staticmethod
     def build(*, message: str, method: str, path: str, params: dict = {}):
@@ -145,19 +154,29 @@ class NotFound(NonRetryableHttpException):
 class Unauthorized(NonRetryableHttpException):
     """The user is unauthorized to make this api call. (http status 401)."""
 
-    pass
+    _default_hint = (
+        "Check that your API key is valid and has access "
+        "to this resource. Regenerate your key if expired."
+    )
 
 
 class BadRequest(NonRetryableHttpException):
     """The user is trying to perform an invalid operation. (http status 400)."""
 
-    pass
+    _default_hint = (
+        "Check the validation errors above for specific "
+        "field issues."
+    )
 
 
 class WorkflowConflictException(NonRetryableHttpException):
     """There is a conflict preventing the workflow from being executed. (http status 409)."""
 
-    pass
+    _default_hint = (
+        "Another operation may be in progress on this "
+        "resource. Wait and retry, or check for "
+        "concurrent modifications."
+    )
 
 
 # A 409 is a Conflict, and can be raised anywhere a conflict occurs, not just in a workflow.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,7 +1,10 @@
 """Tests for the Citrine exception hierarchy."""
 import pytest
 
-from citrine.exceptions import CitrineException
+from citrine.exceptions import (
+    BadRequest, CitrineException, NotFound,
+    Unauthorized, WorkflowConflictException,
+)
 
 
 def test_citrine_exception_without_hint():
@@ -47,3 +50,29 @@ def test_hint_preserved_through_subclass():
     exc = MyError("oops", hint="Fix it.")
     assert exc.hint == "Fix it."
     assert "Hint: Fix it." in str(exc)
+
+
+# --- Default hint tests for HTTP exception subclasses ---
+
+def test_not_found_has_default_hint():
+    exc = NotFound("/test/path")
+    assert exc.hint is not None
+    assert "UID" in exc.hint
+
+
+def test_unauthorized_has_default_hint():
+    exc = Unauthorized("/test/path")
+    assert exc.hint is not None
+    assert "API key" in exc.hint
+
+
+def test_bad_request_has_default_hint():
+    exc = BadRequest("/test/path")
+    assert exc.hint is not None
+    assert "validation" in exc.hint.lower()
+
+
+def test_conflict_has_default_hint():
+    exc = WorkflowConflictException("/test/path")
+    assert exc.hint is not None
+    assert "retry" in exc.hint.lower()


### PR DESCRIPTION
## Summary
- Add `_default_hint` class attribute to `NotFound`, `Unauthorized`, `BadRequest`, `WorkflowConflictException`
- Wire `_default_hint` through `NonRetryableHttpException.__init__` to the base `CitrineException` hint mechanism
- Each hint provides actionable guidance specific to the error type

## Test plan
- [x] 4 new tests verifying each subclass has appropriate hint text
- [x] All 1353 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*PR 5 of 11. Depends on PR 2 (hint support). Base branch: `feature/exception-hint-support`*