### PR TITLE
Enhance auth error message with actionable guidance

### DIFF
--- a/src/citrine/_session.py
+++ b/src/citrine/_session.py
@@ -117,7 +117,16 @@ class Session(requests.Session):
                                             json=data)
 
         if response.status_code != 200:
-            raise UnauthorizedRefreshToken()
+            raise UnauthorizedRefreshToken(
+                "Failed to refresh authentication token.",
+                hint=(
+                    "Your API key may have expired or been "
+                    "revoked. Generate a new one at "
+                    "{}://{}/account/api-keys or set the "
+                    "CITRINE_API_KEY environment variable."
+                    .format(self.scheme, self.authority)
+                )
+            )
         self.access_token = response.json()['access_token']
         self.access_token_expiration = datetime.fromtimestamp(
             jwt.decode(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -94,8 +94,11 @@ def test_get_refresh_token_failure(session: Session):
     with requests_mock.Mocker() as m:
         m.post('http://citrine-testing.fake/api/v1/tokens/refresh', status_code=401)
 
-        with pytest.raises(UnauthorizedRefreshToken):
+        with pytest.raises(UnauthorizedRefreshToken) as exc_info:
             session.get_resource('/foo')
+        msg = str(exc_info.value)
+        assert "refresh authentication token" in msg
+        assert "api-keys" in msg
 
 
 def test_get_no_refresh(session: Session):


### PR DESCRIPTION
## Summary
- `UnauthorizedRefreshToken` now includes a descriptive message and hint
- Hint directs users to regenerate API key at `<host>/account/api-keys` or set `CITRINE_API_KEY` env var

## Test plan
- [x] Updated `test_get_refresh_token_failure` to verify message content
- [x] All 1349 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*PR 11 of 11. Depends on PR 2 (hint support). Base branch: `feature/exception-hint-support`*