### PR TITLE
Improve docstrings for scores, objectives, and constraints

### DIFF
--- a/src/citrine/informatics/constraints/scalar_range_constraint.py
+++ b/src/citrine/informatics/constraints/scalar_range_constraint.py
@@ -8,20 +8,27 @@ __all__ = ['ScalarRangeConstraint']
 
 
 class ScalarRangeConstraint(Serializable['ScalarRangeConstraint'], Constraint):
-    """Represents an inequality constraint on a real-valued material attribute.
+    """Constrain a real-valued property to a numeric range.
+
+    Candidates whose predicted value for the specified
+    descriptor falls outside the range receive a score of
+    zero in the design execution.
 
     Parameters
     ----------
-    descriptor_key: str
-        the key corresponding to a descriptor
-    lower_bound: float
-        the minimum value in the range
-    upper_bound: float
-        the maximum value in the range
-    lower_inclusive: bool
-        if True, will include the lower bound value in the range (default: true)
-    upper_inclusive: bool
-        if True, will include the max value in the range (default: true)
+    descriptor_key : str
+        The key of the descriptor to constrain. Must match
+        a descriptor key defined in the predictor.
+    lower_bound : float, optional
+        Minimum allowed value. If omitted, no lower limit.
+    upper_bound : float, optional
+        Maximum allowed value. If omitted, no upper limit.
+    lower_inclusive : bool, optional
+        Whether the lower bound is inclusive (``>=``) or
+        exclusive (``>``). Default: ``True`` (inclusive).
+    upper_inclusive : bool, optional
+        Whether the upper bound is inclusive (``<=``) or
+        exclusive (``<``). Default: ``True`` (inclusive).
 
     """
 

--- a/src/citrine/informatics/objectives.py
+++ b/src/citrine/informatics/objectives.py
@@ -1,4 +1,10 @@
-"""Tools for working with Objectives."""
+"""Objectives define optimization goals for design executions.
+
+An Objective specifies what property to optimize and in which
+direction. Objectives are passed to :class:`~citrine.informatics.scores.Score`
+instances to define the optimization strategy.
+
+"""
 from citrine._serialization import properties
 from citrine._serialization.serializable import Serializable
 from citrine._serialization.polymorphic_serializable import PolymorphicSerializable
@@ -8,10 +14,12 @@ __all__ = ['Objective', 'ScalarMaxObjective', 'ScalarMinObjective']
 
 
 class Objective(PolymorphicSerializable['Objective']):
-    """
-    An Objective describes a goal for a score associated with a single descriptor.
+    """Base class for optimization objectives.
 
-    Abstract type that returns the proper type given a serialized dict.
+    An Objective ties a scoring direction (maximize or minimize)
+    to a specific descriptor key. Use :class:`ScalarMaxObjective`
+    to maximize a property or :class:`ScalarMinObjective` to
+    minimize it.
 
     """
 
@@ -27,13 +35,17 @@ class Objective(PolymorphicSerializable['Objective']):
 
 
 class ScalarMaxObjective(Serializable['ScalarMaxObjective'], Objective):
-    """
-    Simple single-response maximization objective with optional bounds.
+    """Maximize a real-valued material property.
+
+    The design execution will prefer candidates with higher
+    predicted values for the specified descriptor.
 
     Parameters
     ----------
-    descriptor_key: str
-        the key from which to pull the values
+    descriptor_key : str
+        The key of the descriptor to maximize. Must match a
+        descriptor key defined in the predictor's outputs
+        (e.g. ``'Tensile Strength'``).
 
     """
 
@@ -48,13 +60,17 @@ class ScalarMaxObjective(Serializable['ScalarMaxObjective'], Objective):
 
 
 class ScalarMinObjective(Serializable['ScalarMinObjective'], Objective):
-    """
-    Simple single-response minimization objective with optional bounds.
+    """Minimize a real-valued material property.
+
+    The design execution will prefer candidates with lower
+    predicted values for the specified descriptor.
 
     Parameters
     ----------
-    descriptor_key: str
-        the key from which to pull the values
+    descriptor_key : str
+        The key of the descriptor to minimize. Must match a
+        descriptor key defined in the predictor's outputs
+        (e.g. ``'Cost'``).
 
     """
 

--- a/src/citrine/informatics/scores.py
+++ b/src/citrine/informatics/scores.py
@@ -1,4 +1,20 @@
-"""Tools for working with Scores."""
+"""Scores rank candidate materials during design executions.
+
+A score combines one or more :class:`~citrine.informatics.objectives.Objective`
+instances with optional :class:`~citrine.informatics.constraints.Constraint`
+instances. The platform evaluates each candidate against the score and
+returns candidates ranked from best to worst.
+
+Three score types are available:
+
+* :class:`LIScore` (Likelihood of Improvement) — multi-objective
+  sequential optimization. Requires baseline values.
+* :class:`EIScore` (Expected Improvement) — single-objective
+  sequential optimization. Requires baseline values.
+* :class:`EVScore` (Expected Value) — multi-objective sum of
+  predicted values. No baselines needed.
+
+"""
 from typing import List, Optional
 
 from citrine._serialization import properties
@@ -11,9 +27,12 @@ __all__ = ['Score', 'LIScore', 'EIScore', 'EVScore']
 
 
 class Score(PolymorphicSerializable['Score']):
-    """A Score is used to rank materials according to objectives and constraints.
+    """Base class for scoring strategies used in design executions.
 
-    Abstract type that returns the proper type given a serialized dict.
+    A Score ranks candidate materials by combining objectives
+    (what to optimize) with constraints (what limits to respect).
+    Use one of the concrete subclasses: :class:`LIScore`,
+    :class:`EIScore`, or :class:`EVScore`.
 
     """
 
@@ -31,18 +50,27 @@ class Score(PolymorphicSerializable['Score']):
 
 
 class LIScore(Serializable['LIScore'], Score):
-    """Evaluates the likelihood of scoring better than some baselines for given objectives.
+    """Likelihood of Improvement — multi-objective sequential optimization.
+
+    Ranks candidates by the probability that they simultaneously
+    improve on *every* baseline. Best for iterative experimental
+    campaigns where you want to beat your current best results
+    across all objectives at once.
 
     Parameters
     ----------
-    objectives: list[Objective]
-        objectives (e.g., maximize, minimize, tune, etc.)
-        If multiple objectives are specified then this score evaluates the likelihood of
-        simultaneously exceeding all objectives.
-    baselines: list[float]
-        best-so-far values for the various objectives (there must be one for each objective)
-    constraints: list[Constraint]
-        constraints limiting the allowed values that material instances can have
+    objectives : list[Objective]
+        One or more objectives (e.g. ScalarMaxObjective,
+        ScalarMinObjective). Multiple objectives are treated
+        as a joint requirement: the score is the probability
+        of exceeding *all* baselines simultaneously.
+    baselines : list[float]
+        Current best-known value for each objective, in the
+        same order as ``objectives``. One baseline per
+        objective is required.
+    constraints : list[Constraint], optional
+        Constraints that candidates must satisfy. Candidates
+        violating any constraint receive a score of zero.
 
     """
 
@@ -66,18 +94,27 @@ class LIScore(Serializable['LIScore'], Score):
 
 
 class EIScore(Serializable['EIScore'], Score):
-    """
-    Evaluates the expected magnitude of improvement beyond baselines for a given objective.
+    """Expected Improvement — single-objective sequential optimization.
+
+    Ranks candidates by the expected magnitude of improvement
+    beyond the baseline. Unlike LIScore, this considers *how
+    much* better a candidate is, not just the probability of
+    being better. Best for single-objective campaigns where
+    you want the largest possible gains.
 
     Parameters
     ----------
-    objectives: list[Objective]
-        objectives (e.g., maximize, minimize, tune, etc.)
-        EIScore does not support more than 1 objective at this time.
-    baselines: list[float]
-        best-so-far values for the various objectives (there must be one for each objective)
-    constraints: list[Constraint]
-        constraints limiting the allowed values that material instances can have
+    objectives : list[Objective]
+        Exactly one objective. EIScore does not support
+        multiple objectives; use LIScore for multi-objective
+        optimization.
+    baselines : list[float]
+        Current best-known value for the objective. Must
+        contain exactly one value matching the single
+        objective.
+    constraints : list[Constraint], optional
+        Constraints that candidates must satisfy. Candidates
+        violating any constraint receive a score of zero.
 
     """
 
@@ -101,18 +138,26 @@ class EIScore(Serializable['EIScore'], Score):
 
 
 class EVScore(Serializable['EVScore'], Score):
-    """
-    Evaluates the expected value for given objectives.
+    """Expected Value — multi-objective optimization without baselines.
+
+    Ranks candidates by the sum of predicted values across all
+    objectives. Unlike LIScore and EIScore, no baselines are
+    needed. Useful as a starting point when you have no
+    existing experimental results.
+
+    When multiple objectives are specified, their individual
+    scores are summed with equal weight. The relative
+    weighting cannot be controlled directly; instead, adjust
+    the descriptor scales or units to influence the balance.
 
     Parameters
     ----------
-    objectives: list[Objective]
-        objectives (e.g., maximize, minimize, tune, etc.)
-        If multiple objectives are specified, their scores are summed together. This allows
-        for simultaneous optimization of multiple objectives, although the weighting of the
-        various objectives cannot be directly specified.
-    constraints: list[Constraint]
-        constraints limiting the allowed values that material instances can have
+    objectives : list[Objective]
+        One or more objectives. Scores are summed across all
+        objectives.
+    constraints : list[Constraint], optional
+        Constraints that candidates must satisfy. Candidates
+        violating any constraint receive a score of zero.
 
     """
 


### PR DESCRIPTION
## Summary
- `scores.py`: add module docstring explaining the three score types and when to use each
- `LIScore`: explain "simultaneously exceeding" semantics (joint probability across all objectives)
- `EIScore`: clarify single-objective limitation and magnitude-focused ranking
- `EVScore`: explain equal-weight summing behavior and how to influence weighting
- `ScalarMaxObjective` / `ScalarMinObjective`: explain what `descriptor_key` must match
- `ScalarRangeConstraint`: clarify inclusive/exclusive semantics with operator notation

## Test plan
- [x] All 1342 tests pass (docstring-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Docs PR 2 of 8 in the documentation improvement series.*